### PR TITLE
Activate sport types walking, orienteering for most languages

### DIFF
--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -356,7 +356,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         Part<?> parts[] = new Part<?>[list.size()];
         list.toArray(parts);
 
-        URL url2 = new URL(sport == DB.ACTIVITY.SPORT_RUNNING ? RUN_ENDPOINT : BIKE_ENDPOINT);
+        URL url2 = new URL(sport == DB.ACTIVITY.SPORT_BIKING ? BIKE_ENDPOINT : RUN_ENDPOINT);
         return createObj(url2, parts);
     }
 

--- a/common/src/main/res/values-ca/array.xml
+++ b/common/src/main/res/values-ca/array.xml
@@ -29,11 +29,6 @@
     <item>Córrer</item>
     <item>Ciclisme</item>
     <item>Altre</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Córrer</item>
-    <item>Ciclisme</item>
-    <item>Altre</item>
     <item>Orientació</item>
     <item>Caminar</item>
   </string-array>

--- a/common/src/main/res/values-ca/strings.xml
+++ b/common/src/main/res/values-ca/strings.xml
@@ -106,7 +106,6 @@
   <string name="Delete_workout">Esborrar entrenament</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hola\nAquí tens un entrenament que crec que t\'agradarà.</string>
   <string name="Share_workout">Compartir entrenament...</string>
-  <string name="Not_much_to_say_at_this_point">No hi ha molt a dir en aquest moment</string>
   <string name="New_audio_scheme">Nou esquema d\'àudio</string>
   <string name="Default">Per defecte</string>
   <string name="Notes_about_your_workout">Comentaris sobre el teu entrenament</string>

--- a/common/src/main/res/values-de/array.xml
+++ b/common/src/main/res/values-de/array.xml
@@ -34,11 +34,6 @@
     <item>Laufen</item>
     <item>Radfahren</item>
     <item>Anderweitig</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Laufen</item>
-    <item>Radfahren</item>
-    <item>Anderweitig</item>
     <item>Orientierungslauf</item>
     <item>Gehen</item>
   </string-array>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -285,7 +285,6 @@
   <string name="RunnerUp_workout">RunnerUp-Trainingseinheit: </string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hallo\nHier ist ein Training, dass dir vielleicht gefallen könnte.</string>
   <string name="Share_workout">Trainingseinheit teilen...</string>
-  <string name="Not_much_to_say_at_this_point">Momentan gibt es nicht viel zu sagen.</string>
   <string name="New_audio_scheme">Neues Audioschema</string>
   <string name="Default">Standard</string>
   <string name="Notes_about_your_workout">Notizen über Ihre Trainingseinheit</string>

--- a/common/src/main/res/values-es/array.xml
+++ b/common/src/main/res/values-es/array.xml
@@ -34,11 +34,6 @@
     <item>Carrera</item>
     <item>Ciclismo</item>
     <item>Otro</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Carrera</item>
-    <item>Ciclismo</item>
-    <item>Otro</item>
     <item>Orientación</item>
     <item>Caminar</item>
   </string-array>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Actividades en RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hola\nTengo una actividad que te podría gustar.</string>
   <string name="Share_workout">Compartir actividad...</string>
-  <string name="Not_much_to_say_at_this_point">No hay mucho que decir por ahora</string>
   <string name="New_audio_scheme">Nuevo esquema de audio</string>
   <string name="Default">Por defecto</string>
   <string name="Notes_about_your_workout">Notas sobre la actividad</string>

--- a/common/src/main/res/values-fr/array.xml
+++ b/common/src/main/res/values-fr/array.xml
@@ -34,11 +34,6 @@
     <item>Course à pied</item>
     <item>Vélo</item>
     <item>Autre</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Course à pied</item>
-    <item>Vélo</item>
-    <item>Autre</item>
     <item>Course d\'orientation</item>
     <item>Marche</item>
   </string-array>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Entraînement RunnerUp :</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Bonjour\nVoici un entraînement que vous pourriez aimer.</string>
   <string name="Share_workout">Partager l\'entraînement</string>
-  <string name="Not_much_to_say_at_this_point">Pas grand chose à dire pour le moment</string>
   <string name="New_audio_scheme">Nouveau profile de suivi audio</string>
   <string name="Default">Défaut</string>
   <string name="Notes_about_your_workout">Notes sur l\'entraînement</string>

--- a/common/src/main/res/values-hu/array.xml
+++ b/common/src/main/res/values-hu/array.xml
@@ -34,11 +34,6 @@
     <item>Futás</item>
     <item>Kerékpározás</item>
     <item>Egyéb</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Futás</item>
