### PR TITLE
Download required jars from the gradle build script

### DIFF
--- a/Documentation/howto-build-with-android-studio.txt
+++ b/Documentation/howto-build-with-android-studio.txt
@@ -1,0 +1,18 @@
+Building with Android Studio is quite easy. Just follow these steps:
+
+    1. Run the following command to get all submodules:
+    
+        git submodule init && git submodule update
+        
+    2. Download Android studio here:
+    
+        http://developer.android.com/sdk/installing/studio.html
+        
+    3. When Android Studio is started, choose import project and pick the build.gradle file inside the runnerup folder.
+    
+    4. If Android Studio asks about what gradle to use, choose "gradle wrapper".
+    
+    5. Let Android Studio sync the project
+    
+    6. Press on the play button and the project should compile and deploy to your device!
+

--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,6 @@ android {
             assets.srcDirs = ['assets']
         }
     }
-    /*
-    debug.setRoot('build-types/debug')
-    release.setRoot('build-types/release')
-    */
 }
 
 dependencies {
@@ -40,4 +36,29 @@ dependencies {
     compile files('GraphView/public/graphview-3.1.jar')
     provided files('libs/samsung_ble_sdk_200.jar')
     provided files('libs/antpluginlib_2.0.0.jar')
+}
+
+task downloadSamsungBleSdk(type: DownloadTask) {
+    sourceUrl = 'https://github.com/fishkingsin/BLEDialogTool/raw/master/lib/samsung_ble_sdk_200.jar'
+    target = file('libs/samsung_ble_sdk_200.jar')
+}
+preBuild.dependsOn downloadSamsungBleSdk
+
+task downloadAntPluginLib(type: DownloadTask) {
+    sourceUrl = 'https://github.com/ant-wireless/Android_API_ANTPlus/raw/master/antpluginlib_2.0.0.jar'
+    target = file('libs/antpluginlib_2.0.0.jar')
+}
+preBuild.dependsOn downloadAntPluginLib
+
+class DownloadTask extends DefaultTask {
+    @Input
+    String sourceUrl
+
+    @OutputFile
+    File target
+
+    @TaskAction
+    void download() {
+        ant.get(src: sourceUrl, dest: target)
+    }
 }


### PR DESCRIPTION
I have now fixed so the gradle build script downloads the required jar files from an external source. If you know a better place, just change the urls.

Also added documentation on how to build with Android Studio.
