### PR TITLE
Releaseproperties fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 *.iml
 
 lint.xml
+
+# Release signing property file
+release.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,9 +88,12 @@ allprojects {
 }
 
 def props = new Properties()
-if (rootProject.file("../release.properties").exists()) {
-    props.load(new FileInputStream(rootProject.file("../release.properties")))
+if (rootProject.file("release.properties").exists()) {
+    props.load(new FileInputStream(rootProject.file("release.properties")))
+
+    android.signingConfigs.release.storeFile rootProject.file(props.keyStore)
     android.signingConfigs.release.storePassword props.keyStorePassword
+    android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 }
 

--- a/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
@@ -720,7 +720,7 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
 
     @Override
     public boolean isBondingDevice() {
-        return false;
+        return true;
     }
 
     @Override

--- a/hrdevice/src/org/runnerup/hr/SamsungBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/SamsungBLEHRProvider.java
@@ -679,6 +679,6 @@ public class SamsungBLEHRProvider extends BtHRBase implements HRProvider {
 
     @Override
     public boolean isBondingDevice() {
-        return false;
+        return true;
     }
 }

--- a/release.properties.sample
+++ b/release.properties.sample
@@ -1,0 +1,12 @@
+# Sample release.properties.
+# Specifies the details of the keystore and key that will sign a release build
+#
+# Make a copy of this file as 'release.properties' and it will be used to sign release builds.
+# 'release.properties' will not be added to the repository
+
+# Path of keystore, either absolute or relative to the project's top directory
+keyStore=/path/to/keystore.jks
+keyStorePassword=my_keystore_password
+# The name of the alias in the keystore that you wish to use for signing
+keyAlias=runnerup
+keyAliasPassword=my_key_alias_password

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -35,8 +35,11 @@ dependencies {
 }
 
 def props = new Properties()
-if (rootProject.file("../release.properties").exists()) {
-    props.load(new FileInputStream(rootProject.file("../release.properties")))
+if (rootProject.file("release.properties").exists()) {
+    props.load(new FileInputStream(rootProject.file("release.properties")))
+
+    android.signingConfigs.release.storeFile rootProject.file(props.keyStore)
     android.signingConfigs.release.storePassword props.keyStorePassword
+    android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 }


### PR DESCRIPTION
Hello,

A couple of minor changes to the `release.properties` processing that I think makes things a little cleaner.

* Expects `release.properties` in the root project directory, rather than one level above
* Pulls the key alias and the keystore file path from `release.properties`
* Added `release.properties` to `.gitignore`
* Added a sample 

Any changes you would like, let me know.


Xiao