### PR TITLE
Updated repos libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ language: android
 jdk:
   - oraclejdk8
 
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f $HOME/.gradle/caches/*/classAnalysis/cache.properties.lock
+  - rm -f $HOME/.gradle/caches/*/jarSnapshots/cache.properties.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 android:
     components:
         - tools #latest for "builtin" sdk (24.4.1 in Android-24)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ jdk:
 
 android:
     components:
-        - tools #latest for "builtin" sdk
-        - tools #latest
-        - platform-tools #latest
-        - build-tools-24.0.1
+        - tools #latest for "builtin" sdk (24.4.1 in Android-24)
+        #To update SDK Tools to latest, another update is required
+        #- tools #latest, 25.2.2 as of 2016-09-25
+        - platform-tools #latest, 24.0.3 as of 2016-09-25
+        - build-tools-24.0.2
         - android-24
         - extra-android-m2repository
         - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,9 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    //jcenter and mavenCentral normally have the same packages but there may be a delay after updating the primary
+    jcenter() //Google
+    mavenCentral() //MapBox GraphView
     maven { url "https://oss.sonatype.org/content/groups/public/" } //pebblekit
 }
 
@@ -105,7 +107,7 @@ dependencies {
     latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.2@aar'){
         transitive=true
     }
-    compile 'com.jjoe64:graphview:4.1.1'
+    compile 'com.jjoe64:graphview:4.2.1'
     compile project(':common')
     compile project(':hrdevice')
     latestWearApp project(':wear')

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 
 }
@@ -13,7 +13,7 @@ project.ext {
     //Note that Android Studio does not know about the 'ext' module and will warn
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
-    buildToolsVersion = '24.0.1'
+    buildToolsVersion = '24.0.2' //Update Travis manually
     compileSdkVersion = 24
     targetSdkVersion = 24
     versionName = "1.54"


### PR DESCRIPTION
Add jcenter() repos for Google (not always in mavenCentral), update gradle plugin

Tweak Travis some. Do not set SDK Tools to latest, not needed now (slows down builds)
Reenable cache, decrease build time from 13 to 11:30 (should be cleared at updates)