-    <item>Kerékpározás</item>
-    <item>Egyév</item>
     <item>Tájfutás</item>
     <item>Gyaloglás</item>
   </string-array>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">RunnerUp edzés:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Szia\nItt van egy edzésterv, ami szerintem tetszene</string>
   <string name="Share_workout">Edzésterv megosztása</string>
-  <string name="Not_much_to_say_at_this_point">Eddig nincs mit mondani</string>
   <string name="New_audio_scheme">Új beszéd séma</string>
   <string name="Default">Alapértelmezett</string>
   <string name="Notes_about_your_workout">Jegyzetek az edzésedről</string>

--- a/common/src/main/res/values-id/array.xml
+++ b/common/src/main/res/values-id/array.xml
@@ -34,11 +34,6 @@
     <item>Lari</item>
     <item>Sepeda</item>
     <item>Lainnya</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Lari</item>
-    <item>Sepeda</item>
-    <item>Lainnya</item>
     <item>Orienteering</item>
     <item>Jalan kaki</item>
   </string-array>

--- a/common/src/main/res/values-id/strings.xml
+++ b/common/src/main/res/values-id/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Latihan RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Halo\nIni adalah latihan yang bisa dipakai.</string>
   <string name="Share_workout">Berbagi latihan...</string>
-  <string name="Not_much_to_say_at_this_point">Sejauh ini tidak ada yang perlu disampaikan</string>
   <string name="New_audio_scheme">Skema suara baru</string>
   <string name="Default">Baku</string>
   <string name="Notes_about_your_workout">Catatan terkait latihan</string>

--- a/common/src/main/res/values-it/array.xml
+++ b/common/src/main/res/values-it/array.xml
@@ -34,11 +34,6 @@
     <item>Corsa</item>
     <item>Bicicletta</item>
     <item>Altro</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Corsa</item>
-    <item>Bicicletta</item>
-    <item>Altro</item>
     <item>Orientamento</item>
     <item>Camminata</item>
   </string-array>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -290,7 +290,6 @@
   <string name="RunnerUp_workout">Allenamento RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Ciao\nPenso che questo allenamento ti potrebbe piacere</string>
   <string name="Share_workout">Condividi l\'allenamento</string>
-  <string name="Not_much_to_say_at_this_point">Non c\'è molto da dire a questo punto</string>
   <string name="New_audio_scheme">Nuovo schema audio</string>
   <string name="Default">Standard</string>
   <string name="Notes_about_your_workout">Note relative al tuo allenamento</string>

--- a/common/src/main/res/values-ja/array.xml
+++ b/common/src/main/res/values-ja/array.xml
@@ -34,11 +34,6 @@
     <item>ランニング</item>
     <item>サイクリング</item>
     <item>その他</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>ランニング</item>
-    <item>サイクリング</item>
-    <item>その他</item>
     <item>オリエンテーリング</item>
     <item>ウォーキング</item>
   </string-array>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">RunnerUp ワークアウト: </string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">やあ\nここにあなたのお好みのワークアウトがあります。</string>
   <string name="Share_workout">ワークアウトを共有...</string>
-  <string name="Not_much_to_say_at_this_point">現時点では何もありません</string>
   <string name="New_audio_scheme">新しい音声合図スキーム</string>
   <string name="Default">デフォルト</string>
   <string name="Notes_about_your_workout">ワークアウトについてのメモ</string>

--- a/common/src/main/res/values-lt/array.xml
+++ b/common/src/main/res/values-lt/array.xml
@@ -34,11 +34,6 @@
     <item>Bėgimas</item>
     <item>Dviračių sportas</item>
     <item>Kita</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Bėgimas</item>
-    <item>Dviračių sportas</item>
-    <item>Kita</item>
     <item>Orientacijios sportas</item>
     <item>Ėjimas</item>
   </string-array>

--- a/common/src/main/res/values-lt/strings.xml
+++ b/common/src/main/res/values-lt/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">RunnerUp treniruotė:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Labas\nČia treniruotė, kuri manau tau patiks.</string>
   <string name="Share_workout">Dalintis treniruote...</string>
-  <string name="Not_much_to_say_at_this_point">Mažai ką pasakysi šioje vietoje</string>
   <string name="New_audio_scheme">Nauja audio schema</string>
   <string name="Default">Numatyta</string>
   <string name="Notes_about_your_workout">Pastabos apie tavo treniruotę</string>

--- a/common/src/main/res/values-nl-rNL/strings.xml
+++ b/common/src/main/res/values-nl-rNL/strings.xml
@@ -282,7 +282,6 @@
   <string name="RunnerUp_workout">RunnerUp-workout:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Halllo\nHier is een workout waarvan ik denk dat u hem leuk zult vinden.</string>
   <string name="Share_workout">Workout delen...</string>
