### PR TITLE
Travis: Using latest versions of SDK tools and platform-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: android
 
 android:
     components:
-        - platform-tools
         - tools
+        - tools #update to latest, cannot control version
+        - platform-tools #latest
         - build-tools-24.0.0
         - android-22
-        - extras
+        - extra
         - extra-android-m2repository
         - extra-google-google_play_services
 


### PR DESCRIPTION
tools and build-tools cannot be controlled in Android. Either the SDK default is used (not specifying them in travis.yml) which often gives old versions or the latest versions from Google.
As the default are often too old the latest are used. That will too require some special setup order in the .yml.
In addition 'extras' should apparently be spelled 'extra'.

Some links:
https://github.com/codepath/android_guides/wiki/Setting-up-Travis-CI
https://github.com/travis-ci/travis-ci/issues/6193