### PR TITLE
Use AppCompat Theme

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -42,7 +42,7 @@
 	<application
 	    android:icon="@drawable/icon"
 	    android:label="@string/app_name"
-		android:theme="@android:style/Theme.NoTitleBar">
+		android:theme="@style/AppTheme">
 
 		<activity
 			android:name=".view.MainLayout"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.1.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     latestCompile 'com.google.android.gms:play-services:6.1.11'
     latestCompile 'com.getpebble:pebblekit:3.0.0'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {

--- a/app/res/layout/main.xml
+++ b/app/res/layout/main.xml
@@ -30,8 +30,8 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:padding="0px"
-            android:layout_marginTop="-10px"
-            android:layout_marginBottom="-5px"
+            android:layout_marginTop="0px"
+            android:layout_marginBottom="0px"
              />
 
         <FrameLayout

--- a/app/res/layout/manage_workouts.xml
+++ b/app/res/layout/manage_workouts.xml
@@ -52,17 +52,17 @@
           android:layout_height="wrap_content"
           android:text="@string/Download"
           android:textSize="16sp"
-  />
+      />
 
       <Button
-              android:id="@+id/share_workout_button"
-              style="@style/ButtonText"
-              android:background="@drawable/btn_blue"
-              android:layout_width="0dp"
-              android:layout_weight="1"
-              android:layout_height="wrap_content"
-              android:text="@string/Share"
-              android:textSize="16sp"
+          android:id="@+id/share_workout_button"
+          style="@style/ButtonText"
+          android:background="@drawable/btn_blue"
+          android:layout_width="0dp"
+          android:layout_weight="1"
+          android:layout_height="wrap_content"
+          android:text="@string/Share"
+          android:textSize="16sp"
       />
     </TableRow>
 

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -16,24 +16,34 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-<style name="ButtonText">
-    <item name="android:layout_width">fill_parent</item>
-    <item name="android:layout_height">wrap_content</item>
-    <item name="android:textColor">@color/btn_text_color</item>
-    <item name="android:gravity">center</item>
-    <item name="android:layout_margin">3dp</item>
-    <item name="android:textSize">20sp</item>
-    <item name="android:textStyle">bold</item>
-    <item name="android:shadowColor">#000000</item>
-    <item name="android:shadowDx">1</item>
-    <item name="android:shadowDy">1</item>
-    <item name="android:shadowRadius">2</item>
+    <style name="AppTheme" parent="Theme.AppCompat">
+        <item name="windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+        <item name="android:tabWidgetStyle">@android:style/Widget.TabWidget</item>
+        <!--
+            <item name="colorPrimary">@color/colorPrimary</item>
+            <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+            <item name="colorAccent">@color/colorAccent</item>
+         -->
+    </style>
+<style name="ButtonText" parent="AppTheme">
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/btn_text_color</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_margin">3dp</item>
+        <item name="android:textSize">20sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:shadowColor">#000000</item>
+        <item name="android:shadowDx">1</item>
+        <item name="android:shadowDy">1</item>
+        <item name="android:shadowRadius">2</item>
 </style>
-<style name="ButtonTextGrey">
+<style name="ButtonTextGrey" parent="AppTheme">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:textColor">#000000</item>
     <item name="android:gravity">center</item>
+    <item name="android:textColor">#000000</item>
     <item name="android:layout_margin">3dp</item>
     <item name="android:textSize">20sp</item>
     <item name="android:textStyle">bold</item>
@@ -42,7 +52,7 @@
     <item name="android:shadowDy">1</item>
     <item name="android:shadowRadius">2</item>
 </style>
-<style name="RunHeader">
+<style name="RunHeader" parent="AppTheme">
     <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_weight">1</item>
@@ -50,7 +60,7 @@
     <item name="android:textSize">15sp</item>
     <item name="android:textStyle">bold|italic</item>
 </style>
-<style name="RunInfo">
+<style name="RunInfo" parent="AppTheme">
     <item name="android:layout_width">0dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_weight">1</item>
@@ -59,7 +69,7 @@
     <item name="android:textSize">20sp</item>
     <item name="android:textStyle">bold</item>
 </style>
-<style name="FeedDateHeader">
+<style name="FeedDateHeader" parent="AppTheme">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_margin">10dp</item>
@@ -67,7 +77,7 @@
     <item name="android:textSize">20sp</item>
     <item name="android:textStyle">bold</item>
 </style>
-<style name="FeedActivitySource">
+<style name="FeedActivitySource" parent="AppTheme">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginLeft">5dp</item>

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -356,8 +356,8 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     public void insertAccounts(SQLiteDatabase arg0) {
-        boolean yet = true;
-        boolean notyet = false;
+        final boolean yet = true;
+        final boolean notyet = false;
 
         if (notyet) {
             /**

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -212,7 +212,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         tabSpec.setContent(R.id.tab_upload);
         th.addTab(tabSpec);
 
-        th.getTabWidget().setBackgroundColor(Color.DKGRAY);
+        //th.getTabWidget().setBackgroundColor(Color.DKGRAY);
 
         {
             ListView lv = (ListView) findViewById(R.id.laplist);

--- a/app/src/org/runnerup/view/HRSettingsActivity.java
+++ b/app/src/org/runnerup/view/HRSettingsActivity.java
@@ -619,7 +619,7 @@ public class HRSettingsActivity extends AppCompatActivity implements HRClient {
                 row = convertView;
             }
             TextView tv = (TextView) row.findViewById(android.R.id.text1);
-            tv.setTextColor(resources.getColor(R.color.black));
+            //tv.setTextColor(resources.getColor(R.color.black));
 
             HRDeviceRef btDevice = deviceList.get(position);
             tv.setTag(btDevice);

--- a/app/src/org/runnerup/view/MainLayout.java
+++ b/app/src/org/runnerup/view/MainLayout.java
@@ -129,9 +129,9 @@ public class MainLayout extends TabActivity {
                 .setIndicator(getString(R.string.Settings), myGetDrawable(R.drawable.ic_tab_setup))
                 .setContent(new Intent(this, SettingsActivity.class)));
 
-        // Set tabs Colors
-        tabHost.setBackgroundColor(Color.BLACK);
-        tabHost.getTabWidget().setBackgroundColor(Color.BLACK);
+        //// Set tabs Colors
+        //tabHost.setBackgroundColor(Color.BLACK);
+        //tabHost.getTabWidget().setBackgroundColor(Color.BLACK);
         tabHost.setCurrentTab(0);
         WidgetUtil.addLegacyOverflowButton(getWindow());
 

--- a/app/src/org/runnerup/view/StartActivity.java
+++ b/app/src/org/runnerup/view/StartActivity.java
@@ -215,7 +215,7 @@ public class StartActivity extends Activity implements TickListener, GpsInformat
         tabHost.addTab(tabSpec);
 
         tabHost.setOnTabChangedListener(onTabChangeListener);
-        tabHost.getTabWidget().setBackgroundColor(Color.DKGRAY);
+        //tabHost.getTabWidget().setBackgroundColor(Color.DKGRAY);
 
         simpleAudioListAdapter = new AudioSchemeListAdapter(mDB, inflater, false);
         simpleAudioListAdapter.reload();

--- a/app/src/org/runnerup/widget/WidgetUtil.java
+++ b/app/src/org/runnerup/widget/WidgetUtil.java
@@ -50,10 +50,10 @@ public class WidgetUtil {
         Resources res = ctx.getResources(); // Resource object to get Drawables
         TextView txtTab = new TextView(ctx);
         txtTab.setText(title);
-        txtTab.setTextColor(Color.WHITE);
-        txtTab.setGravity(Gravity.CENTER_HORIZONTAL);
+        //txtTab.setTextColor(Color.WHITE);
+        //txtTab.setGravity(Gravity.CENTER_HORIZONTAL);
         Drawable drawable = res.getDrawable(R.drawable.tab_indicator_holo);
-        WidgetUtil.setBackground(txtTab, drawable); // R.drawable.tab_indicator_holo);
+        WidgetUtil.setBackground(txtTab, drawable);
 
         int h = (25 * drawable.getIntrinsicHeight()) / 10;
         txtTab.setPadding(0, h, 0, h);


### PR DESCRIPTION
Replacing PR #409, #412 

AppCompat theme is required for some newer elements in Support Design library like SnackBars
Using AppCompat also aligns the design with other apps, removes some of the dated look
Some overrides could be removed in code (I did not change the override in styles.xml)

The update slightly changes fonts, dividers and looks, the following "larger" changes are seen (may be more):
 * Backgrounds were previously mostly black, but not all (for instance Advanced Settings were graded). Overrides removed, all gray now
 * Before KK: Button text in manage Workouts have visual glitches when enabling/disabling, issues before too though.
 * Before KK:  CheckBoxes have slightly different appearance than stock and before

I have tried to use singleLine and various other fixes for buttons but do not find a solution that works without glitches.
I propose that visual glitches pre KK are accepted.

Note: AppCompat v22.2.1 seem to miss some functionality compared to v23. Maybe easier to improve visuals with the related SDK-24 PR too (the SDK-24 will require this PR).
Anyway, AppCompat is required to freshen up the GUI to be more standard AndroidManifest

Longer term, the app design should be updated.
Maybe Light theme?
Use more Material Design, skipping the two levels of tabs and use a action bar?