### PR TITLE
Update gradle and plugins to make it possible to build in newer AS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
     components:
-        - tools-25.1.17
+        - tools-25.1.7
         - build-tools-23.0.3
         - android-22
         - extras

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
     components:
-        - build-tools-22.0.1
-        - android-21
+        - build-tools-23.0.3
+        - android-22
         - extras
         - extra-android-m2repository
         - extra-google-google_play_services

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: android
 
 android:
     components:
-        - tools-25.1.7
-        - build-tools-23.0.3
+        - build-tools
         - android-22
         - extras
         - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 
 android:
     components:
+        - tools-25.1.17
         - build-tools-23.0.3
         - android-22
         - extras

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
     components:
-        - build-tools
+        - build-tools-23.0.1
         - android-22
         - extras
         - extra-android-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.3'
 
     sourceSets {
         main {
@@ -74,18 +73,13 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.1.0'
     latestCompile 'com.google.android.gms:play-services:6.1.11'
     latestCompile 'com.getpebble:pebblekit:3.0.0'
-
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar'){
-        transitive=true
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {
+        transitive = true
     }
-
     compile files('../GraphView/public/graphview-3.1.jar')
-
     compile project(':common')
     compile project(':hrdevice')
-
     latestWearApp project(':wear')
-
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '23.0.1'
 
     sourceSets {
         main {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,9 +100,8 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 } else {
-    android.signingConfigs.release.storePassword = 'storePassword'
-    android.signingConfigs.release.keyAlias = 'keyAlias'
-    android.signingConfigs.release.keyPassword = 'keyPassword'
+    project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    android.buildTypes.release.signingConfig = null
 }
 
 android.applicationVariants.all{ variant ->

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.1'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 
 }
-

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 14 18:28:01 CEST 2014
+#Sun Jun 26 15:48:54 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -6,7 +6,7 @@ version = "1.0"
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.3'
     
     sourceSets {
         main {

--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -6,7 +6,7 @@ version = "1.0"
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '23.0.1'
     
     sourceSets {
         main {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 20

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -43,7 +43,6 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias = props.keyAlias
     android.signingConfigs.release.keyPassword = props.keyAliasPassword
 } else {
-    android.signingConfigs.release.storePassword = 'storePassword'
-    android.signingConfigs.release.keyAlias = 'keyAlias'
-    android.signingConfigs.release.keyPassword = 'keyPassword'
+    project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    android.buildTypes.release.signingConfig = null
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 20


### PR DESCRIPTION
Update gradle and plugins to make it possible to build in newer AndroidStudio

 * Latest gradle plugin version
 * gradle wrapper update version to 2.10 (required by gradle plugin)
 * BuildTools updated for gradle plugin
 * com.github.dcendents:android-maven-plugin was renamed to com.github.dcendents:android-maven-gradle-plugin
 * Remove com.jakewharton.sdkmanager that is depreciated. SDK to by updated in gradle plugin 2.2.0 (there are workarounds, not working well)