### PR TITLE
Add useful data to the notification when activity is running.

### DIFF
--- a/app/src/org/runnerup/gpstracker/CurrentTrackerInformation.java
+++ b/app/src/org/runnerup/gpstracker/CurrentTrackerInformation.java
@@ -1,0 +1,12 @@
+package org.runnerup.gpstracker;
+
+public interface CurrentTrackerInformation {
+
+    double getTime();
+
+    double getDistance();
+
+    Double getCurrentSpeed();
+
+    Double getCurrentPace();
+}

--- a/app/src/org/runnerup/gpstracker/GpsInformation.java
+++ b/app/src/org/runnerup/gpstracker/GpsInformation.java
@@ -1,0 +1,9 @@
+package org.runnerup.gpstracker;
+
+public interface GpsInformation {
+    String getGpsAccuracy();
+
+    int getSatellitesAvailable();
+
+    int getSatellitesFixed();
+}

--- a/app/src/org/runnerup/gpstracker/GpsStatus.java
+++ b/app/src/org/runnerup/gpstracker/GpsStatus.java
@@ -17,8 +17,6 @@
 
 package org.runnerup.gpstracker;
 
-import org.runnerup.util.TickListener;
-
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.location.GpsSatellite;
@@ -28,6 +26,8 @@ import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Build;
 import android.os.Bundle;
