### PR TITLE
build.gradle: invert productFlavors order so that fdroid detect correct version code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,17 +27,17 @@ android {
     }
 
     productFlavors {
-        froyo {
-            minSdkVersion 8
-            targetSdkVersion 18
-            versionName "1.47"
-            versionCode 8000047
-        }
         latest {
             minSdkVersion 14
             targetSdkVersion 21
             versionName "1.47"
             versionCode 14000047
+        }
+        froyo {
+            minSdkVersion 8
+            targetSdkVersion 18
+            versionName "1.47"
+            versionCode 8000047
         }
     }
 


### PR DESCRIPTION
See [PR](https://gitlab.com/fdroid/fdroiddata/merge_requests/875/commits) for details but basically fdroid has a tool to automatically retrieve version code from `build.gradle`. However it is really basic and retrieves the first versionCode found, so changing the order will fix the fdroid tool without any drawback on runnerup I guess.
