### PR TITLE
Settings about box updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,6 @@ android:
 notifications:
   email: false
 
-#cache between builds
-before_cache:
-  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -f $HOME/.gradle/caches/*/classAnalysis/cache.properties.lock
-  - rm -f $HOME/.gradle/caches/*/jarSnapshots/cache.properties.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-  
-cache:
-  directories:
-  - $HOME/.gradle/caches/
-  - $HOME/.gradle/wrapper/
-
 script:
     - ./gradlew lintFroyoRelease  assembleFroyoRelease
     - ./gradlew lintLatestRelease assembleLatestRelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ jdk:
 
 android:
     components:
-        - tools
-        - tools #update to latest, cannot control version
+        - tools #latest for "builtin" sdk
+        - tools #latest
         - platform-tools #latest
         - build-tools-24.0.1
         - android-24
-        - extra
         - extra-android-m2repository
+        - extra-google-m2repository
         - extra-google-google_play_services
 
 notifications:
@@ -20,12 +20,14 @@ notifications:
 #cache between builds
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f $HOME/.gradle/caches/*/classAnalysis/cache.properties.lock
+  - rm -f $HOME/.gradle/caches/*/jarSnapshots/cache.properties.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
   
 cache:
   directories:
-  - $HOME/.m2
-  - $HOME/.gradle
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/
 
 script:
     - ./gradlew lintFroyoRelease  assembleFroyoRelease

--- a/app/assets/about.html
+++ b/app/assets/about.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+<html>
+<head>
+<title>About RunnerUp</title>
+</head>
+<body>
+<h2>RunnerUp</h2>
+<p><a href="https://github.com/jonasoreland/runnerup/wiki">RunnerUp wiki</a></p>
+<p><a href="https://github.com/jonasoreland/runnerup/issues">RunnerUp issue list</a></p>
+<p><a href="changes.html">Release History</a></p>
+
+<h2>3rd party software</h2>
+
+<p><a href="http://www.android-graphview.org/">GraphView</a></p>
+<p><a href="https://www.mapbox.com/">MapBox</a></p>
+<p><a href="https://www.thisisant.com/developer/ant/ant-in-android">Android ANT+ SDK</a></p>
+<p><a href="https://github.com/pebble/pebble-android-sdk/">PebbleKit Android</a></p>
+<p><a href="https://github.com/fishkingsin/BLEDialogTool/">Android BLE Dialog Tool for Samsung BLE Library</a>
+   <a href="samsung_ble_license.txt">License</a></p>
+
+</body>
+</html>

