### PR TITLE
Increase priority of button event

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -155,7 +155,7 @@
 		    android:name=".workout.HeadsetButtonReceiver"
 		    android:enabled="true" >
 		    <intent-filter>
-		        <action android:name="android.intent.action.MEDIA_BUTTON" />
+		        <action android:name="android.intent.action.MEDIA_BUTTON" android:priority="2147483647" />
 		    </intent-filter>
 		</receiver>
 		

--- a/assets/changes.html
+++ b/assets/changes.html
@@ -1,6 +1,10 @@
 <html>
 <body>
 <h1>What's new</h1>
+<h2>v1.31</h2>
+<ul>
+    <li>Set maximum priority for media button - start RunnerUp after spotify and headset button should work
+</ul>
 <h2>v1.30</h2>
 <ul>
 <li>Revert experimental Android >= 4.3 BLE HRM changes (that ended up in release by misstake :-( (reported by Yanick Lantaigne)


### PR DESCRIPTION
Start RunnerUp last and it should be able to listen to headset button
