### PR TITLE
Precision was set to float before storing in SQLite

### DIFF
--- a/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
+++ b/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
@@ -86,10 +86,10 @@ public class PersistentGpsLoggerListener extends LocationListenerBase implements
         }
 
         values.put(DB.LOCATION.TIME, arg0.getTime());
-        values.put(DB.LOCATION.LATITUDE, (float) arg0.getLatitude());
-        values.put(DB.LOCATION.LONGITUDE, (float) arg0.getLongitude());
+        values.put(DB.LOCATION.LATITUDE, arg0.getLatitude());
+        values.put(DB.LOCATION.LONGITUDE, arg0.getLongitude());
         if (arg0.hasAltitude()) {
-            values.put(DB.LOCATION.ALTITUDE, (float) arg0.getAltitude());
+            values.put(DB.LOCATION.ALTITUDE, arg0.getAltitude());
         }
 
         //Accuracy related, normally not used in exports


### PR DESCRIPTION
SQLite REAL stores as double but double values from the GPS sensor were converted to float before storing.
This was clearly visible in the graphs, especially if playing around in Genymotion: The reported total distance did not match the graph distance

This was reported in issue #434 too