### PR TITLE
Fixed up release.properties usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 *.iml
 
 lint.xml
+
+# Release signing property file
+release.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,9 +88,12 @@ allprojects {
 }
 
 def props = new Properties()
-if (rootProject.file("../release.properties").exists()) {
-    props.load(new FileInputStream(rootProject.file("../release.properties")))
+if (rootProject.file("release.properties").exists()) {
+    props.load(new FileInputStream(rootProject.file("release.properties")))
+
+    android.signingConfigs.release.storeFile rootProject.file(props.keyStore)
     android.signingConfigs.release.storePassword props.keyStorePassword
+    android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 }
 

--- a/release.properties.sample
+++ b/release.properties.sample
@@ -1,0 +1,12 @@
+# Sample release.properties.
+# Specifies the details of the keystore and key that will sign a release build
+#
+# Make a copy of this file as 'release.properties' and it will be used to sign release builds.
+# 'release.properties' will not be added to the repository
+
+# Path of keystore, either absolute or relative to the project's top directory
+keyStore=/path/to/keystore.jks
+keyStorePassword=my_keystore_password
+# The name of the alias in the keystore that you wish to use for signing
+keyAlias=runnerup
+keyAliasPassword=my_key_alias_password

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -35,8 +35,11 @@ dependencies {
 }
 
 def props = new Properties()
-if (rootProject.file("../release.properties").exists()) {
-    props.load(new FileInputStream(rootProject.file("../release.properties")))
+if (rootProject.file("release.properties").exists()) {
+    props.load(new FileInputStream(rootProject.file("release.properties")))
+
+    android.signingConfigs.release.storeFile rootProject.file(props.keyStore)
     android.signingConfigs.release.storePassword props.keyStorePassword
+    android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 }


### PR DESCRIPTION
Hello,

A couple of minor changes to the `release.properties` processing that I think makes things a little cleaner.

* Expects `release.properties` in the root project directory, rather than one level above
* Pulls the key alias and the keystore file path from `release.properties`
* Added `release.properties` to `.gitignore`
* Added a sample 

Any changes you would like, let me know.


Xiao