### PR TITLE
Back in StartActivity for non Autostart GPS should stop gpsBoundState

### DIFF
--- a/app/src/org/runnerup/view/StartActivity.java
+++ b/app/src/org/runnerup/view/StartActivity.java
@@ -373,6 +373,16 @@ public class StartActivity extends Activity implements TickListener, GpsInformat
         super.onDestroy();
     }
 
+    @Override
+    public void onBackPressed () {
+        if (!getAutoStartGps() && mGpsStatus.isLogging()) {
+            stopGps();
+            updateView();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
     private final BroadcastReceiver startEventBroadcastReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
There is currently no way to stop the GPS if you have started GPS but do not start an actvity.
You have to remove RunnerUp from recent apps.

This change stops GPS with Back button, without exiting the app
(Home, recent apps have no effect as before).