### PR TITLE
Code changes to support requesting MM permissions dynamically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: android
 
+jdk:
+  - oraclejdk8
+
 android:
     components:
         - tools
         - tools #update to latest, cannot control version
         - platform-tools #latest
         - build-tools-24.0.1
-        - android-22
+        - android-24
         - extra
         - extra-android-m2repository
         - extra-google-google_play_services

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -29,6 +29,7 @@
 		<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 		<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 		<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
+		<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 		<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 		<uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
 		<uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,9 @@ android {
         // Disable some specific checks completely, some specific with path in lint.xml
         disable 'MissingTranslation','MissingQuantity','ImpliedQuantity','InvalidPackage'
     }
+
+    //Froyo compatibility
+    useLibrary 'org.apache.http.legacy'
 }
 
 repositories {
@@ -90,7 +93,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    //design uses com.android.support:appcompat, not explicitly required
+    compile 'com.android.support:design:24.1.1'
     latestCompile 'com.google.android.gms:play-services:6.1.11'
     latestCompile 'com.getpebble:pebblekit:3.0.0'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {
@@ -120,7 +124,7 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 } else {
-    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.info('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }
 

--- a/app/src/org/runnerup/tracker/GpsStatus.java
+++ b/app/src/org/runnerup/tracker/GpsStatus.java
@@ -17,8 +17,10 @@
 
 package org.runnerup.tracker;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.GpsSatellite;
 import android.location.Location;
 import android.location.LocationListener;
@@ -26,13 +28,14 @@ import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 
 import org.runnerup.util.TickListener;
 /**
- * 
+ *
  * This is a helper class that is used to determine when the GPS status is good
  * enough (isFixed())
- * 
+ *
  */
 
 @TargetApi(Build.VERSION_CODES.FROYO)
@@ -74,16 +77,19 @@ public class GpsStatus implements LocationListener,
     public void start(TickListener listener) {
         clear(true);
         this.listener = listener;
-        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        try {
-            lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
-        } catch (Exception ex) {
-            lm = null;
-        }
-
-        if (lm != null) {
-            locationManager = lm;
-            locationManager.addGpsStatusListener(this);
+        if (ContextCompat.checkSelfPermission(this.context,
+                Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+            try {
+                lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
+            } catch (Exception ex) {
+                lm = null;
+            }
+            if (lm != null) {
+                locationManager = lm;
+                locationManager.addGpsStatusListener(this);
+            }
         }
     }
 
@@ -91,7 +97,11 @@ public class GpsStatus implements LocationListener,
         this.listener = null;
         if (locationManager != null) {
             locationManager.removeGpsStatusListener(this);
-            locationManager.removeUpdates(this);
+            if (ContextCompat.checkSelfPermission(this.context,
+                    Manifest.permission.ACCESS_FINE_LOCATION)
+                    == PackageManager.PERMISSION_GRANTED) {
+                locationManager.removeUpdates(this);
+            }
             locationManager = null;
         }
     }

--- a/app/src/org/runnerup/view/RunActivity.java
+++ b/app/src/org/runnerup/view/RunActivity.java
@@ -17,6 +17,7 @@
 
 package org.runnerup.view;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ComponentName;
@@ -246,7 +247,7 @@ public class RunActivity extends Activity implements TickListener {
 
             if (mTracker != null) {
                 Location l2 = mTracker.getLastKnownLocation();
-                if (!l2.equals(l)) {
+                if (l2 != null && !l2.equals(l)) {
                     l = l2;
                 }
             }

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -17,12 +17,16 @@
 
 package org.runnerup.view;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
@@ -32,6 +36,10 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
 
 import org.runnerup.R;
 import org.runnerup.db.DBHelper;
@@ -40,13 +48,13 @@ import org.runnerup.util.FileUtil;
 import java.io.IOException;
 
 @TargetApi(Build.VERSION_CODES.FROYO)
-public class SettingsActivity extends PreferenceActivity {
+public class SettingsActivity extends PreferenceActivity
+        implements ActivityCompat.OnRequestPermissionsResultCallback{
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.settings);
         setContentView(R.layout.settings_wrapper);
-
         {
             Preference btn = findPreference("exportdb");
             btn.setOnPreferenceClickListener(onExportClick);
@@ -84,6 +92,81 @@ public class SettingsActivity extends PreferenceActivity {
         return false;
     }
 
+    @SuppressLint("InlinedApi")
+    public static boolean requestReadStoragePermissions(final Activity activity) {
+        boolean ret = true;
+        if (Build.VERSION.SDK_INT >= 16 &&
+                ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.READ_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ret = false;
+
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                //The caller informs the user, no toast or SnackBar
+            } else {
+                //Request permission - not working from Settings.Activity
+                //ActivityCompat.requestPermissions(activity,
+                //        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                //        REQUEST_READ_EXTERNAL_STORAGE);
+                String s = "Read permission is NOT granted";
+                Log.i(activity.getClass().getSimpleName(), s);
+            }
+        }
+        return ret;
+    }
+
+    public static boolean requestWriteStoragePermissions(final Activity activity) {
+        boolean ret = true;
+        if (ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ret = false;
+
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                //The caller informs the user, no toast or SnackBar
+            } else {
+                 //Request permission - not working from Settings.Activity
+                 //ActivityCompat.requestPermissions(activity,
+                 //        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                 //        REQUEST_WRITE_EXTERNAL_STORAGE);
+                String s = "Write permission is NOT granted";
+                Log.i(activity.getClass().getSimpleName(), s);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Id to identify a permission request.
+     */
+    private static final int REQUEST_READ_EXTERNAL_STORAGE = 2000;
+    private static final int REQUEST_WRITE_EXTERNAL_STORAGE = 2001;
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+
+        if (requestCode == REQUEST_READ_EXTERNAL_STORAGE || requestCode == REQUEST_WRITE_EXTERNAL_STORAGE) {
+            // Check if the only required permission has been granted (could react on the response)
+            if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                //OK, could redo request here
+            } else {
+                String s = (requestCode == REQUEST_READ_EXTERNAL_STORAGE ? "READ" : "WRITE")
+                        + " permission was NOT granted";
+                if (grantResults.length >= 1) {
+                    s += grantResults[0];
+                }
+
+                Log.i(getClass().getSimpleName(), s);
+                //Toast.makeText(SettingsActivity.this, s, Toast.LENGTH_SHORT).show();
+            }
+
+        } else {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
     final OnPreferenceClickListener onExportClick = new OnPreferenceClickListener() {
 
         @Override
@@ -98,14 +181,19 @@ public class SettingsActivity extends PreferenceActivity {
                 }
 
             };
-            String from = DBHelper.getDbPath(getApplicationContext());
-            String to = dstdir + "/runnerup.db.export";
-            try {
-                int cnt = FileUtil.copyFile(to, from);
-                builder.setMessage("Copied " + cnt + " bytes");
-                builder.setPositiveButton(getString(R.string.Great), listener);
-            } catch (IOException e) {
-                builder.setMessage("Exception: " + e.toString());
+            if(requestWriteStoragePermissions(SettingsActivity.this)) {
+                String from = DBHelper.getDbPath(getApplicationContext());
+                String to = dstdir + "/runnerup.db.export";
+                try {
+                    int cnt = FileUtil.copyFile(to, from);
+                    builder.setMessage("Copied " + cnt + " bytes");
+                    builder.setPositiveButton(getString(R.string.Great), listener);
+                } catch (IOException e) {
+                    builder.setMessage("Exception: " + e.toString());
+                    builder.setNegativeButton(getString(R.string.Darn), listener);
+                }
+            } else {
+                builder.setMessage("Storage permission not granted in Android settings");
                 builder.setNegativeButton(getString(R.string.Darn), listener);
             }
             builder.show();
@@ -117,9 +205,24 @@ public class SettingsActivity extends PreferenceActivity {
 
         @Override
         public boolean onPreferenceClick(Preference preference) {
-            String srcdir = Environment.getExternalStorageDirectory().getPath();
-            String from = srcdir + "/runnerup.db.export";
-            DBHelper.importDatabase(SettingsActivity.this, from);
+            if (requestReadStoragePermissions(SettingsActivity.this)) {
+                String srcdir = Environment.getExternalStorageDirectory().getPath();
+                String from = srcdir + "/runnerup.db.export";
+                DBHelper.importDatabase(SettingsActivity.this, from);
+            } else {
+                AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this);
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+
+                };
+                builder.setTitle("Import runnerup.db");
+                builder.setMessage("Storage permission not granted in Android settings");
+                builder.setNegativeButton(getString(R.string.Darn), listener);
+                builder.show();
+            }
             return false;
         }
     };

--- a/app/src/org/runnerup/workout/AutoPauseTrigger.java
+++ b/app/src/org/runnerup/workout/AutoPauseTrigger.java
@@ -48,7 +48,7 @@ public class AutoPauseTrigger extends Trigger {
         Double currentSpeed = workout.getSpeed(Scope.CURRENT);
         //if (currentSpeed == null)
         //    return;
-        if (currentSpeed < mAutoPauseMinSpeed) {
+        if (currentSpeed < mAutoPauseMinSpeed && lastLocation != null) {
             if (!mIsAutoPaused && mHasStopped
                     && (lastLocation.getTime() - mStoppedMovingAt) > mAutoPauseAfterSeconds * 1000) {
                 mIsAutoPaused = true;

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ project.ext {
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
     buildToolsVersion = '24.0.1'
-    compileSdkVersion = 22
-    targetSdkVersion = 22
+    compileSdkVersion = 24
+    targetSdkVersion = 24
     versionName = "1.53"
     versionCode = 14000053
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -49,6 +49,6 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias = props.keyAlias
     android.signingConfigs.release.keyPassword = props.keyAliasPassword
 } else {
-    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.info('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }

--- a/wear/src/main/java/org/runnerup/view/SearchingFragment.java
+++ b/wear/src/main/java/org/runnerup/view/SearchingFragment.java
@@ -29,7 +29,7 @@ import android.view.ViewGroup;
 
 import org.runnerup.R;
 
-@TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
+//@TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
 public class SearchingFragment extends Fragment {
 
     private CircledImageView mButton;
@@ -48,9 +48,11 @@ public class SearchingFragment extends Fragment {
         View view = inflater.inflate(R.layout.searching, container, false);
         super.onViewCreated(view, savedInstanceState);
 
-        mButton = (CircledImageView) view.findViewById(R.id.icon_searching);
-        AnimationDrawable frameAnimation = (AnimationDrawable) mButton.getForeground();
-        frameAnimation.start();
+        if (Build.VERSION.SDK_INT >= 23) {
+            mButton = (CircledImageView) view.findViewById(R.id.icon_searching);
+            AnimationDrawable frameAnimation = (AnimationDrawable) mButton.getForeground();
+            frameAnimation.start();
+        }
 
         return view;
     }


### PR DESCRIPTION
GPS is requested at App startup. If not granted a SnackBar will nag the user (unless not ask again is ticked). (This is tricky to do when pressing Start button, the request is done asynchronously.)
A few corrections to handle GPS not started
Longer term, the GPS can be set to work like other sensors, to be able to deactivate it

Also for read/write backups. There it would be natural to always request permission, but this do not work, so popup asking the user to manually activate.

Only popup for storage permissions
The request is not working there for some reason. (This could be improved with at least supplying a link to the settings).
This should be good enough for now.

Note that sharing activities and workouts uses "internal" directories that do not require permissions.

Note: CircledImageView.setForeground() listed as added in SDK 23
Compile possible with compile SDK 22 though, seem strange that this occurs. However, few Wear should use SDK22 anyway.