### PR TITLE
hrValue==0 means nothing

### DIFF
--- a/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
@@ -176,17 +176,9 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
                             BluetoothGattCharacteristic.FORMAT_UINT8, 1);
                 }
 
-                if (hrValue == 0) {
-                    if (mIsConnecting) {
-                        reportConnectFailed("got hrValue = 0 => reportConnectFailed");
-                        return;
-                    }
-                    log("got hrValue == 0 => disconnecting");
-                    reportDisconnected();
-                    return;
+                if (hrValue > 0) {
+                    hrTimestamp = System.currentTimeMillis();
                 }
-
-                hrTimestamp = System.currentTimeMillis();
 
                 if (mIsConnecting) {
                     reportConnected(true);


### PR DESCRIPTION
There are two reasons to remove this check:

 1. Some HRM devices reports hrValue==0 for some time, right after it restored contact with the body. This state causes reportConnectFailed(), which starts new full cycle of reconnection, while RetryingHRProviderProxy actually is just successfully finished reconnection.
 2. reportConnectFailed() is called from onConnectionStateChanged(), so it is useless here.

In worst case, very first retrieved hrValue is zero in a series of reconnections => all reconnections will be failed until attempts limit is reached. No HR recording until application restart!