### PR TITLE
Add plugin that automatically downloads dependencies from sdk manager in gradle builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
-apply plugin: 'android'
-
 buildscript {
     repositories {
         mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.+'
     }
 
 }
+
+apply plugin: 'android-sdk-manager'
+apply plugin: 'android'
 
 android {
     compileSdkVersion 19


### PR DESCRIPTION
I found a [plugin](https://github.com/JakeWharton/sdk-manager-plugin) from @JakeWharton that makes it very easy for people to get started with Android Studio.

You only have to follow these steps:
1. git submodule init && git submodule update
2. Download bluetooth and antlib jars and put them in libs
2. Install Android Studio
3. Import project and choose the git folder for runner up
4. Android Studio will trigger gradle which will download all dependencies automatically.

We need to find a way to download the bluetooth and ant jars from respective sites to automate the process even further! :)
