### PR TITLE
Another try to fix jonasoreland/runnerup#440

### DIFF
--- a/app/res/layout/title_spinner.xml
+++ b/app/res/layout/title_spinner.xml
@@ -46,6 +46,7 @@
 
     <Spinner
         android:id="@+id/spinner"
+        android:spinnerMode="dialog"
         android:layout_width="0dp"
         android:layout_height="0dp" />
 </LinearLayout>


### PR DESCRIPTION
Another try to fix jonasoreland/runnerup#440

Show all TitleSpinners as modal dialog. This type of spinners cannot be closed with parent update. Another point - it is bigger and thus more usable outdoor :)