### PR TITLE
Fitness account setup dialog becomes frozen when user clicks outside of it

### DIFF
--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -574,6 +574,7 @@ public class SyncManager {
             }
         });
         final AlertDialog dialog = builder.create();
+        dialog.setCanceledOnTouchOutside(false);
         dialog.show();
     }
 


### PR DESCRIPTION
Quick workaround: prevent closing dialog when user clicks outside.