--- a/app/assets/samsung_ble_license.txt
+++ b/app/assets/samsung_ble_license.txt
@@ -1,0 +1,7 @@
+Copyright (c) [6/5/2013] [James Kong]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,14 +93,14 @@ android {
 
 repositories {
     mavenCentral()
-    maven { url "https://oss.sonatype.org/content/groups/public/" }
+    maven { url "https://oss.sonatype.org/content/groups/public/" } //pebblekit
 }
 
 dependencies {
     //design uses com.android.support:appcompat, not explicitly required
     compile 'com.android.support:design:24.1.1'
     latestCompile 'com.google.android.gms:play-services-wearable:9.4.0'
-    latestCompile 'com.getpebble:pebblekit:3.0.0'
+    latestCompile 'com.getpebble:pebblekit:3.1.0'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {
         transitive = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ android {
     defaultConfig {
         applicationId = doExtractStringFromManifest("package")
         //By default all AppCompat translations are included, saves 350KB
-        resConfigs "ar","ca","de","en","es","fr","hu","id","it","ja","lt","nl","pl","pt","ru","sv","tr"
+        resConfigs "ar", "ca", "de", "en", "es", "fr", "hu", "id", "it", "ja", "lt", "nl", "pl", "pt", "ru", "sv", "tr"
     }
 
     signingConfigs {
@@ -84,7 +84,7 @@ android {
         //promote to error
         fatal 'InlinedApi'
         //Should be enabled, see PR #333
-        warning 'MissingQuantity','ImpliedQuantity'
+        warning 'MissingQuantity', 'ImpliedQuantity'
         // Ignore some specific checks, also some specific with path in lint.xml
         warning 'MissingTranslation'
         showAll true
@@ -99,12 +99,12 @@ repositories {
 dependencies {
     //design uses com.android.support:appcompat, not explicitly required
     compile 'com.android.support:design:24.1.1'
-    latestCompile 'com.google.android.gms:play-services:6.1.11'
+    latestCompile 'com.google.android.gms:play-services-wearable:9.4.0'
     latestCompile 'com.getpebble:pebblekit:3.0.0'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:0.7.4@aar') {
         transitive = true
     }
-    compile files('../GraphView/public/graphview-3.1.jar')
+    compile 'com.jjoe64:graphview:3.1.4'
     compile project(':common')
     compile project(':hrdevice')
     latestWearApp project(':wear')
@@ -132,8 +132,8 @@ if (rootProject.file("release.properties").exists()) {
     android.buildTypes.release.signingConfig = null
 }
 
-android.applicationVariants.all{ variant ->
-    variant.mergeResources.doLast{
+android.applicationVariants.all { variant ->
+    variant.mergeResources.doLast {
         if (rootProject.file("mapbox.properties").exists()) {
             props.load(new FileInputStream(rootProject.file("mapbox.properties")))
             File valuesFile = file("${buildDir}/intermediates/res/merged/${variant.dirName}/values/values.xml")

--- a/app/froyo/java/org/runnerup/widget/AboutPreference.java
+++ b/app/froyo/java/org/runnerup/widget/AboutPreference.java
@@ -39,6 +39,10 @@ public class AboutPreference extends DialogPreference {
         init();
     }
 
+    public static boolean isGooglePlayServicesAvailable(Context context) {
+        return  false;
+    }
+
     void init() {
         setNegativeButtonText(null);
         Context ctx = getContext();

--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -75,6 +75,7 @@ public class AboutPreference extends DialogPreference {
 
     @Override
     protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
         if (!isPlayPref()) {
             WebView wv = (WebView) view.findViewById(R.id.web_view1);
             wv.loadUrl("file:///android_asset/changes.html");

--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -78,18 +78,11 @@ public class AboutPreference extends DialogPreference {
         super.onBindDialogView(view);
         if (!isPlayPref()) {
             WebView wv = (WebView) view.findViewById(R.id.web_view1);
-            wv.loadUrl("file:///android_asset/changes.html");
+            wv.loadUrl("file:///android_asset/about.html");
         }
     }
 
     private void init(Context context) {
-        try {
-            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            this.setDialogTitle("RunnerUp v" + pInfo.versionName);
-        } catch (NameNotFoundException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
         if (isPlayPref()) {
             setNegativeButtonText(null);
             CharSequence msg = GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(this

--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -91,6 +91,13 @@ public class AboutPreference extends DialogPreference {
                 this.setDialogMessage(msg);
             }
         } else {
+            try {
+                PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+                this.setDialogTitle(context.getString(R.string.About_RunnerUp)+" v" + pInfo.versionName);
+            } catch (NameNotFoundException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
             if (isGooglePlayServicesAvailable(context)) {
                 setNegativeButtonText(context.getString(R.string.OK));
                 setPositiveButtonText(context.getString(R.string.Rate_RunnerUp));

--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -26,7 +26,8 @@ import android.os.Build;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 
-import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 
 import org.runnerup.R;
 
@@ -43,7 +44,11 @@ public class AboutPreference extends DialogPreference {
         init();
     }
 
-    void init() {
+    public static boolean isGooglePlayServicesAvailable(Context context) {
+        return  GoogleApiAvailability.getInstance ().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
+    }
+
+    private void init() {
         setNegativeButtonText(null);
         Context ctx = getContext();
         Resources res = ctx.getResources();
@@ -56,7 +61,7 @@ public class AboutPreference extends DialogPreference {
         }
         String str = res.getString(R.string.Google_Play_Services_Legal_Notices);
         if (str.contentEquals(this.getTitle())) {
-            CharSequence msg = GooglePlayServicesUtil.getOpenSourceSoftwareLicenseInfo(this
+            CharSequence msg = GoogleApiAvailability.getInstance ().getOpenSourceSoftwareLicenseInfo(this
                     .getContext());
             if (msg != null) {
                 this.setDialogMessage(msg);

--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -19,12 +19,16 @@ package org.runnerup.widget;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Build;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
+import android.view.View;
+import android.webkit.WebView;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -34,38 +38,72 @@ import org.runnerup.R;
 @TargetApi(Build.VERSION_CODES.FROYO)
 public class AboutPreference extends DialogPreference {
 
+    private Context context;
+
     public AboutPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
+        this.context = context;
+        init(context);
     }
 
     public AboutPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        init();
+        init(context);
     }
 
     public static boolean isGooglePlayServicesAvailable(Context context) {
-        return  GoogleApiAvailability.getInstance ().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
     }
 
-    private void init() {
-        setNegativeButtonText(null);
-        Context ctx = getContext();
-        Resources res = ctx.getResources();
+    private boolean isPlayPref() {
+        return this.getKey() != null && this.getKey().contentEquals("googleplayserviceslegalnotices");
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        if (which == DialogInterface.BUTTON_POSITIVE) {
+            if (!isPlayPref()) {
+                try {
+                    Uri uri = Uri.parse("market://details?id=" + context.getPackageName());
+                    context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        if (!isPlayPref()) {
+            WebView wv = (WebView) view.findViewById(R.id.web_view1);
+            wv.loadUrl("file:///android_asset/changes.html");
+        }
+    }
+
+    private void init(Context context) {
         try {
-            PackageInfo pInfo = ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0);
+            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
             this.setDialogTitle("RunnerUp v" + pInfo.versionName);
         } catch (NameNotFoundException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        String str = res.getString(R.string.Google_Play_Services_Legal_Notices);
-        if (str.contentEquals(this.getTitle())) {
-            CharSequence msg = GoogleApiAvailability.getInstance ().getOpenSourceSoftwareLicenseInfo(this
+        if (isPlayPref()) {
+            setNegativeButtonText(null);
+            CharSequence msg = GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(this
                     .getContext());
             if (msg != null) {
                 this.setDialogMessage(msg);
             }
+        } else {
+            if (isGooglePlayServicesAvailable(context)) {
+                setNegativeButtonText(context.getString(R.string.OK));
+                setPositiveButtonText(context.getString(R.string.Rate_RunnerUp));
+            } else {
+                setNegativeButtonText(null);
+            }
+            setDialogLayoutResource(R.layout.whatsnew);
         }
     }
 }

--- a/app/proguard.txt
+++ b/app/proguard.txt
@@ -6,9 +6,7 @@
 -dontwarn com.vividsolutions.jts.awt.**
 -dontwarn android.support.**
 -dontwarn com.squareup.okhttp.**
--keep public class android.util.FloatMath
--dontwarn com.almeros.android.multitouch.TwoFingerGestureDetector
--dontwarn com.google.android.gms.common.GooglePlayServicesUtil
 -dontnote android.net.http.*
 -dontnote org.apache.commons.codec.**
 -dontnote org.apache.http.**
+-dontwarn com.almeros.android.multitouch.TwoFingerGestureDetector

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -285,7 +285,7 @@
         <org.runnerup.widget.AboutPreference
             android:key="googleplayserviceslegalnotices"
             android:title="@string/Google_Play_Services_Legal_Notices"
-            android:dialogMessage="@string/Not_much_to_say_at_this_point" />
+            android:dialogMessage="Google Play Services is not installed" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -279,8 +279,7 @@
 
     <PreferenceCategory android:key="aboutcategory" android:title="@string/About">
         <org.runnerup.widget.AboutPreference
-            android:title="@string/About_RunnerUp"
-            android:dialogMessage="@string/Not_much_to_say_at_this_point" />
+            android:title="@string/About_RunnerUp" />
 
         <org.runnerup.widget.AboutPreference
             android:key="googleplayserviceslegalnotices"

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -41,6 +41,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
+import org.runnerup.BuildConfig;
 import org.runnerup.R;
 import org.runnerup.db.DBHelper;
 import org.runnerup.util.FileUtil;
@@ -70,7 +71,7 @@ public class SettingsActivity extends PreferenceActivity
         }
 
         //remove google play notices from froyo since we do not use it
-        if (!AboutPreference.isGooglePlayServicesAvailable(this)) {
+        if (BuildConfig.FLAVOR.equals("froyo") && !AboutPreference.isGooglePlayServicesAvailable(this)) {
             Preference pref = findPreference("googleplayserviceslegalnotices");
             PreferenceCategory category = (PreferenceCategory)findPreference("aboutcategory");
             category.removePreference(pref);
@@ -227,6 +228,7 @@ public class SettingsActivity extends PreferenceActivity
             return false;
         }
     };
+
     final OnPreferenceClickListener onPruneClick = new OnPreferenceClickListener() {
 
         @Override

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -44,6 +44,7 @@ import android.util.Log;
 import org.runnerup.R;
 import org.runnerup.db.DBHelper;
 import org.runnerup.util.FileUtil;
+import org.runnerup.widget.AboutPreference;
 
 import java.io.IOException;
 
@@ -69,7 +70,7 @@ public class SettingsActivity extends PreferenceActivity
         }
 
         //remove google play notices from froyo since we do not use it
-        if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.FROYO) {
+        if (!AboutPreference.isGooglePlayServicesAvailable(this)) {
             Preference pref = findPreference("googleplayserviceslegalnotices");
             PreferenceCategory category = (PreferenceCategory)findPreference("aboutcategory");
             category.removePreference(pref);

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven { url "https://oss.sonatype.org/content/groups/public/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/groups/public/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -293,7 +293,6 @@
   <string name="RunnerUp_workout">RunnerUp workout: </string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hi\nHere is a workout I think you might like.</string>
   <string name="Share_workout">Share workout...</string>
-  <string name="Not_much_to_say_at_this_point">Not much to say at this point</string>
   <string name="New_audio_scheme">New audio scheme</string>
   <string name="Default">Default</string>
   <string name="Notes_about_your_workout">Notes about your workout</string>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 group = "org.runnerup.hr"
 version = "1.0"

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -35,8 +35,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:1.1.+'
-    compile 'com.google.android.gms:play-services-wearable:+'
+    compile 'com.google.android.support:wearable:1.1.0'
+    compile 'com.google.android.gms:play-services-wearable:9.4.0'
     compile project(':common')
 }
 


### PR DESCRIPTION
Display GoogleService aboutbox only when Play Services is available

Previously, this was connected to Froyo SDK, not if play services was installed.
The "RU default" message were therefore displayed also for GingerBread and where Play is not installed (like in the emulator without Play)
Requires updated Play (removing depreciated call), could be adapted to earlier version too

Show What's New for RU About DialogPreference
Also link to Play