### PR TITLE
Put configured accounts on top of the list

### DIFF
--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -121,7 +121,7 @@ public class AccountListActivity extends FragmentActivity implements Constants,
         };
 
         return new SimpleCursorLoader(this, mDB, DB.ACCOUNT.TABLE, from, null, null,
-                DB.ACCOUNT.ENABLED + " desc, " + DB.ACCOUNT.NAME);
+                DB.ACCOUNT.ENABLED + " desc, " + DB.ACCOUNT.AUTH_CONFIG + " is null, " + DB.ACCOUNT.NAME);
     }
 
     @Override


### PR DESCRIPTION
When viewing the accounts list, put the configured one on top for faster access
