### PR TITLE
tool version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,20 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
 before_cache:
-  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -f $HOME/.gradle/caches/*/classAnalysis/cache.properties.lock
-  - rm -f $HOME/.gradle/caches/*/jarSnapshots/cache.properties.lock
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f  $HOME/.gradle/caches/*/classAnalysis/cache.properties.lock
+  - rm -f  $HOME/.gradle/caches/*/jarSnapshots/cache.properties.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 android:
     components:
         - tools #latest for "builtin" sdk (24.4.1 in Android-24)
         #To update SDK Tools to latest, another update is required
-        #- tools #latest, 25.2.2 as of 2016-09-25
-        - platform-tools #latest, 24.0.3 as of 2016-09-25
-        - build-tools-24.0.2
+        #- tools #latest, 25.2.2 as of 2016-10-29
+        - platform-tools #latest, 25.0.0 as of 2016-10-29
+        - build-tools-25.0.0
         - android-24
         - extra-android-m2repository
         - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,9 +100,9 @@ repositories {
 
 dependencies {
     //design uses com.android.support:appcompat, not explicitly required
-    latestCompile 'com.android.support:design:24.2.1'
+    latestCompile 'com.android.support:design:25.0.0'
     froyoCompile 'com.android.support:design:24.1.0' //SDK <10 dropped in 24.2
-    latestCompile 'com.google.android.gms:play-services-wearable:9.4.0'
+    latestCompile 'com.google.android.gms:play-services-wearable:9.8.0'
     latestCompile 'com.getpebble:pebblekit:3.1.0'
     latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.2@aar'){
         transitive=true

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 
 }
@@ -13,7 +13,7 @@ project.ext {
     //Note that Android Studio does not know about the 'ext' module and will warn
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
-    buildToolsVersion = '24.0.2' //Update Travis manually
+    buildToolsVersion = '25.0.0' //Update Travis manually
     compileSdkVersion = 24
     targetSdkVersion = 24
     versionName = "1.54"


### PR DESCRIPTION
To avoid nagging from Android Studio
Android-25 (7.1.1) is OK too, but awaiting emulators with Google Play to be available as well as source
