### PR TITLE
Centralize build-tools and other shared versions'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,22 @@ language: android
 
 android:
     components:
-        - build-tools-23.0.1
         - platform-tools
         - tools
+        - build-tools-24.0.0
         - android-22
         - extras
         - extra-android-m2repository
         - extra-google-google_play_services
+
+notifications:
+  email: false
+
+# cache between builds
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.gradle
 
 script:
     - ./gradlew lintFroyoRelease

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
@@ -34,14 +34,14 @@ android {
     productFlavors {
         latest {
             minSdkVersion 14
-            targetSdkVersion 22
-            versionName "1.53"
-            versionCode 14000053
+            targetSdkVersion rootProject.ext.compileSdkVersion
+            versionName rootProject.ext.versionName
+            versionCode rootProject.ext.versionCode
         }
         froyo {
             minSdkVersion 8
-            targetSdkVersion 22
-            versionName "1.53"
+            targetSdkVersion rootProject.ext.targetSdkVersion
+            versionName rootProject.ext.versionName
             versionCode 8000053
         }
     }
@@ -103,7 +103,7 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 } else {
-    project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,17 @@ buildscript {
 
 }
 
-ext {
+project.ext {
+    //Common settings for all builds
+    //Note that Android Stuio does not know abot the 'ext' module and will warn, but gradle knows
+    //Some settings may differ for 'froyo' release
+    //minSdkVersion differs between modules
+    buildToolsVersion = '23.0.1'
+    compileSdkVersion = 22
+    targetSdkVersion = 22
+    versionName = "1.53"
+    versionCode = 14000053
+
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set
     preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 
 project.ext {
     //Common settings for all builds
-    //Note that Android Stuio does not know abot the 'ext' module and will warn, but gradle knows
+    //Note that Android Studio does not know about the 'ext' module and will warn
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
-    buildToolsVersion = '23.0.1'
+    buildToolsVersion = '24.0.0'
     compileSdkVersion = 22
     targetSdkVersion = 22
     versionName = "1.53"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 22
+        targetSdkVersion rootProject.ext.compileSdkVersion
         versionCode 1
         versionName '1.0'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip

--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -5,8 +5,8 @@ group = "org.runnerup.hr"
 version = "1.0"
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
@@ -26,7 +26,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 22
+        targetSdkVersion rootProject.ext.compileSdkVersion
         versionCode 1
         versionName = version
     }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 20
-        targetSdkVersion 22
-        versionName "1.53"
-        versionCode 14000053
+        targetSdkVersion rootProject.ext.compileSdkVersion
+        versionName rootProject.ext.versionName
+        versionCode rootProject.ext.versionCode
     }
 
     dexOptions {
@@ -48,6 +48,6 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias = props.keyAlias
     android.signingConfigs.release.keyPassword = props.keyAliasPassword
 } else {
-    project.logger.warn('WARN: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }


### PR DESCRIPTION
Simplify updates of versions

Instead of changing build-tools etc in 4 separate files, set it in the common file