### PR TITLE
Prepare for Play Services update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: 'com.android.application'
 
+import java.util.regex.Pattern
+
+def doExtractStringFromManifest(name) {
+    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
+    def pattern = Pattern.compile(name + "=\"(.*?)\"")
+    def matcher = pattern.matcher(manifestFile.getText())
+    matcher.find()
+    return matcher.group(1)
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -44,6 +54,10 @@ android {
             versionName rootProject.ext.versionName
             versionCode 8000053
         }
+    }
+
+    defaultConfig {
+        applicationId = doExtractStringFromManifest("package")
     }
 
     signingConfigs {


### PR DESCRIPTION
No actual change. Propose it is merged so change if is available if testing for some reason - annoying to find these issues

Update Play Services requires applicationId to be set. Using a dynamic approach
The play version is not updated right now. No new api is needed what I know and updating just increases the size with 3MB (which is an issue on older devices).