### PR TITLE
AutoPauseTrigger detection of invalid current speed

### DIFF
--- a/app/src/org/runnerup/workout/AutoPauseTrigger.java
+++ b/app/src/org/runnerup/workout/AutoPauseTrigger.java
@@ -45,9 +45,10 @@ public class AutoPauseTrigger extends Trigger {
 
     private void HandleAutoPause(Workout workout) {
         Location lastLocation = workout.getLastKnownLocation();
-        Double currentSpeed = workout.getSpeed(Scope.CURRENT);
-        //if (currentSpeed == null)
-        //    return;
+        double currentSpeed = workout.getSpeed(Scope.CURRENT);
+        if (!workout.isEnabled(Dimension.SPEED, Scope.CURRENT)) {
+            currentSpeed = 0;
+        }
         if (currentSpeed < mAutoPauseMinSpeed && lastLocation != null) {
             if (!mIsAutoPaused && mHasStopped
                     && (lastLocation.getTime() - mStoppedMovingAt) > mAutoPauseAfterSeconds * 1000) {

--- a/app/test/java/org/runnerup/workout/AutoPauseTriggerTest.java
+++ b/app/test/java/org/runnerup/workout/AutoPauseTriggerTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+//Hint: Local Unit Test can use System.out.print for printouts
+
 public class AutoPauseTriggerTest {
     @Test
     public void shouldSetPauseIfSpeedIsLow() {
@@ -38,6 +40,7 @@ public class AutoPauseTriggerTest {
         Workout workout = mock(Workout.class);
         when(workout.getLastKnownLocation()).thenReturn(location);
         when(workout.getSpeed((Scope) any())).thenReturn(9d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
 
         AutoPauseTrigger sut = new AutoPauseTrigger(autoPauseAfterSeconds, autoPauseMinSpeed);
 
@@ -60,6 +63,7 @@ public class AutoPauseTriggerTest {
         Workout workout = mock(Workout.class);
         when(workout.getLastKnownLocation()).thenReturn(location);
         when(workout.getSpeed((Scope) any())).thenReturn(11d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
 
         AutoPauseTrigger sut = new AutoPauseTrigger(autoPauseAfterSeconds, autoPauseMinSpeed);
 
@@ -82,6 +86,7 @@ public class AutoPauseTriggerTest {
         Workout workout = mock(Workout.class);
         when(workout.getLastKnownLocation()).thenReturn(location);
         when(workout.getSpeed((Scope) any())).thenReturn(9d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
 
         AutoPauseTrigger sut = new AutoPauseTrigger(autoPauseAfterSeconds, autoPauseMinSpeed);
 
@@ -91,6 +96,7 @@ public class AutoPauseTriggerTest {
         sut.onTick(workout);
 
         when(workout.getSpeed((Scope) any())).thenReturn(11d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
         when(location.getTime()).thenReturn(5000L);
         sut.onTick(workout);
 
@@ -108,12 +114,14 @@ public class AutoPauseTriggerTest {
         Workout workout = mock(Workout.class);
         when(workout.getLastKnownLocation()).thenReturn(location);
         when(workout.getSpeed((Scope) any())).thenReturn(9d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
 
         AutoPauseTrigger sut = new AutoPauseTrigger(autoPauseAfterSeconds, autoPauseMinSpeed);
 
         sut.onTick(workout);
         sut.onTick(workout);
         when(workout.getSpeed((Scope) any())).thenReturn(11d);
+        when(workout.isEnabled((Dimension) any(), (Scope) any())).thenReturn(true);
         when(location.getTime()).thenReturn(5000L);
         sut.onTick(workout);
         verify(workout, never()).onPause(workout);


### PR DESCRIPTION
The check for invalid speed was incorrectly implemented. This was detected in a lint check, a quick fix was attempted but backed out in c18c8000203c23431dccc39d93ff2acef6e6a338.
This corrects the check again
Also fixes AutoPause issues for devices where getSpeed() always return 0. At least GenyMotion, but there seem to be other out there too