### PR TITLE
Fixed a bug created by a recent change that broke wearable support.

### DIFF
--- a/app/latest/java/org/runnerup/tracker/component/TrackerWear.java
+++ b/app/latest/java/org/runnerup/tracker/component/TrackerWear.java
@@ -103,16 +103,18 @@ public class TrackerWear extends DefaultTrackerComponent
     }
 
     private boolean hasPlay() {
-        boolean res = false;
+        int result;
         try {
-            res = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) !=
-                    ConnectionResult.SUCCESS;
-        } catch(Exception e){}
-        return res;
+            result = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);
+        } catch(Exception e) {
+            return false;
+        }
+        return (result == ConnectionResult.SUCCESS);
     }
 
     @Override
     public TrackerComponent.ResultCode onInit(final Callback callback, Context context) {
+        this.context = context;
         if (!hasPlay()) {
             return ResultCode.RESULT_NOT_SUPPORTED;
         }
@@ -126,7 +128,6 @@ public class TrackerWear extends DefaultTrackerComponent
         }
 
         tracker.registerTrackerStateListener(this);
-        this.context = context;
         mGoogleApiClient = new GoogleApiClient.Builder(context)
                 .addConnectionCallbacks(new GoogleApiClient.ConnectionCallbacks() {
                     @Override


### PR DESCRIPTION
This commit introduced a bug that broke wearables:
[Refresh Graph handling](https://github.com/jonasoreland/runnerup/commit/8023ced7a1f483f25887c9ea6c954279cad59afa)

Specifically, the change in TrackerWear.java that moved the isGooglePlayServicesAvailable() check to a helper function had two problems:
1 - the logical test was inverted (!= instead of ==)
2 - the (this.)context variable was not initialized before the new helper function was called

This change restored wearable functionality in my own testing.  Please consider merging this pull request or a suitable alternative.

Thanks!

