### PR TITLE
Android 5.0: Change notification visibility to public 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
             minSdkVersion 8
             targetSdkVersion 18
             versionName "1.46"
-            versionCode 8000046 
+            versionCode 8000046
         }
         latest {
             minSdkVersion 14
-            targetSdkVersion 20
+            targetSdkVersion 21
             versionName "1.46"
             versionCode 14000046
         }
@@ -66,18 +66,18 @@ android {
 }
 
 dependencies {
-    latestCompile 'com.android.support:support-v4:20.0.0'
+    latestCompile 'com.android.support:support-v4:21.0.0'
     latestCompile 'com.google.android.gms:play-services:6.1.11'
 
     froyoCompile 'com.android.support:support-v4:19.1.+'
     froyoCompile 'com.google.android.gms:play-services:3.2.65'
 
     compile files('../GraphView/public/graphview-3.1.jar')
-    
+
     compile project(':common')
     compile project(':hrdevice')
 
-    latestWearApp project(':wear')
+   latestWearApp project(':wear')
 }
 
 allprojects {

--- a/app/froyo/java/org/runnerup/util/NotificationCompat.java
+++ b/app/froyo/java/org/runnerup/util/NotificationCompat.java
@@ -25,6 +25,6 @@ import android.support.v4.app.NotificationCompat.Builder;
  */
 public class NotificationCompat {
 
-    public static void setLocalOnly(Builder builder) {
+    public static void customSettings(Builder builder) {
     }
 }

--- a/app/froyo/java/org/runnerup/util/NotificationCompat.java
+++ b/app/froyo/java/org/runnerup/util/NotificationCompat.java
@@ -25,6 +25,10 @@ import android.support.v4.app.NotificationCompat.Builder;
  */
 public class NotificationCompat {
 
-    public static void customSettings(Builder builder) {
+    public static void setLocalOnly(Builder builder) {
+    }
+    public static void setVisibility(Builder builder) {
+    }
+    public static void setCategory(Builder builder) {
     }
 }

--- a/app/latest/java/org/runnerup/util/NotificationCompat.java
+++ b/app/latest/java/org/runnerup/util/NotificationCompat.java
@@ -17,6 +17,7 @@
 package org.runnerup.util;
 
 import android.annotation.TargetApi;
+import android.app.Notification;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat.Builder;
 
@@ -25,9 +26,13 @@ import android.support.v4.app.NotificationCompat.Builder;
  */
 public class NotificationCompat {
 
-    public static void setLocalOnly(Builder builder) {
+    public static void customSettings(Builder builder) {
         if (Build.VERSION.SDK_INT >= 20) {
             builder.setLocalOnly(true);
+        }
+        if (Build.VERSION.SDK_INT >= 21) {
+            builder.setVisibility(Notification.VISIBILITY_PUBLIC);
+            builder.setCategory(Notification.CATEGORY_SERVICE);
         }
     }
 }

--- a/app/latest/java/org/runnerup/util/NotificationCompat.java
+++ b/app/latest/java/org/runnerup/util/NotificationCompat.java
@@ -26,12 +26,18 @@ import android.support.v4.app.NotificationCompat.Builder;
  */
 public class NotificationCompat {
 
-    public static void customSettings(Builder builder) {
+    public static void setLocalOnly(Builder builder) {
         if (Build.VERSION.SDK_INT >= 20) {
             builder.setLocalOnly(true);
         }
+    }
+    public static void setVisibility(Builder builder) {
         if (Build.VERSION.SDK_INT >= 21) {
             builder.setVisibility(Notification.VISIBILITY_PUBLIC);
+        }
+    }
+    public static void setCategory(Builder builder) {
+        if (Build.VERSION.SDK_INT >= 21) {
             builder.setCategory(Notification.CATEGORY_SERVICE);
         }
     }

--- a/app/src/org/runnerup/notification/GpsBoundState.java
+++ b/app/src/org/runnerup/notification/GpsBoundState.java
@@ -29,7 +29,9 @@ public class GpsBoundState implements NotificationState {
         builder.setContentText(context.getString(R.string.Ready_to_start_running));
         builder.setSmallIcon(R.drawable.icon);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.customSettings(builder);
+        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.setVisibility(builder);
+        org.runnerup.util.NotificationCompat.setCategory(builder);
 
         notification = builder.build();
     }

--- a/app/src/org/runnerup/notification/GpsBoundState.java
+++ b/app/src/org/runnerup/notification/GpsBoundState.java
@@ -29,7 +29,7 @@ public class GpsBoundState implements NotificationState {
         builder.setContentText(context.getString(R.string.Ready_to_start_running));
         builder.setSmallIcon(R.drawable.icon);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.customSettings(builder);
 
         notification = builder.build();
     }

--- a/app/src/org/runnerup/notification/GpsSearchingState.java
+++ b/app/src/org/runnerup/notification/GpsSearchingState.java
@@ -33,7 +33,9 @@ public class GpsSearchingState implements NotificationState {
         builder.setContentTitle(context.getString(R.string.Searching_for_GPS));
         builder.setSmallIcon(R.drawable.icon);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.customSettings(builder);
+        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.setVisibility(builder);
+        org.runnerup.util.NotificationCompat.setCategory(builder);
     }
 
     @Override

--- a/app/src/org/runnerup/notification/GpsSearchingState.java
+++ b/app/src/org/runnerup/notification/GpsSearchingState.java
@@ -33,7 +33,7 @@ public class GpsSearchingState implements NotificationState {
         builder.setContentTitle(context.getString(R.string.Searching_for_GPS));
         builder.setSmallIcon(R.drawable.icon);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.customSettings(builder);
     }
 
     @Override

--- a/app/src/org/runnerup/notification/OngoingState.java
+++ b/app/src/org/runnerup/notification/OngoingState.java
@@ -39,7 +39,7 @@ public class OngoingState implements NotificationState {
         builder.setSmallIcon(R.drawable.icon);
         builder.setOngoing(true);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.customSettings(builder);
     }
 
     @Override

--- a/app/src/org/runnerup/notification/OngoingState.java
+++ b/app/src/org/runnerup/notification/OngoingState.java
@@ -39,7 +39,9 @@ public class OngoingState implements NotificationState {
         builder.setSmallIcon(R.drawable.icon);
         builder.setOngoing(true);
         builder.setOnlyAlertOnce(true);
-        org.runnerup.util.NotificationCompat.customSettings(builder);
+        org.runnerup.util.NotificationCompat.setLocalOnly(builder);
+        org.runnerup.util.NotificationCompat.setVisibility(builder);
+        org.runnerup.util.NotificationCompat.setCategory(builder);
     }
 
     @Override


### PR DESCRIPTION
Currently when screen is locked, notification content (distance / time / pace) is hidden because its lollipop default behavior. Changing visibility to public set it readable again.
Visibility is only available in API 21 so I bumped build.gradle from API 20 to API 21.