### PR TITLE
Update build.gradle to reflect antpluginlib update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     compile files('../GraphView/public/graphview-3.1.jar')
     provided files('libs/samsung_ble_sdk_200.jar')
-    compile files('libs/antpluginlib_3.1.0.jar')
+    compile files('libs/antpluginlib_3-3-0-RC1.jar')
 
     compile project(':common')
 
@@ -95,8 +95,8 @@ task downloadSamsungBleSdk(type: DownloadTask) {
 preBuild.dependsOn downloadSamsungBleSdk
 
 task downloadAntPluginLib(type: DownloadTask) {
-    sourceUrl = 'https://github.com/ant-wireless/ANT-Android-SDKs/raw/master/ANT%2B_Android_SDK/API/antpluginlib_3-1-0.jar'
-    target = file('libs/antpluginlib_3.1.0.jar')
+    sourceUrl = 'https://github.com/ant-wireless/ANT-Android-SDKs/raw/master/ANT%2B_Android_SDK/API/antpluginlib_3-3-0-RC1.jar'
+    target = file('libs/antpluginlib_3-3-0-RC1.jar')
 }
 preBuild.dependsOn downloadAntPluginLib
 


### PR DESCRIPTION
This is bound to get broken again, though. Either we use it as a submodule or its link will break again and a new commit will be needed everytime.