### PR TITLE
Sdk 24 http update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: android
 
+jdk:
+  - oraclejdk8
+
 android:
     components:
         - tools
         - tools #update to latest, cannot control version
         - platform-tools #latest
         - build-tools-24.0.1
-        - android-22
+        - android-24
         - extra
         - extra-android-m2repository
         - extra-google-google_play_services

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -29,6 +29,7 @@
 		<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 		<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 		<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
+		<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 		<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 		<uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
 		<uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,9 +82,6 @@ android {
         // Disable some specific checks completely, some specific with path in lint.xml
         disable 'MissingTranslation','MissingQuantity','ImpliedQuantity','InvalidPackage'
     }
-
-    //Froyo compatibility
-    useLibrary 'org.apache.http.legacy'
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,9 @@ android {
         // Disable some specific checks completely, some specific with path in lint.xml
         disable 'MissingTranslation','MissingQuantity','ImpliedQuantity','InvalidPackage'
     }
+
+    //Froyo compatibility
+    useLibrary 'org.apache.http.legacy'
 }
 
 repositories {
@@ -90,7 +93,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    //design uses com.android.support:appcompat, not explicitly required
+    compile 'com.android.support:design:24.1.1'
     latestCompile 'com.google.android.gms:play-services:6.1.11'
     latestCompile 'com.getpebble:pebblekit:3.0.0'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {
@@ -120,7 +124,7 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias props.keyAlias
     android.signingConfigs.release.keyPassword props.keyAliasPassword
 } else {
-    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.info('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }
 

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -32,7 +32,6 @@ import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -116,7 +115,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         out.close();
 
         JSONObject response = null;
-        if (conn.getResponseCode() == HttpStatus.SC_OK) {
+        if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
             try {
                 response = SyncHelper.parse(conn.getInputStream());
             } finally {
@@ -191,7 +190,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
             BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line = in.readLine();
 
-            if (conn.getResponseCode() == HttpStatus.SC_OK) {
+            if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 if (line.contains("<result>success</result>")) {
                     // Store the authentication token.
                     getCookies(conn);
@@ -496,7 +495,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         SyncHelper.postMulti(conn, parts);
 
         int code = conn.getResponseCode();
-        if (code != HttpStatus.SC_OK && code != HttpStatus.SC_MOVED_TEMPORARILY) {
+        if (code != HttpURLConnection.HTTP_OK && code != HttpURLConnection.HTTP_MOVED_TEMP) {
             throw new Exception("got a " + code + " response code from upload");
         }
 

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -200,7 +199,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK &&
+            if (responseCode == HttpURLConnection.HTTP_OK &&
                     "OK".contentEquals(res.getString("_0")) &&
                     res.has("authToken")) {
                 authToken = res.getString("authToken");
@@ -292,7 +291,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK &&
+            if (responseCode == HttpURLConnection.HTTP_OK &&
                     "OK".contentEquals(res.getString("_0"))) {
                 s.activityId = mID;
                 return s;
@@ -351,7 +350,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
 
             conn.disconnect();
 
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 parseFeed(feedUpdater, reply);
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -27,7 +27,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -284,7 +283,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         int code = conn.getResponseCode();
         String msg = conn.getResponseMessage();
 
-        if (code != HttpStatus.SC_OK) {
+        if (code != HttpURLConnection.HTTP_OK) {
             conn.disconnect();
             throw new Exception("Got code: " + code + ", msg: " + msg + " from " + url.toString());
         } else {

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -232,7 +231,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 int responseCode = conn.getResponseCode();
                 String amsg = conn.getResponseMessage();
                 getCookies(conn);
-                if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+                if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
                     String redirect = conn.getHeaderField("Location");
                     conn.disconnect();
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -243,7 +242,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                     responseCode = conn.getResponseCode();
                     amsg = conn.getResponseMessage();
                     getCookies(conn);
-                } else if (responseCode != HttpStatus.SC_OK) {
+                } else if (responseCode != HttpURLConnection.HTTP_OK) {
                     Log.e(getName(), "FunBeatSynchronizer::connect() - got " + responseCode
                             + ", msg: " + amsg);
                 }
@@ -388,7 +387,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             String amsg = conn.getResponseMessage();
             getCookies(conn);
             String redirect = null;
-            if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+            if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
                 redirect = conn.getHeaderField("Location");
                 conn.disconnect();
                 conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -399,7 +398,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 responseCode = conn.getResponseCode();
                 amsg = conn.getResponseMessage();
                 getCookies(conn);
-            } else if (responseCode != HttpStatus.SC_OK) {
+            } else if (responseCode != HttpURLConnection.HTTP_OK) {
                 Log.e(getName(), "FunBeatSynchronizer::upload() - got " + responseCode + ", msg: "
                         + amsg);
             }
@@ -434,7 +433,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 responseCode = conn.getResponseCode();
                 amsg = conn.getResponseMessage();
                 getCookies(conn);
-                if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+                if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
                     redirect = conn.getHeaderField("Location");
                     conn.disconnect();
                     conn = (HttpURLConnection) new URL(BASE_URL + redirect)
@@ -513,7 +512,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             final JSONObject reply = SyncHelper.parse(in);
             final int code = conn.getResponseCode();
             conn.disconnect();
-            if (code == HttpStatus.SC_OK) {
+            if (code == HttpURLConnection.HTTP_OK) {
                 parseFeed(feedUpdater, reply);
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -24,7 +24,6 @@ import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -165,9 +164,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             Log.e(getName(), "GarminSynchronizer.connect() CHOOSE_URL => code: " + responseCode
                     + ", msg: " + amsg);
 
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 return connectOld();
-            } else if (responseCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+            } else if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
                 return connectNew();
             }
         } catch (MalformedURLException e) {
@@ -203,7 +202,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
             getCookies(conn);
-            if (responseCode != HttpStatus.SC_OK) {
+            if (responseCode != HttpURLConnection.HTTP_OK) {
                 Log.e(getName(), "GarminSynchronizer::connect() - got " + responseCode + ", msg: "
                         + amsg);
             }
@@ -327,9 +326,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             int code = conn.getResponseCode();
             Log.e(getName(), "attempt: " + i + " => code: " + code);
             getCookies(conn);
-            if (code == HttpStatus.SC_OK)
+            if (code == HttpURLConnection.HTTP_OK)
                 break;
-            if (code != HttpStatus.SC_MOVED_TEMPORARILY)
+            if (code != HttpURLConnection.HTTP_MOVED_TEMP)
                 break;
             List<String> fields = conn.getHeaderFields().get("location");
             conn.disconnect();
@@ -404,7 +403,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
 
         int responseCode = conn.getResponseCode();
         String amsg = conn.getResponseMessage();
-        if (responseCode == HttpStatus.SC_OK) {
+        if (responseCode == HttpURLConnection.HTTP_OK) {
             JSONObject reply = SyncHelper.parse(new BufferedReader(new InputStreamReader(
             // if "activityType" not in res or res["activityType"]["key"] != acttype:
             conn.getInputStream())));
@@ -444,7 +443,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             SyncHelper.postMulti(conn, parts);
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 JSONObject reply = SyncHelper.parse(new BufferedReader(new InputStreamReader(
                         conn.getInputStream())));
                 conn.disconnect();
@@ -504,7 +503,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             //String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 obj = obj.getJSONObject("com.garmin.connect.workout.dto.WorkoutScheduleDto");
                 return obj.getString("workoutId");
             }
@@ -540,7 +539,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 JSONArray arr = obj.getJSONArray("calendarItems");
                 for (int i = 0; ; i++) {
                     obj = arr.optJSONObject(i);
@@ -578,7 +577,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 obj = obj.getJSONObject("com.garmin.connect.workout.dto.BaseUserWorkoutListDto");
                 JSONArray arr = obj.getJSONArray("baseUserWorkouts");
                 for (int i = 0;; i++) {
@@ -632,7 +631,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             conn.disconnect();
             int responseCode = conn.getResponseCode();
             String amsg = conn.getResponseMessage();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 return;
             }
             ex = new Exception(amsg);

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -193,9 +192,9 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
 
             int code = connect.getResponseCode();
             try {
-                if (code == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+                if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
                     continue;
-                } else if (code != HttpStatus.SC_OK) {
+                } else if (code != HttpURLConnection.HTTP_OK) {
                     Log.i(getName(), SyncHelper.parse(new GZIPInputStream(connect.getErrorStream())).toString());
                     status = Status.ERROR;
                     break;
@@ -244,7 +243,7 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
             int code = conn.getResponseCode();
             conn.disconnect();
 
-            if (code != HttpStatus.SC_OK) {
+            if (code != HttpURLConnection.HTTP_OK) {
                 throw new Exception("got a " + code + " response code from upload");
             } else {
                 JSONArray data = reply.getJSONArray("dataSource");

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -272,7 +271,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             String amsg = conn.getResponseMessage();
             conn.connect();
 
-            if (responseCode != HttpStatus.SC_OK) {
+            if (responseCode != HttpURLConnection.HTTP_OK) {
                 throw new Exception(amsg);
             }
 
@@ -286,7 +285,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             responseCode = conn.getResponseCode();
             amsg = conn.getResponseMessage();
             conn.disconnect();
-            if (responseCode == HttpStatus.SC_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 s = Status.OK;
                 s.activityId = mID;
                 return s;
@@ -355,7 +354,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             final JSONObject reply = SyncHelper.parse(in);
             final int code = conn.getResponseCode();
             conn.disconnect();
-            if (code == HttpStatus.SC_OK)
+            if (code == HttpURLConnection.HTTP_OK)
                 return reply;
         } finally {
             if (conn != null)

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -29,7 +29,6 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -342,7 +341,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
                 conn.addRequestProperty("Content-Type", "application/vnd.com.runkeeper.FitnessActivityFeed+json");
 
                 InputStream input = new BufferedInputStream(conn.getInputStream());
-                if (conn.getResponseCode() == HttpStatus.SC_OK) {
+                if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
                     JSONObject resp = SyncHelper.parse(input);
                     requestUrl = parseForNext(resp, list);
                     s = Status.OK;
@@ -431,7 +430,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
             String amsg = conn.getResponseMessage();
             conn.disconnect();
             conn = null;
-            if (responseCode >= HttpStatus.SC_OK && responseCode < HttpStatus.SC_MULTIPLE_CHOICES) {
+            if (responseCode >= HttpURLConnection.HTTP_OK && responseCode < HttpURLConnection.HTTP_MULT_CHOICE) {
                 s = Status.OK;
                 s.activityId = mID;
                 return s;
@@ -488,7 +487,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
             conn.addRequestProperty("Authorization", "Bearer " + access_token);
             conn.addRequestProperty("Content-type", "application/vnd.com.runkeeper.FitnessActivity+json");
 
-            if (conn.getResponseCode() == HttpStatus.SC_OK) {
+            if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 BufferedInputStream input = new BufferedInputStream(conn.getInputStream());
                 JSONObject resp = SyncHelper.parse(input);
                 activity = RunKeeper.parseToActivity(resp, getLapLength());
@@ -672,7 +671,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
         JSONObject obj = SyncHelper.parse(in);
 
         conn.disconnect();
-        if (responseCode == HttpStatus.SC_OK) {
+        if (responseCode == HttpURLConnection.HTTP_OK) {
             return obj;
         }
         throw new IOException(amsg);

--- a/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -33,11 +33,11 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.BuildConfig;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.tracker.WorkoutObserver;
@@ -49,11 +49,10 @@ import org.runnerup.workout.WorkoutInfo;
 public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements WorkoutObserver {
 
     public static final String NAME = "RunnerUp LIVE";
-    public static final String POST_URL = "http://weide.devsparkles.se/api/Resource/";
+    private static final String POST_URL = "http://weide.devsparkles.se/api/Resource/";
     private final Context context;
-    private final double mMinLiveLogDelayMillis = 5000;
 
-    long id = 0;
+    private long id = 0;
     private String username = null;
     private String password = null;
     private String postUrl = POST_URL;
@@ -96,10 +95,7 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
 
     @Override
     public boolean isConfigured() {
-        if (username != null && password != null) {
-            return true;
-        }
-        return false;
+        return username != null && password != null;
     }
 
     @Override
@@ -152,7 +148,8 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
             case DB.LOCATION.TYPE_DISCARD:
                 return 6;
         }
-        assert (false);
+        //Instead of assert (false);
+        if (BuildConfig.DEBUG) { throw new AssertionError(); }
         return 0;
     }
 
@@ -160,6 +157,7 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
     public void workoutEvent(WorkoutInfo workoutInfo, int type) {
 
         if (type == DB.LOCATION.TYPE_GPS) {
+            double mMinLiveLogDelayMillis = 5000;
             if (System.currentTimeMillis()-mTimeLastLog < mMinLiveLogDelayMillis) {
                 return;
             }

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -25,7 +25,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -237,7 +236,7 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
             if (!found) {
                 Log.e(getName(), "Unhandled response from RunningAHEADSynchronizer: " + obj);
             }
-            if (responseCode == HttpStatus.SC_OK && found) {
+            if (responseCode == HttpURLConnection.HTTP_OK && found) {
                 conn.disconnect();
                 return Status.OK;
             }

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -25,7 +25,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
@@ -226,7 +225,7 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
             BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             JSONObject obj = SyncHelper.parse(in);
 
-            if (responseCode == HttpStatus.SC_CREATED && obj.getLong("id") > 0) {
+            if (responseCode == HttpURLConnection.HTTP_CREATED && obj.getLong("id") > 0) {
                 conn.disconnect();
                 s = Status.OK;
                 s.activityId = mID;

--- a/app/src/org/runnerup/tracker/GpsStatus.java
+++ b/app/src/org/runnerup/tracker/GpsStatus.java
@@ -17,8 +17,10 @@
 
 package org.runnerup.tracker;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.GpsSatellite;
 import android.location.Location;
 import android.location.LocationListener;
@@ -26,13 +28,14 @@ import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 
 import org.runnerup.util.TickListener;
 /**
- * 
+ *
  * This is a helper class that is used to determine when the GPS status is good
  * enough (isFixed())
- * 
+ *
  */
 
 @TargetApi(Build.VERSION_CODES.FROYO)
@@ -74,16 +77,19 @@ public class GpsStatus implements LocationListener,
     public void start(TickListener listener) {
         clear(true);
         this.listener = listener;
-        LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        try {
-            lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
-        } catch (Exception ex) {
-            lm = null;
-        }
-
-        if (lm != null) {
-            locationManager = lm;
-            locationManager.addGpsStatusListener(this);
+        if (ContextCompat.checkSelfPermission(this.context,
+                Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+            try {
+                lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
+            } catch (Exception ex) {
+                lm = null;
+            }
+            if (lm != null) {
+                locationManager = lm;
+                locationManager.addGpsStatusListener(this);
+            }
         }
     }
 
@@ -91,7 +97,11 @@ public class GpsStatus implements LocationListener,
         this.listener = null;
         if (locationManager != null) {
             locationManager.removeGpsStatusListener(this);
-            locationManager.removeUpdates(this);
+            if (ContextCompat.checkSelfPermission(this.context,
+                    Manifest.permission.ACCESS_FINE_LOCATION)
+                    == PackageManager.PERMISSION_GRANTED) {
+                locationManager.removeUpdates(this);
+            }
             locationManager = null;
         }
     }

--- a/app/src/org/runnerup/view/RunActivity.java
+++ b/app/src/org/runnerup/view/RunActivity.java
@@ -17,6 +17,7 @@
 
 package org.runnerup.view;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ComponentName;
@@ -246,7 +247,7 @@ public class RunActivity extends Activity implements TickListener {
 
             if (mTracker != null) {
                 Location l2 = mTracker.getLastKnownLocation();
-                if (!l2.equals(l)) {
+                if (l2 != null && !l2.equals(l)) {
                     l = l2;
                 }
             }

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -17,12 +17,16 @@
 
 package org.runnerup.view;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
@@ -32,6 +36,10 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
 
 import org.runnerup.R;
 import org.runnerup.db.DBHelper;
@@ -40,13 +48,13 @@ import org.runnerup.util.FileUtil;
 import java.io.IOException;
 
 @TargetApi(Build.VERSION_CODES.FROYO)
-public class SettingsActivity extends PreferenceActivity {
+public class SettingsActivity extends PreferenceActivity
+        implements ActivityCompat.OnRequestPermissionsResultCallback{
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.settings);
         setContentView(R.layout.settings_wrapper);
-
         {
             Preference btn = findPreference("exportdb");
             btn.setOnPreferenceClickListener(onExportClick);
@@ -84,6 +92,81 @@ public class SettingsActivity extends PreferenceActivity {
         return false;
     }
 
+    @SuppressLint("InlinedApi")
+    public static boolean requestReadStoragePermissions(final Activity activity) {
+        boolean ret = true;
+        if (Build.VERSION.SDK_INT >= 16 &&
+                ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.READ_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ret = false;
+
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                //The caller informs the user, no toast or SnackBar
+            } else {
+                //Request permission - not working from Settings.Activity
+                //ActivityCompat.requestPermissions(activity,
+                //        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                //        REQUEST_READ_EXTERNAL_STORAGE);
+                String s = "Read permission is NOT granted";
+                Log.i(activity.getClass().getSimpleName(), s);
+            }
+        }
+        return ret;
+    }
+
+    public static boolean requestWriteStoragePermissions(final Activity activity) {
+        boolean ret = true;
+        if (ContextCompat.checkSelfPermission(activity,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ret = false;
+
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                //The caller informs the user, no toast or SnackBar
+            } else {
+                 //Request permission - not working from Settings.Activity
+                 //ActivityCompat.requestPermissions(activity,
+                 //        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                 //        REQUEST_WRITE_EXTERNAL_STORAGE);
+                String s = "Write permission is NOT granted";
+                Log.i(activity.getClass().getSimpleName(), s);
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Id to identify a permission request.
+     */
+    private static final int REQUEST_READ_EXTERNAL_STORAGE = 2000;
+    private static final int REQUEST_WRITE_EXTERNAL_STORAGE = 2001;
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+
+        if (requestCode == REQUEST_READ_EXTERNAL_STORAGE || requestCode == REQUEST_WRITE_EXTERNAL_STORAGE) {
+            // Check if the only required permission has been granted (could react on the response)
+            if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                //OK, could redo request here
+            } else {
+                String s = (requestCode == REQUEST_READ_EXTERNAL_STORAGE ? "READ" : "WRITE")
+                        + " permission was NOT granted";
+                if (grantResults.length >= 1) {
+                    s += grantResults[0];
+                }
+
+                Log.i(getClass().getSimpleName(), s);
+                //Toast.makeText(SettingsActivity.this, s, Toast.LENGTH_SHORT).show();
+            }
+
+        } else {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
     final OnPreferenceClickListener onExportClick = new OnPreferenceClickListener() {
 
         @Override
@@ -98,14 +181,19 @@ public class SettingsActivity extends PreferenceActivity {
                 }
 
             };
-            String from = DBHelper.getDbPath(getApplicationContext());
-            String to = dstdir + "/runnerup.db.export";
-            try {
-                int cnt = FileUtil.copyFile(to, from);
-                builder.setMessage("Copied " + cnt + " bytes");
-                builder.setPositiveButton(getString(R.string.Great), listener);
-            } catch (IOException e) {
-                builder.setMessage("Exception: " + e.toString());
+            if(requestWriteStoragePermissions(SettingsActivity.this)) {
+                String from = DBHelper.getDbPath(getApplicationContext());
+                String to = dstdir + "/runnerup.db.export";
+                try {
+                    int cnt = FileUtil.copyFile(to, from);
+                    builder.setMessage("Copied " + cnt + " bytes");
+                    builder.setPositiveButton(getString(R.string.Great), listener);
+                } catch (IOException e) {
+                    builder.setMessage("Exception: " + e.toString());
+                    builder.setNegativeButton(getString(R.string.Darn), listener);
+                }
+            } else {
+                builder.setMessage("Storage permission not granted in Android settings");
                 builder.setNegativeButton(getString(R.string.Darn), listener);
             }
             builder.show();
@@ -117,9 +205,24 @@ public class SettingsActivity extends PreferenceActivity {
 
         @Override
         public boolean onPreferenceClick(Preference preference) {
-            String srcdir = Environment.getExternalStorageDirectory().getPath();
-            String from = srcdir + "/runnerup.db.export";
-            DBHelper.importDatabase(SettingsActivity.this, from);
+            if (requestReadStoragePermissions(SettingsActivity.this)) {
+                String srcdir = Environment.getExternalStorageDirectory().getPath();
+                String from = srcdir + "/runnerup.db.export";
+                DBHelper.importDatabase(SettingsActivity.this, from);
+            } else {
+                AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this);
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+
+                };
+                builder.setTitle("Import runnerup.db");
+                builder.setMessage("Storage permission not granted in Android settings");
+                builder.setNegativeButton(getString(R.string.Darn), listener);
+                builder.show();
+            }
             return false;
         }
     };

--- a/app/src/org/runnerup/workout/AutoPauseTrigger.java
+++ b/app/src/org/runnerup/workout/AutoPauseTrigger.java
@@ -48,7 +48,7 @@ public class AutoPauseTrigger extends Trigger {
         Double currentSpeed = workout.getSpeed(Scope.CURRENT);
         //if (currentSpeed == null)
         //    return;
-        if (currentSpeed < mAutoPauseMinSpeed) {
+        if (currentSpeed < mAutoPauseMinSpeed && lastLocation != null) {
             if (!mIsAutoPaused && mHasStopped
                     && (lastLocation.getTime() - mStoppedMovingAt) > mAutoPauseAfterSeconds * 1000) {
                 mIsAutoPaused = true;

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ project.ext {
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
     buildToolsVersion = '24.0.1'
-    compileSdkVersion = 22
-    targetSdkVersion = 22
+    compileSdkVersion = 24
+    targetSdkVersion = 24
     versionName = "1.53"
     versionCode = 14000053
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -49,6 +49,6 @@ if (rootProject.file("release.properties").exists()) {
     android.signingConfigs.release.keyAlias = props.keyAlias
     android.signingConfigs.release.keyPassword = props.keyAliasPassword
 } else {
-    project.logger.warn('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
+    project.logger.info('INFO: Set the values storeFile, storePassword, keyAlias, and keyPassword in release.properties to sign the release.')
     android.buildTypes.release.signingConfig = null
 }

--- a/wear/src/main/java/org/runnerup/view/SearchingFragment.java
+++ b/wear/src/main/java/org/runnerup/view/SearchingFragment.java
@@ -29,7 +29,7 @@ import android.view.ViewGroup;
 
 import org.runnerup.R;
 
-@TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
+//@TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
 public class SearchingFragment extends Fragment {
 
     private CircledImageView mButton;
@@ -48,9 +48,11 @@ public class SearchingFragment extends Fragment {
         View view = inflater.inflate(R.layout.searching, container, false);
         super.onViewCreated(view, savedInstanceState);
 
-        mButton = (CircledImageView) view.findViewById(R.id.icon_searching);
-        AnimationDrawable frameAnimation = (AnimationDrawable) mButton.getForeground();
-        frameAnimation.start();
+        if (Build.VERSION.SDK_INT >= 23) {
+            mButton = (CircledImageView) view.findViewById(R.id.icon_searching);
+            AnimationDrawable frameAnimation = (AnimationDrawable) mButton.getForeground();
+            frameAnimation.start();
+        }
 
         return view;
     }


### PR DESCRIPTION
SDK depreciates org.apache.http.HttpStatus

The use of HttpStatus error codes is incorrect mix of the modules. These changes should be safe after a code review. RU uses HttpURLConnection  except in RunnerUp live. RU Live requires some verification, I have not been able to do that, is there a server?

This is not a required merge, I submit it to finalize the change I started with before finding the workaround.
Several possible outcomes of the PR:
  * Accepted as-is
   - RU Live can be tested somewhere?
   - RU Live is considered obsolete
  * Accepted except for RU Live (also keep build.gradle then). Obviously, a new PR is needed
 * Ignored, the branch is kept as a reference (at least in my clone)

Note: This is based of SDK-24 but could be applied to SDK-22 as well