### PR TITLE
Mapbox 4.2 update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,11 +100,11 @@ repositories {
 
 dependencies {
     //design uses com.android.support:appcompat, not explicitly required
-    latestCompile 'com.android.support:design:25.0.0'
+    latestCompile 'com.android.support:design:25.0.1'
     froyoCompile 'com.android.support:design:24.1.0' //SDK <10 dropped in 24.2
     latestCompile 'com.google.android.gms:play-services-wearable:9.8.0'
     latestCompile 'com.getpebble:pebblekit:3.1.0'
-    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.2@aar'){
+    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.5@aar'){
         transitive=true
     }
     compile 'com.jjoe64:graphview:4.2.1'

--- a/app/proguard.txt
+++ b/app/proguard.txt
@@ -12,3 +12,5 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn java.lang.invoke.**
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-dontwarn okhttp3.internal.http.HttpEngine
+-dontwarn okhttp3.internal.Platform


### PR DESCRIPTION
with beta.3 and later a workaround is needed to zoom to activity when opening.
The workaround (so far) is to try move the camera at view updates as long as position is 0,0
mapbox/mapbox-gl-native#6855 (comment) (and related issues)

beta.2 works fine (4.1.1 had marker issues) but beta.5 should be better