+
+import org.runnerup.util.TickListener;
 /**
  * 
  * This is a helper class that is used to determine when the GPS status is good

--- a/app/src/org/runnerup/notification/ForegroundNotificationDisplayStrategy.java
+++ b/app/src/org/runnerup/notification/ForegroundNotificationDisplayStrategy.java
@@ -1,0 +1,22 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+import android.app.Service;
+
+public class ForegroundNotificationDisplayStrategy implements NotificationDisplayStrategy {
+    private final Service service;
+
+    public ForegroundNotificationDisplayStrategy(Service service) {
+        this.service = service;
+    }
+
+    @Override
+    public void notify(int notificationId, Notification notification) {
+        service.startForeground(notificationId, notification);
+    }
+
+    @Override
+    public void cancel(int notificationId) {
+        service.stopForeground(true);
+    }
+}

--- a/app/src/org/runnerup/notification/GpsBoundState.java
+++ b/app/src/org/runnerup/notification/GpsBoundState.java
@@ -1,0 +1,33 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+
+import org.runnerup.R;
+import org.runnerup.view.StartActivity;
+
+public class GpsBoundState implements NotificationState {
+    private final Context context;
+
+    public GpsBoundState(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public Notification createNotification() {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+        Intent i = new Intent(context, StartActivity.class);
+        i.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent pi = PendingIntent.getActivity(context, 0, i, 0);
+
+        builder.setContentIntent(pi);
+        builder.setContentTitle("Activity ready");
+        builder.setContentText("Ready to start running!");
+        builder.setSmallIcon(R.drawable.icon);
+
+        return builder.build();
+    }
+}

--- a/app/src/org/runnerup/notification/GpsSearchingState.java
+++ b/app/src/org/runnerup/notification/GpsSearchingState.java
@@ -1,0 +1,38 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+
+import org.runnerup.R;
+import org.runnerup.gpstracker.GpsInformation;
+import org.runnerup.view.StartActivity;
+
+public class GpsSearchingState implements NotificationState {
+    private final Context context;
+    private final GpsInformation gpsInformation;
+
+    public GpsSearchingState(Context context, GpsInformation gpsInformation) {
+        this.context = context;
+        this.gpsInformation = gpsInformation;
+    }
+
+    @Override
+    public Notification createNotification() {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+        Intent i = new Intent(context, StartActivity.class);
+        i.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent pi = PendingIntent.getActivity(context, 0, i, 0);
+
+        builder.setContentIntent(pi);
+        builder.setContentTitle("Searching for GPS");
+        builder.setContentText(String.format("GPS Satellites: %d/%d%s",
+                gpsInformation.getSatellitesFixed(), gpsInformation.getSatellitesAvailable(),
+                gpsInformation.getGpsAccuracy()));
+        builder.setSmallIcon(R.drawable.icon);
+
+        return builder.build();
+    }
+}

--- a/app/src/org/runnerup/notification/NotificationDisplayStrategy.java
+++ b/app/src/org/runnerup/notification/NotificationDisplayStrategy.java
@@ -1,0 +1,8 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+
+public interface NotificationDisplayStrategy {
+    void notify(int notificationId, Notification notification);
+    void cancel(int notificationId);
+}

--- a/app/src/org/runnerup/notification/NotificationManagerDisplayStrategy.java
+++ b/app/src/org/runnerup/notification/NotificationManagerDisplayStrategy.java
@@ -1,0 +1,22 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+
+public class NotificationManagerDisplayStrategy implements NotificationDisplayStrategy {
+    private final NotificationManager notificationManager;
+
+    public NotificationManagerDisplayStrategy(NotificationManager notificationManager) {
+        this.notificationManager = notificationManager;
+    }
+
+    @Override
+    public void notify(int notificationId, Notification notification) {
+        notificationManager.notify(notificationId, notification);
+    }
+
+    @Override
+    public void cancel(int notificationId) {
+        notificationManager.cancel(notificationId);
+    }
+}

--- a/app/src/org/runnerup/notification/NotificationState.java
+++ b/app/src/org/runnerup/notification/NotificationState.java
@@ -1,0 +1,7 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+
+public interface NotificationState {
+    Notification createNotification();
+}

--- a/app/src/org/runnerup/notification/NotificationStateManager.java
+++ b/app/src/org/runnerup/notification/NotificationStateManager.java
@@ -1,0 +1,23 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+
+public class NotificationStateManager {
+    private static final int NOTIFICATION_ID = 1;
+    private final NotificationDisplayStrategy strategy;
+
+    public NotificationStateManager(NotificationDisplayStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public void displayNotificationState(NotificationState state) {
+        if(state == null) throw new IllegalArgumentException("state is null");
+
+        Notification notification = state.createNotification();
+        strategy.notify(NOTIFICATION_ID, notification);
+    }
+
+    public void cancelNotification() {
+        strategy.cancel(NOTIFICATION_ID);
+    }
+}

--- a/app/src/org/runnerup/notification/OngoingState.java
+++ b/app/src/org/runnerup/notification/OngoingState.java
@@ -1,0 +1,72 @@
+package org.runnerup.notification;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+
+import org.runnerup.R;
+import org.runnerup.gpstracker.CurrentTrackerInformation;
+import org.runnerup.util.Formatter;
+import org.runnerup.view.RunActivity;
+
+public class OngoingState implements NotificationState {
+    private final Formatter formatter;
+    private final CurrentTrackerInformation currentTrackerInformation;
+    private final Context context;
+
+    public OngoingState(Formatter formatter, CurrentTrackerInformation currentTrackerInformation, Context context) {
+        this.formatter = formatter;
+        this.currentTrackerInformation = currentTrackerInformation;
+        this.context = context;
+    }
+
+    @Override
+    public Notification createNotification() {
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+        Intent i = new Intent(context, RunActivity.class);
+        i.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent pi = PendingIntent.getActivity(context, 0, i, 0);
+
+        String distance = getDistance();
+        String time = getTime();
+        String pace = getPace();
+
+        builder.setTicker("RunnerUp activity started");
+        builder.setContentIntent(pi);
+        builder.setContentTitle("Activity ongoing");
+        String content = String.format("Dist: %s, Time: %s, Pace: %s", distance, time, pace);
+        builder.setContentText(content);
+        builder.setSmallIcon(R.drawable.icon);
+        builder.setOngoing(true);
+
+        NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle(builder);
+        bigTextStyle.setBigContentTitle("Activity ongoing");
+        bigTextStyle.bigText(String.format("Distance: %s,\nTime: %s\nPace: %s", distance, time, pace));
+        builder.setStyle(bigTextStyle);
+
+        return builder.build();
+    }
+
+    private String getDistance() {
+        Double ad = currentTrackerInformation.getDistance();
+        if(ad == null) return "0";
+
+        return formatter.formatDistance(Formatter.TXT_SHORT, Math.round(ad));
+    }
+
+    private String getPace() {
+        Double ap = currentTrackerInformation.getCurrentPace();
+        if(ap == null) return "0";
+
+        return formatter.formatPace(Formatter.TXT_SHORT, ap);
+    }
+
+    private String getTime() {
+        Double at = currentTrackerInformation.getTime();
+        if(at == null) return "0";
+
+        return formatter.formatElapsedTime(Formatter.TXT_LONG, Math.round(at));
+    }
+}

--- a/app/src/org/runnerup/view/RunActivity.java
+++ b/app/src/org/runnerup/view/RunActivity.java
@@ -17,25 +17,6 @@
 
 package org.runnerup.view;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-
-import org.runnerup.R;
-import org.runnerup.gpstracker.GpsTracker;
-import org.runnerup.util.Formatter;
-import org.runnerup.util.HRZones;
-import org.runnerup.util.TickListener;
-import org.runnerup.widget.WidgetUtil;
-import org.runnerup.workout.HeadsetButtonReceiver;
-import org.runnerup.workout.Intensity;
-import org.runnerup.workout.Scope;
-import org.runnerup.workout.Step;
-import org.runnerup.workout.Workout;
-import org.runnerup.workout.feedback.RUTextToSpeech;
-
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -63,6 +44,25 @@ import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
+
+import org.runnerup.R;
+import org.runnerup.gpstracker.GpsTracker;
+import org.runnerup.util.Formatter;
+import org.runnerup.util.HRZones;
+import org.runnerup.util.TickListener;
+import org.runnerup.widget.WidgetUtil;
+import org.runnerup.workout.HeadsetButtonReceiver;
+import org.runnerup.workout.Intensity;
+import org.runnerup.workout.Scope;
+import org.runnerup.workout.Step;
+import org.runnerup.workout.Workout;
+import org.runnerup.workout.feedback.RUTextToSpeech;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 
 @TargetApi(Build.VERSION_CODES.FROYO)
 public class RunActivity extends Activity implements TickListener {
@@ -212,7 +212,7 @@ public class RunActivity extends Activity implements TickListener {
     void onGpsTrackerBound() {
         workout = mGpsTracker.getWorkout();
         mGpsTracker.createActivity(workout.getSport());
-        mGpsTracker.setForeground(RunActivity.class);
+        mGpsTracker.setGpsTrackerBound();
         mGpsTracker.start();
 
         SharedPreferences prefs = workout.getAudioCues();


### PR DESCRIPTION
This PR adds gps status to a notification which will start when the StartActivity starts. It will disappear when the gps is stopping or when an activity is started. When an activity is started a notification will show distance, time and pace. (this will only show up on the phone) In Android L you will see this notification on your lock screen.

It would be nice to be able to start, pause, resume and stop from the notification but this isn't possible at the moment as all logic is in the activity and not the service.

The thought here is that this will prepare for some more features in a wear app. We can create a Wear-service in RunnerUp which communicates with the wear app. When pressing an action like "Start Activity" in the RunnerUp notification (or on the start button), we can send an intent to the service which in turn sends a message to the wear app. The wear app can then display a custom android activity for an ongoing activity. We can add actions in this activity that will send pause and stop calls back to the main runnerup app.
