### PR TITLE
Issue #168 -- round wearable screens not centered properly

### DIFF
--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:1.1.0'
+    compile 'com.google.android.support:wearable:1.4.0'
     compile 'com.google.android.gms:play-services-wearable:9.4.0'
     compile project(':common')
 }

--- a/wear/src/main/res/layout/connect_to_phone.xml
+++ b/wear/src/main/res/layout/connect_to_phone.xml
@@ -41,7 +41,7 @@
                 android:id="@+id/icon_open_on_phone"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/go_to_phone_animation"
+                android:src="@drawable/open_on_phone_animation"
                 app:circle_color="@color/action_button"
                 app:circle_radius="40dp"
                 app:circle_radius_pressed="50dp"

--- a/wear/src/main/res/layout/stopped.xml
+++ b/wear/src/main/res/layout/stopped.xml
@@ -41,7 +41,7 @@
                 android:id="@+id/icon_resume"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/go_to_phone_animation"
+                android:src="@drawable/open_on_phone_animation"
                 app:circle_border_width="0dp"
                 app:circle_color="@color/action_button"
                 app:circle_radius="32dp" />


### PR DESCRIPTION
Update wearable support library to v1.4.0 to fix centering issue on round wear screens.  I believe this will address Issue #168.

Reference:
[Android Issue 187432:  Setting padding on BoxInsetLayout does not work as documented](https://code.google.com/p/android/issues/detail?id=187432)

Removing the padding would also fix the problem, but updating to wearable support library 1.4.0 seems like the better long term fix.  (And I will need at least 1.2.0 for the Ambient mode feature, but I didn't want to pollute that merge with a lot of extra stuff....)

As a result of this version change, I also had to replace the deprecated go_to_phone_animation drawable with a very similar (identical?) [open_on_phone_animation ](https://developer.android.com/reference/android/support/wearable/R.drawable.html#open_on_phone_animation) drawable.  I figured this out a while ago, but I couldn't find any documentation as to why they changed, but this seemed to happen between 1.1.0 and 1.2.0.
