### PR TITLE
Raise SDK to 10 (Gingerbread 2.3.3)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
             versionCode 14000053
         }
         froyo {
-            minSdkVersion 8
+            minSdkVersion 10
             targetSdkVersion 22
             versionName "1.53"
             versionCode 8000053


### PR DESCRIPTION
Opened primarily for discussion, minor file change
Android usage: https://developer.android.com/about/dashboards/index.html
Froyo (SDK 8) has 0.1%, SDK 9 has less than 0.1%. Even SDK 10 has 2.0%
One specific reason to drop Froyo is a change in SDK 23, backwards supported from SDK 9: (see Apache Http Removal)
https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html
While the SDK can be updated still supporting SDK 8, it is another limitation

An alternative to raising the SDK is to drop the "froyo"build completely, just starting with ICS (SDK 14).
If Froyo builds are needed, they can be done from a separate maintenance branch (just few new features supported).
I guess ICS/JB should be supported mainline some time more, for instance Sony Xperia Active is on 4.0.1

There are usage statistics in Play...