### PR TITLE
Suppress proguard warnings

### DIFF
--- a/app/proguard.txt
+++ b/app/proguard.txt
@@ -12,3 +12,5 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn java.lang.invoke.**
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-dontwarn okhttp3.internal.http.HttpEngine
+-dontwarn okhttp3.internal.Platform


### PR DESCRIPTION
Required on Travis, not necessary in my local build
(The SDK tools are slightly older on Travis, the only difference I know. Updating to Android-25 makes environments more the same)