### PR TITLE
Multiple selection of live server

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -129,16 +129,6 @@
 	<PreferenceScreen 
             android:key="second_preferencescreen"
             android:title="Advanced options">
-			
-	    <org.runnerup.widget.TextPreference
-	        android:defaultValue="http://weide.devsparkles.se/api/Resource/"
-	        android:dependency="@string/pref_runneruplive_active"
-	        android:inputType="text"
-	        android:key="@string/pref_runneruplive_serveradress"
-	        android:persistent="true"
-	        android:summary="asdf"
-	        android:title="RunnerUp live address"
-	        android:enabled="true" />
 
         <org.runnerup.widget.TextPreference
             android:defaultValue="3"

--- a/res/values/array.xml
+++ b/res/values/array.xml
@@ -57,5 +57,26 @@
 	<string-array name="muteValues">
     	<item>no</item>
     	<item>yes</item>
-	</string-array>	
+	</string-array>
+
+    <string-array name="liveservername">
+        <item>weide.devsparkles.se</item>
+        <item>live.runnerup.info</item>
+    </string-array>
+    <string-array name="liveserverurl">
+        <item>http://weide.devsparkles.se/MAP/MAP</item>
+        <item>http://live.runnerup.info</item>
+    </string-array>
+    <string-array name="liveposturl">
+        <item>http://weide.devsparkles.se/api/Resource/</item>
+        <item>http://live.runnerup.info/requests.php</item>
+    </string-array>
+    <string-array name="liveauthtype">
+        <item>user</item>
+        <item>user_pass</item>
+    </string-array>
+    <string-array name="liveauthurl">
+        <item></item>
+        <item>http://live.runnerup.info/clientauth.php</item>
+    </string-array>
 </resources>

--- a/res/values/pref_keys.xml
+++ b/res/values/pref_keys.xml
@@ -87,9 +87,7 @@
     <string name="pref_pace_graph_smoothing_filters">pref_pace_graph_smoothing_filters</string>
     
     <string name="pref_runneruplive_active">pref_runneruplive_active</string>
-    <string name="pref_runneruplive_serveradress">pref_runneruplive_serveradress</string>
-    <string name="pref_runneruplive_username">pref_runneruplive_username</string>
-    
+
     <string name="pref_keystartstop_active">pref_keystartstop_active</string>
     
     <string name="pref_bt_name">pref_bt_name</string>

--- a/src/org/runnerup/export/Uploader.java
+++ b/src/org/runnerup/export/Uploader.java
@@ -33,7 +33,7 @@ import android.util.Pair;
 public interface Uploader {
 
     enum AuthMethod {
-        OAUTH2, USER_PASS
+        OAUTH2, USER_PASS, RUNNERUP_LIVE
     }
 
     enum Status {


### PR DESCRIPTION
- Include a selection of live servers to be used when configuring the live server.
- Remove the option under Advanced settings and move this into the Accounts setting for the live server.
- Store the authentication options for the live server within the AUTH_CONFIG column in the database

Please check the code as this was hacked together quite quickly ....

Note this pull request currently removes the option to define an own server.  Will that be an issue?
