### PR TITLE
Author:		gerhardol <gerhard.nospam@gmail.com>

### DIFF
--- a/app/src/org/runnerup/tracker/GpsStatus.java
+++ b/app/src/org/runnerup/tracker/GpsStatus.java
@@ -98,13 +98,14 @@ public class GpsStatus implements LocationListener,
         this.listener = null;
         if (locationManager != null) {
             locationManager.removeGpsStatusListener(this);
-            if (ContextCompat.checkSelfPermission(this.context,
-                    Manifest.permission.ACCESS_FINE_LOCATION)
-                    == PackageManager.PERMISSION_GRANTED) {
+
+            try {
                 locationManager.removeUpdates(this);
+            } catch (SecurityException ex) {
+                //Ignore if user turn off GPS
             }
-            locationManager = null;
         }
+        locationManager = null;
     }
 
     @Override


### PR DESCRIPTION
GPS (and other sensors) were not stopped when activity was stopped

On Marshmallow and later. Permissions are required to handle GPS, the check when closing was incorrect.
The solution was to ignore the check and handle the SecurityException that occurs if the user deactivates GPS permission for RunnerUp while recording an activity.

Some Lint corrections too