### PR TITLE
Update ANT+ lib to 3.6.0

### DIFF
--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     provided files('libs/samsung_ble_sdk_200.jar')
-    compile files('../ANT-Android-SDKs/ANT+_Android_SDK/API/antpluginlib_3-1-0.jar')
+    compile files('../ANT-Android-SDKs/ANT+_Android_SDK/API/antpluginlib_3-6-0.jar')
 }
 
 task downloadSamsungBleSdk(type: DownloadTask) {


### PR DESCRIPTION
Part of #435, keeping the submodule structure