### PR TITLE
Patch to fix problem with  verifying login to garmin connect

### DIFF
--- a/src/org/runnerup/export/GarminUploader.java
+++ b/src/org/runnerup/export/GarminUploader.java
@@ -162,7 +162,8 @@ public class GarminUploader extends FormCrawler implements Uploader {
 				int responseCode = conn.getResponseCode();
 				String amsg = conn.getResponseMessage();
 				System.err.println("obj: " + obj.toString());
-				if (obj.getString("username").contentEquals(username)) {
+				// Returns username(which is actually Displayname from profile) if logged in
+				if (obj.getString("username").isEmpty()) {
 					return Uploader.Status.OK;
 				} else {
 					return Uploader.Status.CANCEL;


### PR DESCRIPTION
Login to garmin connect was successful if "username" is not empty. Note that "username" returned here is not same as login name, but rather the "Display name" from profile.
