### PR TITLE
Include accuracy/bearing/speed in FileSynchronizer exports

### DIFF
--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -118,7 +118,7 @@ public class FileSynchronizer extends DefaultSynchronizer {
                 tcx.export(mID, new OutputStreamWriter(out));
             }
             if (mFormat.contains("gpx")) {
-                GPX gpx = new GPX(db);
+                GPX gpx = new GPX(db, true);
                 File file = new File(fileBase + "gpx");
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
                 gpx.export(mID, new OutputStreamWriter(out));

--- a/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
+++ b/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
@@ -94,18 +94,22 @@ public class PersistentGpsLoggerListener extends LocationListenerBase implements
         values.put(DB.LOCATION.TIME, arg0.getTime());
         values.put(DB.LOCATION.LATITUDE, (float) arg0.getLatitude());
         values.put(DB.LOCATION.LONGITUDE, (float) arg0.getLongitude());
+        if (arg0.hasAltitude()) {
+            values.put(DB.LOCATION.ALTITUDE, (float) arg0.getAltitude());
+        }
+
+        //Accuracy related, normally not used in exports
+        //Most GPS chips also includes no of sats: arg0.getExtras().getInt("satellites", -1)
         if (arg0.hasAccuracy()) {
             values.put(DB.LOCATION.ACCURANCY, arg0.getAccuracy());
         }
         if (arg0.hasSpeed()) {
             values.put(DB.LOCATION.SPEED, arg0.getSpeed());
         }
-        if (arg0.hasAltitude()) {
-            values.put(DB.LOCATION.ALTITUDE, (float) arg0.getAltitude());
-        }
         if (arg0.hasBearing()) {
             values.put(DB.LOCATION.BEARING, arg0.getBearing());
         }
+
         if (hrValue != null) {
             values.put(DB.LOCATION.HR, hrValue);
         }


### PR DESCRIPTION
All other GPX exports are unchanged, including share as GPX

Eventually, there will be Preferences related to this but this is something that can be broken out from the sensor update