-  <string name="Not_much_to_say_at_this_point">Er valt op dit moment niet veel over te zeggen</string>
   <string name="New_audio_scheme">Nieuw audioschema</string>
   <string name="Default">Standaard</string>
   <string name="Notes_about_your_workout">Notities aangaande uw workout</string>

--- a/common/src/main/res/values-nl/array.xml
+++ b/common/src/main/res/values-nl/array.xml
@@ -34,11 +34,6 @@
     <item>Lopen</item>
     <item>Fietsen</item>
     <item>Andere</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Lopen</item>
-    <item>Fietsen</item>
-    <item>Andere</item>
     <item>Orienteren</item>
     <item>Wandelen</item>
   </string-array>

--- a/common/src/main/res/values-nl/strings.xml
+++ b/common/src/main/res/values-nl/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">RunnerUp training</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hallo\nHier is een training die je misschien leuk vindt.</string>
   <string name="Share_workout">Training delen</string>
-  <string name="Not_much_to_say_at_this_point">Niet veel te zeggen op dit moment</string>
   <string name="New_audio_scheme">Nieuw audio schema</string>
   <string name="Default">Standaard</string>
   <string name="Notes_about_your_workout">Opmerkingen over je training</string>

--- a/common/src/main/res/values-pl/array.xml
+++ b/common/src/main/res/values-pl/array.xml
@@ -34,11 +34,6 @@
     <item>Bieganie</item>
     <item>Jazda rowerem</item>
     <item>Inne</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Bieganie</item>
-    <item>Jazda na rowerze</item>
-    <item>Inne</item>
     <item>Bieg na orientację</item>
     <item>Chodzenie</item>
   </string-array>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Trening RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">To jest trening, który możesz polubić.</string>
   <string name="Share_workout">Podziel się treningiem...</string>
-  <string name="Not_much_to_say_at_this_point">Nie wiele do powiedzenia w tym momencie</string>
   <string name="New_audio_scheme">Nowy schemat wskazówek</string>
   <string name="Default">Domyślne</string>
   <string name="Notes_about_your_workout">Notatki</string>

--- a/common/src/main/res/values-pt-rBR/array.xml
+++ b/common/src/main/res/values-pt-rBR/array.xml
@@ -34,11 +34,6 @@
     <item>Corrida</item>
     <item>Ciclismo</item>
     <item>Outros</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Corrida</item>
-    <item>Ciclismo</item>
-    <item>Outros</item>
     <item>Orientação</item>
     <item>Caminhada</item>
   </string-array>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Exercício do RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Olá\nAqui está um exercício que eu acho que você pode gostar.</string>
   <string name="Share_workout">Compartilhar exercício...</string>
-  <string name="Not_much_to_say_at_this_point">Não há muito a dizer neste momento</string>
   <string name="New_audio_scheme">Novo esquema de áudio</string>
   <string name="Default">Padrão</string>
   <string name="Notes_about_your_workout">Anotações sobre seu exercício</string>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">Тренировка RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Привет!\nВот тренировки. Я думаю ты можешь так же .</string>
   <string name="Share_workout">Опубликовать</string>
-  <string name="Not_much_to_say_at_this_point">Автору программы нечего сказать о этом пункте</string>
   <string name="New_audio_scheme">Новая голосовая схема</string>
   <string name="Default">Стандартная</string>
   <string name="Notes_about_your_workout">Примечания о этом занятии</string>

--- a/common/src/main/res/values-sv/array.xml
+++ b/common/src/main/res/values-sv/array.xml
@@ -34,11 +34,6 @@
     <item>Löpning</item>
     <item>Cykling</item>
     <item>Övrigt</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Löpning</item>
-    <item>Cykling</item>
-    <item>Övrigt</item>
     <item>Orientering</item>
     <item>Gång</item>
   </string-array>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -291,7 +291,6 @@
   <string name="RunnerUp_workout">RunnerUp träningspass:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hej\nHär är ett träningspass jag tror du skulle gilla.</string>
   <string name="Share_workout">Dela träningspass...</string>
-  <string name="Not_much_to_say_at_this_point">Inte så mycket att tillägga just nu</string>
   <string name="New_audio_scheme">Nytt ljudschema</string>
   <string name="Default">Standard</string>
   <string name="Notes_about_your_workout">Anteckningar om ditt träningspass</string>


### PR DESCRIPTION
Transifex needs to be updated too
If "sportEntriesExperimental" was not translated, the standard appears still.
Also remove "Not_much_to_say_at_this_point", no longer used (warning in some situations)
Facebook activity type set to Biking only for Biking (was biking for all other than Running before. Could have set Other to Biking but most of the code handles Other as Running)
