### PR TITLE
Transifex cleanup

### DIFF
--- a/app/res/layout-v14/feed_widget.xml
+++ b/app/res/layout-v14/feed_widget.xml
@@ -18,7 +18,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Latest feed (click to refresh)"
+        android:text="@string/latest_feed_click_to_refresh"
         android:id="@+id/textView"
         android:layout_above="@+id/widget_empty"
         android:layout_toRightOf="@+id/widget_app_icon"

--- a/app/res/layout/filepermission.xml
+++ b/app/res/layout/filepermission.xml
@@ -16,6 +16,7 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/linear1_layout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -42,7 +43,8 @@
                 android:id="@+id/text_view1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="URL" />
+                android:text="URL"
+                tools:ignore="HardcodedText" />
 
             <EditText
                 android:id="@+id/fileuri"
@@ -63,12 +65,14 @@
             android:id="@+id/tcxformat"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="TCX" />
+            android:text="TCX"
+            tools:ignore="HardcodedText" />
         <CheckBox
             android:id="@+id/gpxformat"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="GPX" />
+            android:text="GPX"
+            tools:ignore="HardcodedText" />
     </TableRow>
 
 </LinearLayout>

--- a/app/res/layout/start.xml
+++ b/app/res/layout/start.xml
@@ -124,7 +124,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="\?" />
+                android:text="\?"
+                tools:ignore="HardcodedText" />
         </FrameLayout>
 
         <FrameLayout
@@ -146,7 +147,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="\?" />
+                android:text="\?"
+                tools:ignore="HardcodedText" />
         </FrameLayout>
     </LinearLayout>
 

--- a/common/src/main/res/values-ar/strings.xml
+++ b/common/src/main/res/values-ar/strings.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+  <!--~ Copyright (C) 2014 jonas.oreland@gmail.com
+  ~
+  ~  This program is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  This program is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.-->
+  <!--metrics stuff-->
+  <!--format hint stuff-->
+  <!--strings with argument to provide-->
+  <!--first argument is a date, second a time, for instance: "Yesterday at 13:32"-->
+  <!--weird stuff: should it be placeholders or even removed?-->
+  <!--other-->
+  <string name="recovery">التعافي</string>
+  <string name="warm_up">الإحماء</string>
+  <string name="cool_down">الراحة</string>
+</resources>

--- a/common/src/main/res/values-ca/array.xml
+++ b/common/src/main/res/values-ca/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Milles</item>
     <item>Kilòmetres</item>
@@ -32,10 +32,6 @@
     <item>Orientació</item>
     <item>Caminar</item>
   </string-array>
-  <string-array name="muteValues">
-    <item>no</item>
-    <item>sí</item>
-  </string-array>
   <string-array name="types">
     <item>Temps</item>
     <item>Distància</item>
@@ -43,37 +39,5 @@
   <string-array name="sexes">
     <item>Home</item>
     <item>Dona</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Català</item>
-    <item>Anglès</item>
-    <item>Holandès</item>
-    <item>Alemany</item>
-    <item>Japonès</item>
-    <item>Àrab</item>
-    <item>Rus</item>
-    <item>Espanyol</item>
-    <item>Francès</item>
-    <item>Italià</item>
-    <item>Polonès</item>
-    <item>Turc</item>
-    <item>Portuguès</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>ca</item>
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-ca/strings.xml
+++ b/common/src/main/res/values-ca/strings.xml
@@ -127,9 +127,9 @@
   <string name="Yes">Sí</string>
   <string name="Create">Crea</string>
   <string name="No">No</string>
-  <string name="Loading">S\'està carregant...</string>
+  <string name="Loading">S\'està carregant…</string>
   <string name="Saving">Desant</string>
-  <string name="Cancellingplease_wait">S\'està cancel·lant...</string>
+  <string name="Cancellingplease_wait">S\'està cancel·lant…</string>
   <string name="try_again_later">Torneu a provar més tard!</string>
   <string name="Are_you_sure">N\'esteu segur?</string>
   <string name="Downloadeditremove_workouts">Baixa/edita/suprimeix els progressos</string>
@@ -147,7 +147,7 @@
   <string name="Advanced_options">Opcions avançades</string>
   <string name="Export">Exporta</string>
   <string name="Import">Importa</string>
-  <string name="About">Quant a...</string>
+  <string name="About">Quant a…</string>
   <string name="About_RunnerUp">Quant al RunnerUp</string>
   <string name="Total_distance">Distància total</string>
   <string name="Total_time">Temps total</string>
@@ -167,7 +167,7 @@
   <string name="Advanced">Avançat</string>
   <string name="Manual">Manual</string>
   <string name="Battery_level">Nivell de la bateria</string>
-  <string name="Searching_for_GPS">S\'està cercant el GPS...</string>
+  <string name="Searching_for_GPS">S\'està cercant el GPS…</string>
   <string name="Warning">Atenció</string>
   <string name="Do_not_show_again">No tornis a mostrar</string>
   <string name="Save">Desa</string>
@@ -191,7 +191,7 @@
   <string name="Downloading_1s_will_overwrite_2_workout_with_same_name">S\'està baixant %1$s i sobreescriurà l\'entrenament amb el mateix nom %2$ </string>
   <string name="Delete_workout">Suprimeix l\'entrenament</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hola\nAquest entrenament potser us agradarà.</string>
-  <string name="Share_workout">Comparteix l\'entrenament...</string>
+  <string name="Share_workout">Comparteix l\'entrenament…</string>
   <string name="New_audio_scheme">Esquema nou d\'àudio</string>
   <string name="Default">Per defecte</string>
   <string name="Notes_about_your_workout">Comentaris sobre l\'entrenament</string>

--- a/common/src/main/res/values-ca/strings.xml
+++ b/common/src/main/res/values-ca/strings.xml
@@ -175,8 +175,6 @@
   <string name="Add_repeat">Afegeix una repetició</string>
   <string name="Discard">Descarta</string>
   <string name="Failed_to_create_workout">Ha fallat en crear l\'entrenament</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Website">Web</string>
   <string name="Automatic_upload">Penja automàticament</string>
   <string name="Include_map_in_post">Inclou el mapa a la publicació</string>

--- a/common/src/main/res/values-cs/array.xml
+++ b/common/src/main/res/values-cs/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Míle</item>
     <item>Kilometry</item>
@@ -18,14 +18,8 @@
     <item>Cyklistika</item>
     <item>Ostatní</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Ne</item>
-    <item>Ano</item>
-  </string-array>
   <string-array name="sexes">
     <item>Muž</item>
     <item>Žena</item>
   </string-array>
-  <!--Audio cue languages-->
-  <!--Note: keep in same order as languagesNames-->
 </resources>

--- a/common/src/main/res/values-de/array.xml
+++ b/common/src/main/res/values-de/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Meilen</item>
     <item>Kilometer</item>
@@ -37,14 +37,6 @@
     <item>Orientierungslauf</item>
     <item>Gehen</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Nein</item>
-    <item>Ja</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nein</item>
-    <item>ja</item>
-  </string-array>
   <string-array name="types">
     <item>Zeit</item>
     <item>Distanz</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Männlich</item>
     <item>Weiblich</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Englisch</item>
-    <item>Niederländisch</item>
-    <item>Deutsch</item>
-    <item>Japanisch</item>
-    <item>Arabisch</item>
-    <item>Russisch</item>
-    <item>Spanisch</item>
-    <item>Französisch</item>
-    <item>Italienisch</item>
-    <item>Polnisch</item>
-    <item>Türkisch</item>
-    <item>Portugiesisch</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Alter</string>
   <string name="edit">bearbeiten</string>
   <string name="Synchronizing">Synchronisiere:</string>
-  <string name="synchronizing_feed">synchronisiere Feed...</string>
+  <string name="synchronizing_feed">synchronisiere Feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Tabellenformat</string>
   <string name="Clear_uploads">Uploads löschen</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Ablehnen</string>
   <string name="No_way">Niemals</string>
   <string name="No">No</string>
-  <string name="Loading">Lade...</string>
+  <string name="Loading">Lade…</string>
   <string name="Saving">Speichern</string>
-  <string name="Cancellingplease_wait">Abbruch... bitte warten</string>
+  <string name="Cancellingplease_wait">Abbruch… bitte warten</string>
   <string name="try_again_later">Bitte später erneut versuchen.</string>
   <string name="Are_you_sure">Bist Du sicher?</string>
   <string name="Configure_audio_cues">Audiohinweise konfigurieren</string>
@@ -284,7 +284,7 @@
   <string name="Delete_workout">Trainingseinheit löschen </string>
   <string name="RunnerUp_workout">RunnerUp-Trainingseinheit: </string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hallo\nHier ist ein Training, dass dir vielleicht gefallen könnte.</string>
-  <string name="Share_workout">Trainingseinheit teilen...</string>
+  <string name="Share_workout">Trainingseinheit teilen…</string>
   <string name="New_audio_scheme">Neues Audioschema</string>
   <string name="Default">Standard</string>
   <string name="Notes_about_your_workout">Notizen über Ihre Trainingseinheit</string>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -165,7 +165,6 @@
   <string name="Downloadeditremove_workouts">Trainingseinheiten herunterladen/bearbeiten/löschen</string>
   <string name="Note_you_need_to_connect_to_the_account_too">Anmerkung: Sie müssen sich auch mit dem Konto verbinden</string>
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Verwende Dein Headset um RunnerUp zu starten/pausieren/fortzusetzen</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Datenbank auf SD-Karte exportieren (z.B. für Aktualisierungen)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Datenbank von SD-Karte importieren (z.B. nach einer Aktualisierung)</string>
   <string name="Test_audio_cue">Audiohinweis testen</string>
@@ -264,8 +263,6 @@
   <string name="Add_repeat">Wiederholung hinzufügen</string>
   <string name="Discard">Verwerfen</string>
   <string name="Failed_to_create_workout">Fehler beim Erstellen der Trainingseinheit</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Audiohinweissprache</string>
   <string name="Website">Webseite</string>
   <string name="Automatic_upload">Automatisch hochladen</string>

--- a/common/src/main/res/values-en-rNL/array.xml
+++ b/common/src/main/res/values-en-rNL/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mijlen</item>
     <item>Kilometers</item>
@@ -30,14 +30,6 @@
   </string-array>
   <!--Note: same order as above, same values as Dimension-->
   <!--Note: keep in same order as DB.ACCOUNT.SPORT_-->
-  <string-array name="muteEntries">
-    <item>Nee</item>
-    <item>Ja</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nee</item>
-    <item>ja</item>
-  </string-array>
   <string-array name="types">
     <item>Tijd</item>
     <item>Afstand</item>
@@ -46,6 +38,4 @@
     <item>Man</item>
     <item>Vrouw</item>
   </string-array>
-  <!--Audio cue languages-->
-  <!--Note: keep in same order as languagesNames-->
 </resources>

--- a/common/src/main/res/values-en-rNL/strings.xml
+++ b/common/src/main/res/values-en-rNL/strings.xml
@@ -116,7 +116,7 @@
   <string name="Age">Leeftijd</string>
   <string name="edit">aanpassen</string>
   <string name="Synchronizing">Synchroniseren:</string>
-  <string name="synchronizing_feed">synchroniseren van de feed...</string>
+  <string name="synchronizing_feed">synchroniseren van de feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Tabel formaat</string>
   <string name="Clear_uploads">Uploads wissen</string>
@@ -154,9 +154,9 @@
   <string name="Dismiss">Afwijzen</string>
   <string name="No_way">Absoluut niet</string>
   <string name="No">Nee</string>
-  <string name="Loading">Laden...</string>
+  <string name="Loading">Laden…</string>
   <string name="Saving">Opslaan</string>
-  <string name="Cancellingplease_wait">Annuleren...even geduld aub</string>
+  <string name="Cancellingplease_wait">Annuleren…even geduld aub</string>
   <string name="try_again_later">Probeer het later opnieuw!</string>
   <string name="Are_you_sure">Weet u het zeker?</string>
   <string name="Configure_audio_cues">Auditieve signalen instellen</string>

--- a/common/src/main/res/values-en-rNL/strings.xml
+++ b/common/src/main/res/values-en-rNL/strings.xml
@@ -165,7 +165,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Gebruik uw headset om RunnerUp te starten/pauzeren/hervatten</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Omzetten rust-stap met type afstand tot herstel-stap voor Interval-tabblad</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Omzetten rust-stap met type afstand tot herstel-stap voor Geavanceerde-tabblad</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exporteer de database naar sdcard (bijv. voor een upgrade)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importeer de database van sdcard (bijv. na een upgrade)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Coach om u te helpen uw doel te bereiken (als u uw doel reeds heeft ingesteld)</string>

--- a/common/src/main/res/values-es/array.xml
+++ b/common/src/main/res/values-es/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Millas</item>
     <item>Kilómetros</item>
@@ -37,14 +37,6 @@
     <item>Orientación</item>
     <item>Caminar</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>No</item>
-    <item>Sí</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>no</item>
-    <item>sí</item>
-  </string-array>
   <string-array name="types">
     <item>Tiempo</item>
     <item>Distancia</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Hombre</item>
     <item>Mujer</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Inglés</item>
-    <item>Holandés</item>
-    <item>Alemán</item>
-    <item>Japonés</item>
-    <item>Árabe</item>
-    <item>Ruso</item>
-    <item>Español</item>
-    <item>Francés</item>
-    <item>Italiano</item>
-    <item>Polaco</item>
-    <item>Turco</item>
-    <item>Portugues</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Usa tus auriculares para iniciar/pausar/resumir RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Convertir paso de reposo por tipo distancia a paso de recuperación por intervalo en la pestaña de Intervalo</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Convertir paso de reposo por tipo distancia a paso de recuperación por intervalo en la pestaña de Avanzado</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exportar la base de datos a la tarjeta sd (ej. para actualización)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importar la base de datos de la tarjeta sd (ej. después de actualizar)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Entrenador para ayudarte a conseguir tu objetivo (si has seleccionado objetivo)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Añadir repetición</string>
   <string name="Discard">Descartar</string>
   <string name="Failed_to_create_workout">Fallo al crear la actividad</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Idioma de las indicaciones de audio</string>
   <string name="Website">Página web</string>
   <string name="Automatic_upload">Subida automática</string>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Edad</string>
   <string name="edit">editar</string>
   <string name="Synchronizing">Sincronizando:</string>
-  <string name="synchronizing_feed">sincronizando fuente...</string>
+  <string name="synchronizing_feed">sincronizando fuente…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Formato de tabla</string>
   <string name="Clear_uploads">Limpiar subidas</string>
@@ -156,7 +156,7 @@
   <string name="Dismiss">Rechazar</string>
   <string name="No_way">De ninguna manera</string>
   <string name="No">No</string>
-  <string name="Loading">Cargando...</string>
+  <string name="Loading">Cargando…</string>
   <string name="Saving">Guardando</string>
   <string name="Cancellingplease_wait">Cancelando… por favor, espere</string>
   <string name="try_again_later">Inténtalo de nuevo más tarde</string>
@@ -286,11 +286,11 @@
   <string name="Overwrite_existing">Sobrescribir existentes</string>
   <string name="Create_new_workout">Crear nueva actividad</string>
   <string name="Set_workout_name">Cambiar nombre de la actividad</string>
-  <string name="Downloading_1s_will_overwrite_2_workout_with_same_name">Descargar %1$s sobrescribirá el ejercicio  con el mismo nombre</string>
+  <string name="Downloading_1s_will_overwrite_2_workout_with_same_name">Descargar %1$s sobrescribirá el ejercicio  con el mismo nombre %2$</string>
   <string name="Delete_workout">Eliminar entrenamiento</string>
   <string name="RunnerUp_workout">Actividades en RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hola\nTengo una actividad que te podría gustar.</string>
-  <string name="Share_workout">Compartir actividad...</string>
+  <string name="Share_workout">Compartir actividad…</string>
   <string name="New_audio_scheme">Nuevo esquema de audio</string>
   <string name="Default">Por defecto</string>
   <string name="Notes_about_your_workout">Notas sobre la actividad</string>

--- a/common/src/main/res/values-fr/array.xml
+++ b/common/src/main/res/values-fr/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Milles</item>
     <item>Kilomètres</item>
@@ -37,14 +37,6 @@
     <item>Course d\'orientation</item>
     <item>Marche</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Non</item>
-    <item>Oui</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>non</item>
-    <item>oui</item>
-  </string-array>
   <string-array name="types">
     <item>Temps</item>
     <item>Distance</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Homme</item>
     <item>Femme</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Anglais</item>
-    <item>Néerlandais</item>
-    <item>Allemand</item>
-    <item>Japonais</item>
-    <item>Arabe</item>
-    <item>Russe</item>
-    <item>Espagnol</item>
-    <item>Français</item>
-    <item>Italien</item>
-    <item>Polonais</item>
-    <item>Turc</item>
-    <item>Portugais</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Utilisez le casque pour démarrer/pauser/reprendre RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Convertir les étapes de repos de type distance en étapes de récupération dans l\'onglet Intervalle </string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Convertir les étapes de repos de type distance en étapes de récupération dans l\'onglet Avancé </string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exporter les données sur carte SD (ex : pour mise à jour)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importer les données depuis la carte SD (ex : après mise à jour)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Le suivi audio vous aide à atteindre votre objectif (si défini)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Ajout une répétition</string>
   <string name="Discard">Abandonner</string>
   <string name="Failed_to_create_workout">Impossible de créer l\'entraînement</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Langue du suivi audio</string>
   <string name="Website">Site web</string>
   <string name="Automatic_upload">Télécharger automatiquement</string>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Age</string>
   <string name="edit">éditer</string>
   <string name="Synchronizing">Synchronisation :</string>
-  <string name="synchronizing_feed">synchronization des actualités...</string>
+  <string name="synchronizing_feed">synchronization des actualités…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Format table</string>
   <string name="Clear_uploads">Supprimer les uploads</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Continuer</string>
   <string name="No_way">Non</string>
   <string name="No">Non</string>
-  <string name="Loading">Chargement...</string>
+  <string name="Loading">Chargement…</string>
   <string name="Saving">Sauvegarde</string>
-  <string name="Cancellingplease_wait">Annulation... veuillez patienter</string>
+  <string name="Cancellingplease_wait">Annulation… veuillez patienter</string>
   <string name="try_again_later">essayez plus tard !</string>
   <string name="Are_you_sure">Êtes-vous sûr ?</string>
   <string name="Configure_audio_cues">Configurer le suivi audio</string>

--- a/common/src/main/res/values-hu/array.xml
+++ b/common/src/main/res/values-hu/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mérföld</item>
     <item>Kilométer</item>
@@ -37,14 +37,6 @@
     <item>Tájfutás</item>
     <item>Gyaloglás</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Nem</item>
-    <item>Igen</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nem</item>
-    <item>igen</item>
-  </string-array>
   <string-array name="types">
     <item>Idő</item>
     <item>Távolság</item>
@@ -53,6 +45,4 @@
     <item>Férfi</item>
     <item>Nő</item>
   </string-array>
-  <!--Audio cue languages-->
-  <!--Note: keep in same order as languagesNames-->
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Használd a fülhallgatót az indításhoz/szünethez/folytatáshoz</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Távolság típusú pihenés lépés konvertálása regeneráció lépéssé Intervallum fülhöz.</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Távolság típusú pihenés lépés konvertálása regeneráció lépéssé Fejlett fülhöz.</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Adatbázis exportálása sd kártyára (pl. frissítéshez)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Adatbázis importálása sd kártyáról (pl. frissítés után)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Egy edző: segít a kitűzött cél elérésében (amennyiben be van állítva kitűzött cél)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Ismétlés hozzáadása</string>
   <string name="Discard">Elvetés</string>
   <string name="Failed_to_create_workout">Sikertelen az edzésterv létrehozása</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Beszéd visszajelzés nyelve</string>
   <string name="Website">Weboldal</string>
   <string name="Automatic_upload">Automatikus feltöltés</string>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Életkor</string>
   <string name="edit">szerkesztés</string>
   <string name="Synchronizing">Szinkronizálás:</string>
-  <string name="synchronizing_feed">hírfolyam szinkronizálása...</string>
+  <string name="synchronizing_feed">hírfolyam szinkronizálása…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Táblázat formátum</string>
   <string name="Clear_uploads">Feltöltések törlése</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Elutasít</string>
   <string name="No_way">Nem létezik</string>
   <string name="No">Nem</string>
-  <string name="Loading">Betöltés...</string>
+  <string name="Loading">Betöltés…</string>
   <string name="Saving">Mentés</string>
-  <string name="Cancellingplease_wait">Törlés... kérlek várj</string>
+  <string name="Cancellingplease_wait">Törlés… kérlek várj</string>
   <string name="try_again_later">Próbáld újra később!</string>
   <string name="Are_you_sure">Biztos vagy benne?</string>
   <string name="Configure_audio_cues">Beszéd visszajelzés beállítása</string>

--- a/common/src/main/res/values-id/array.xml
+++ b/common/src/main/res/values-id/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mil</item>
     <item>Kilometer</item>
@@ -37,14 +37,6 @@
     <item>Orienteering</item>
     <item>Jalan kaki</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Tidak</item>
-    <item>Ya</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>tidak</item>
-    <item>ya</item>
-  </string-array>
   <string-array name="types">
     <item>Waktu</item>
     <item>Jarak</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Pria</item>
     <item>Wanita</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Inggris</item>
-    <item>Belanda</item>
-    <item>Jerman</item>
-    <item>Jepang</item>
-    <item>Arab</item>
-    <item>Rusia</item>
-    <item>Spanyol</item>
-    <item>Perancis</item>
-    <item>Italia</item>
-    <item>Polandia</item>
-    <item>Turki</item>
-    <item>Portugis</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-id/strings.xml
+++ b/common/src/main/res/values-id/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Gunakan headset untuk memulai/menjeda/melanjutkan RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Convert rest-step with type distance to recovery-step for Interval-tab</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Konversikan langkah istirahat dengan tipe jarak ke langkah pemulihan untuk tab Mahir</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Ekspor data ke sdcard (sebelum upgrade)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Impor data dari sdcard (setelah upgrade)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Suara pelatih untuk mencapai target (jika target sudah ditetapkan)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Tambahkan ulangan</string>
   <string name="Discard">Buang</string>
   <string name="Failed_to_create_workout">Gagal membuat latihan</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Bahasa isyarat suara</string>
   <string name="Website">Laman web</string>
   <string name="Automatic_upload">Unggah otomatis</string>

--- a/common/src/main/res/values-id/strings.xml
+++ b/common/src/main/res/values-id/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Umur</string>
   <string name="edit">edit</string>
   <string name="Synchronizing">Menyinkronkan:</string>
-  <string name="synchronizing_feed">menyingkronkan umpan...</string>
+  <string name="synchronizing_feed">menyingkronkan umpan…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Format tabel</string>
   <string name="Clear_uploads">Kosongkan unggahan</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Selesai</string>
   <string name="No_way">Tidak mungkin</string>
   <string name="No">Tidak</string>
-  <string name="Loading">Memuat...</string>
+  <string name="Loading">Memuat…</string>
   <string name="Saving">Menyimpan</string>
-  <string name="Cancellingplease_wait">Membatalkan...harap tunggu</string>
+  <string name="Cancellingplease_wait">Membatalkan…harap tunggu</string>
   <string name="try_again_later">coba lagi nanti!</string>
   <string name="Are_you_sure">Anda yakin?</string>
   <string name="Configure_audio_cues">Pengaturan isyarat suara</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">Hapus latihan</string>
   <string name="RunnerUp_workout">Latihan RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Halo\nIni adalah latihan yang bisa dipakai.</string>
-  <string name="Share_workout">Berbagi latihan...</string>
+  <string name="Share_workout">Berbagi latihan…</string>
   <string name="New_audio_scheme">Skema suara baru</string>
   <string name="Default">Baku</string>
   <string name="Notes_about_your_workout">Catatan terkait latihan</string>

--- a/common/src/main/res/values-it/array.xml
+++ b/common/src/main/res/values-it/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Miglia</item>
     <item>Chilometri</item>
@@ -37,14 +37,6 @@
     <item>Orientamento</item>
     <item>Camminata</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>No</item>
-    <item>Sì</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>no</item>
-    <item>sì</item>
-  </string-array>
   <string-array name="types">
     <item>Tempo</item>
     <item>Distanza</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Uomo</item>
     <item>Donna</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Inglese</item>
-    <item>Olandese</item>
-    <item>Tedesco</item>
-    <item>Giapponese</item>
-    <item>Arabo</item>
-    <item>Russo</item>
-    <item>Spagnolo</item>
-    <item>Francese</item>
-    <item>Italiano</item>
-    <item>Polacco</item>
-    <item>Turco</item>
-    <item>Portoghese</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Età</string>
   <string name="edit">modifica</string>
   <string name="Synchronizing">Sincronizzando:</string>
-  <string name="synchronizing_feed">sincronizzando feed...</string>
+  <string name="synchronizing_feed">sincronizzando feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Formato tabella</string>
   <string name="Clear_uploads">Svuota caricamenti</string>
@@ -142,7 +142,7 @@
   <string name="Clear_HR_settings">Cancella impostazioni frequenza cardiaca</string>
   <string name="Heart_rate_monitor_is_not_supported_for_your_device">Monitoraggio frequenza cardiaca non supportata per questo dispositivo</string>
   <string name="Select_type_of_Bluetooth_device">Seleziona tipo dispositivo Bluetooth</string>
-  <string name="Scanning">Ricerca...</string>
+  <string name="Scanning">Ricerca…</string>
   <string name="Failed_to_load_workout">Caricamento allenamento fallito!!</string>
   <string name="Icon_list">Lista icone</string>
   <string name="Problem">Problema</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Chiudi</string>
   <string name="No_way">Assolutamente no</string>
   <string name="No">No</string>
-  <string name="Loading">Caricamento...</string>
-  <string name="Saving">Salvando...</string>
-  <string name="Cancellingplease_wait">Cancellando...prego attendere</string>
+  <string name="Loading">Caricamento…</string>
+  <string name="Saving">Salvando…</string>
+  <string name="Cancellingplease_wait">Cancellando…prego attendere</string>
   <string name="try_again_later">riprova più tardi!</string>
   <string name="Are_you_sure">Ne sei sicuro?</string>
   <string name="Configure_audio_cues">Configura riferimenti audio</string>
@@ -206,7 +206,7 @@
   <string name="Experimental_HRM_devices">Dispositivi HRM sperimentali</string>
   <string name="Experimental_features">Funzionalità sperimentali</string>
   <string name="Mock_HRM_devices">Dispositivi HRM \"fantoccio\"</string>
-  <string name="About">A proposito...</string>
+  <string name="About">A proposito…</string>
   <string name="About_RunnerUp">Info su RunnerUp</string>
   <string name="Triggers">Eventi</string>
   <string name="Time_triggered_audio_cue">Riferimento audio attivato per tempo</string>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Usa gli auricolari per avviare/sospendere/riprendere RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Converti il tratto di riposo di tipo distanza in tratto di recupero per la scheda Intervallo</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Converti il tratto di riposo di tipo distanza in tratto di recupero per la scheda Avanzato</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Esporta database su sdcard (ad esempio prima di un aggiornamento di sistema)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importa database su sdcard (ad esempio dopo un aggiornamento di sistema)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Allenatore (ti aiuta a raggiungere l\'obiettivo - se fissato)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Aggiungi ripetizione</string>
   <string name="Discard">Scarta</string>
   <string name="Failed_to_create_workout">Impossibile creare l\'attività</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Lingua dei riferimenti audio</string>
   <string name="Website">Sito web</string>
   <string name="Automatic_upload">Upload automatico</string>

--- a/common/src/main/res/values-ja/array.xml
+++ b/common/src/main/res/values-ja/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>マイル</item>
     <item>キロメートル</item>
@@ -37,50 +37,8 @@
     <item>オリエンテーリング</item>
     <item>ウォーキング</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>いいえ</item>
-    <item>はい</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>no</item>
-    <item>yes</item>
-  </string-array>
-  <string-array name="types">
-    <item>時間</item>
-    <item>距離</item>
-  </string-array>
   <string-array name="sexes">
     <item>男性</item>
     <item>女性</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>英語</item>
-    <item>オランダ語</item>
-    <item>ドイツ語</item>
-    <item>日本語</item>
-    <item>アラビア語</item>
-    <item>ロシア語</item>
-    <item>スペイン語</item>
-    <item>フランス語</item>
-    <item>イタリア語</item>
-    <item>ポーランド語</item>
-    <item>トルコ語</item>
-    <item>ポルトガル語</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">ヘッドセットを使用して RunnerUp を開始/一時休止/再開する</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">インターバルタブの、距離タイプの休憩ステップをリカバリーステップに変換</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">高度タブの、距離タイプの休憩ステップをリカバリーステップに変換</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">SD カードにデータベースをエクスポート (アップグレード用など)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">SD カードからデータベースをインポート (アップグレード後など)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">あなたが目標を達成を支援するためコーチする (目標を設定した場合)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">繰り返しを追加</string>
   <string name="Discard">破棄</string>
   <string name="Failed_to_create_workout">ワークアウトの作成に失敗しました</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">音声合図の言語</string>
   <string name="Website">Webサイト</string>
   <string name="Automatic_upload">自動アップロード</string>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">年齢</string>
   <string name="edit">編集</string>
   <string name="Synchronizing">同期中:</string>
-  <string name="synchronizing_feed">フィードを同期中...</string>
+  <string name="synchronizing_feed">フィードを同期中…</string>
   <string name="OK">OK</string>
   <string name="Table_format">テーブル形式</string>
   <string name="Clear_uploads">アップロードをクリア</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">閉じる</string>
   <string name="No_way">とんでもない</string>
   <string name="No">いいえ</string>
-  <string name="Loading">ロード中...</string>
+  <string name="Loading">ロード中…</string>
   <string name="Saving">保存中</string>
-  <string name="Cancellingplease_wait">キャンセル中...しばらくお待ちください</string>
+  <string name="Cancellingplease_wait">キャンセル中…しばらくお待ちください</string>
   <string name="try_again_later">後で再度実行してください!</string>
   <string name="Are_you_sure">よろしいですか?</string>
   <string name="Configure_audio_cues">音声合図の設定</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">ワークアウトを削除</string>
   <string name="RunnerUp_workout">RunnerUp ワークアウト: </string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">やあ\nここにあなたのお好みのワークアウトがあります。</string>
-  <string name="Share_workout">ワークアウトを共有...</string>
+  <string name="Share_workout">ワークアウトを共有…</string>
   <string name="New_audio_scheme">新しい音声合図スキーム</string>
   <string name="Default">デフォルト</string>
   <string name="Notes_about_your_workout">ワークアウトについてのメモ</string>

--- a/common/src/main/res/values-lt/array.xml
+++ b/common/src/main/res/values-lt/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mylios</item>
     <item>Kilometrai</item>
@@ -37,14 +37,6 @@
     <item>Orientacijios sportas</item>
     <item>Ėjimas</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Ne</item>
-    <item>Taip</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>ne</item>
-    <item>taip</item>
-  </string-array>
   <string-array name="types">
     <item>Laikas</item>
     <item>Atstumas</item>
@@ -52,37 +44,5 @@
   <string-array name="sexes">
     <item>Vyras</item>
     <item>Moteris</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Lietuvių</item>
-    <item>Anglų</item>
-    <item>Olandų</item>
-    <item>Vokiečių</item>
-    <item>Japonų</item>
-    <item>Arabų</item>
-    <item>Rusų</item>
-    <item>Ispanų</item>
-    <item>Prancūzų</item>
-    <item>Italų</item>
-    <item>Lenkų</item>
-    <item>Turkų</item>
-    <item>Portugalų</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>lt</item>
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-lt/strings.xml
+++ b/common/src/main/res/values-lt/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Amžius</string>
   <string name="edit">redaguoti</string>
   <string name="Synchronizing">Sinchronizavimas</string>
-  <string name="synchronizing_feed">sinchronizuoja kanalą...</string>
+  <string name="synchronizing_feed">sinchronizuoja kanalą…</string>
   <string name="OK">Gerai</string>
   <string name="Table_format">Lentelės formatas</string>
   <string name="Clear_uploads">Išvalyti įkėlimus</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Nutraukti</string>
   <string name="No_way">Jokiu būdu</string>
   <string name="No">Ne</string>
-  <string name="Loading">Kraunasi...</string>
+  <string name="Loading">Kraunasi…</string>
   <string name="Saving">Išsaugoja</string>
-  <string name="Cancellingplease_wait">Nutraukiama...palaukite</string>
+  <string name="Cancellingplease_wait">Nutraukiama…palaukite</string>
   <string name="try_again_later">pabandyk kitą kartą!</string>
   <string name="Are_you_sure">Ar tikrai?</string>
   <string name="Configure_audio_cues">Konfigūruoti garsinius nurodymus</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">Ištrinti treniruotę</string>
   <string name="RunnerUp_workout">RunnerUp treniruotė:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Labas\nČia treniruotė, kuri manau tau patiks.</string>
-  <string name="Share_workout">Dalintis treniruote...</string>
+  <string name="Share_workout">Dalintis treniruote…</string>
   <string name="New_audio_scheme">Nauja audio schema</string>
   <string name="Default">Numatyta</string>
   <string name="Notes_about_your_workout">Pastabos apie tavo treniruotę</string>

--- a/common/src/main/res/values-lt/strings.xml
+++ b/common/src/main/res/values-lt/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Naudoti laisvų rankų įrangą RunnerUp paleidimui/stabdymui/pratęsimui</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Konvertuoti poilsio intervalą su atstumo tipu į atsistatymo intervalą \"Intervalo\" skirtuke</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Konvertuoti poilsio intervalą su atstumo tipu į atsistatymo intervalą \"Sudėtingesni\" skirtuke</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Eksportuoti duomenų bazę į SD kortelę (pvz. atnaujinimui)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importuoti duomenų bazę iš SD kortelės (pvz. po atnaujinimo)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Padėti pasiekti tikslą (jei tikslas yra nustatytas)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Pridėti pakartojimą</string>
   <string name="Discard">Nutraukti</string>
   <string name="Failed_to_create_workout">Nepavyko sukurti treniruotės</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Garsinių nurodymų kalba </string>
   <string name="Website">Tinklapis</string>
   <string name="Automatic_upload">Automatinis įkėlimas</string>

--- a/common/src/main/res/values-nb-rNO/array.xml
+++ b/common/src/main/res/values-nb-rNO/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mil</item>
     <item>Kilometer</item>
@@ -34,21 +34,8 @@
     <item>Springing</item>
     <item>Sykling</item>
     <item>Annet</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Springing</item>
-    <item>Sykling</item>
-    <item>Annet</item>
     <item>Orientering</item>
     <item>Gåing</item>
-  </string-array>
-  <string-array name="muteEntries">
-    <item>Nei</item>
-    <item>Ja</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nei</item>
-    <item>ja</item>
   </string-array>
   <string-array name="types">
     <item>Tid</item>
@@ -57,37 +44,5 @@
   <string-array name="sexes">
     <item>Mann</item>
     <item>Dame</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Norska</item>
-    <item>Engelsk</item>
-    <item>Hollandsk</item>
-    <item>Tysk</item>
-    <item>Japansk</item>
-    <item>Arabisk</item>
-    <item>Russisk</item>
-    <item>Spansk</item>
-    <item>Fransk</item>
-    <item>Italiensk</item>
-    <item>Polsk</item>
-    <item>Tyrkisk</item>
-    <item>Portugisisk</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>nb</item>
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-nb-rNO/strings.xml
+++ b/common/src/main/res/values-nb-rNO/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Bruk hodesettet ditt til å starte/pause/gjenoppta RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Konverter hvile-steg med typen distanse til restitusjonsteget for intervallfanen</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Konverter hvile-steg med typen distanse til restitusjonsteget for avansert-fanen</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Eksporter database til SD-kort (f.eks. for oppdatering)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importer database fra SD-kort (f.eks. etter oppdatering)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Hjelpetrener for å nå målet (hvis et mål er satt)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Legg til gjentagelse</string>
   <string name="Discard">Forkast</string>
   <string name="Failed_to_create_workout">Klarte ikke å lage treningsøkt</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Språk for lydinstrukser</string>
   <string name="Website">Nettside</string>
   <string name="Automatic_upload">Automatisk opplasting</string>
@@ -291,7 +288,6 @@
   <string name="RunnerUp_workout">RunnerUp-treningsøkt:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hei\nHer er en treningsøkt jeg tror du vil like.</string>
   <string name="Share_workout">Del treningsøkt…</string>
-  <string name="Not_much_to_say_at_this_point">Ikke så mye å si per nu</string>
   <string name="New_audio_scheme">Nytt lydopplegg</string>
   <string name="Default">Forvalg</string>
   <string name="Notes_about_your_workout">Notater om din treningsøkt</string>

--- a/common/src/main/res/values-nl-rBE/strings.xml
+++ b/common/src/main/res/values-nl-rBE/strings.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+  <!--~ Copyright (C) 2014 jonas.oreland@gmail.com
+  ~
+  ~  This program is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  This program is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.-->
+  <string name="app_name">RunnerUp</string>
+  <!--metrics stuff-->
+  <string name="metrics_distance_km">km</string>
+  <string name="metrics_distance_mi">mi</string>
+  <string name="metrics_distance_m">m</string>
+  <string name="metrics_elapsed_h">u</string>
+  <string name="metrics_elapsed_m">m</string>
+  <string name="metrics_elapsed_min">min</string>
+  <string name="metrics_elapsed_s">s</string>
+  <!--format hint stuff-->
+  <string name="Maximum_heart_rate_MHR">Maximale hartslag (MHS)</string>
+  <!--strings with argument to provide-->
+  <!--first argument is a date, second a time, for instance: "Yesterday at 13:32"-->
+  <!--weird stuff: should it be placeholders or even removed?-->
+  <!--other-->
+  <string name="recovery">herstel</string>
+  <string name="warm_up">opwarming</string>
+  <string name="cool_down">afkoeling</string>
+</resources>

--- a/common/src/main/res/values-nl-rNL/array.xml
+++ b/common/src/main/res/values-nl-rNL/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mijlen</item>
     <item>Kilometers</item>
@@ -35,14 +35,6 @@
     <item>Fietsen</item>
     <item>Anders</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Nee</item>
-    <item>Ja</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nee</item>
-    <item>ja</item>
-  </string-array>
   <string-array name="types">
     <item>Tijd</item>
     <item>Afstand</item>
@@ -50,21 +42,5 @@
   <string-array name="sexes">
     <item>Man</item>
     <item>Vrouw</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-nl-rNL/strings.xml
+++ b/common/src/main/res/values-nl-rNL/strings.xml
@@ -117,7 +117,7 @@
   <string name="Age">Leeftijd</string>
   <string name="edit">aanpassen</string>
   <string name="Synchronizing">Synchroniseren:</string>
-  <string name="synchronizing_feed">bezig met synchroniseren van de feed...</string>
+  <string name="synchronizing_feed">bezig met synchroniseren van de feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Tabel formaat</string>
   <string name="Clear_uploads">Uploads wissen</string>
@@ -155,9 +155,9 @@
   <string name="Dismiss">Afwijzen</string>
   <string name="No_way">Absoluut niet</string>
   <string name="No">Nee</string>
-  <string name="Loading">Laden...</string>
+  <string name="Loading">Laden…</string>
   <string name="Saving">Opslaan</string>
-  <string name="Cancellingplease_wait">Annuleren...even geduld aub</string>
+  <string name="Cancellingplease_wait">Annuleren…even geduld aub</string>
   <string name="try_again_later">Probeer het later opnieuw!</string>
   <string name="Are_you_sure">Weet u het zeker?</string>
   <string name="Configure_audio_cues">Auditieve signalen instellen</string>
@@ -281,7 +281,7 @@
   <string name="Delete_workout">Workout verwijderen</string>
   <string name="RunnerUp_workout">RunnerUp-workout:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Halllo\nHier is een workout waarvan ik denk dat u hem leuk zult vinden.</string>
-  <string name="Share_workout">Workout delen...</string>
+  <string name="Share_workout">Workout delen…</string>
   <string name="New_audio_scheme">Nieuw audioschema</string>
   <string name="Default">Standaard</string>
   <string name="Notes_about_your_workout">Notities aangaande uw workout</string>

--- a/common/src/main/res/values-nl-rNL/strings.xml
+++ b/common/src/main/res/values-nl-rNL/strings.xml
@@ -166,7 +166,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Gebruik uw headset om RunnerUp te starten/pauzeren/hervatten</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Omzetten rust-stap met type afstand tot herstel-stap voor Interval-tabblad</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Omzetten rust-stap met type afstand tot herstel-stap voor Geavanceerde-tabblad</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exporteer de database naar sdcard (bijv. voor een upgrade)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importeer de database van sdcard (bijv. na een upgrade)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Coach om u te helpen uw doel te bereiken (als u uw doel reeds heeft ingesteld)</string>
@@ -262,8 +261,6 @@
   <string name="Add_repeat">Herhaling toevoegen</string>
   <string name="Discard">Verwerpen</string>
   <string name="Failed_to_create_workout">Het is niet gelukt om een training te creëren.</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Taal van audiobegeleiding</string>
   <string name="Website">Website</string>
   <string name="Automatic_upload">Automatische upload</string>

--- a/common/src/main/res/values-nl/array.xml
+++ b/common/src/main/res/values-nl/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mijlen</item>
     <item>Kilometers</item>
@@ -37,14 +37,6 @@
     <item>Orienteren</item>
     <item>Wandelen</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Nee</item>
-    <item>Ja</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nee</item>
-    <item>ja</item>
-  </string-array>
   <string-array name="types">
     <item>Tijd</item>
     <item>Afstand</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Man</item>
     <item>Vrouw</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Engels</item>
-    <item>Nederlands</item>
-    <item>Duits</item>
-    <item>Japans</item>
-    <item>Arabisch</item>
-    <item>Russisch</item>
-    <item>Spaans</item>
-    <item>Frans</item>
-    <item>Italiaans</item>
-    <item>Pools</item>
-    <item>Turks</item>
-    <item>Portugees</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-nl/strings.xml
+++ b/common/src/main/res/values-nl/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Leeftijd</string>
   <string name="edit">aanpassen</string>
   <string name="Synchronizing">Synchroniseren:</string>
-  <string name="synchronizing_feed">synchroniseren van de feed...</string>
+  <string name="synchronizing_feed">synchroniseren van de feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Tabel formaat</string>
   <string name="Clear_uploads">Uploads wissen</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Afwijzen</string>
   <string name="No_way">Absoluut niet</string>
   <string name="No">Nee</string>
-  <string name="Loading">Laden...</string>
+  <string name="Loading">Laden…</string>
   <string name="Saving">Opslaan</string>
-  <string name="Cancellingplease_wait">Annuleren...even geduld aub</string>
+  <string name="Cancellingplease_wait">Annuleren…even geduld aub</string>
   <string name="try_again_later">Probeer het later opnieuw!</string>
   <string name="Are_you_sure">Weet u het zeker?</string>
   <string name="Configure_audio_cues">Auditieve signalen instellen</string>

--- a/common/src/main/res/values-nl/strings.xml
+++ b/common/src/main/res/values-nl/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Gebruik uw headset om RunnerUp te starten/pauzeren/hervatten</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Omzetten rust-stap met type afstand tot herstel-stap voor Interval-tabblad</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Omzetten rust-stap met type afstand tot herstel-stap voor Geavanceerde-tabblad</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exporteer de database naar sdcard (bijv. voor een upgrade)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importeer de database van sdcard (bijv. na een upgrade)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Coach om u te helpen uw doel te bereiken (als u uw doel reeds heeft ingesteld)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Herhaling toevoegen</string>
   <string name="Discard">Verwijder</string>
   <string name="Failed_to_create_workout">Training maken gefaald</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Taal audiobegeleiding</string>
   <string name="Website">Website</string>
   <string name="Automatic_upload">Automatische upload</string>

--- a/common/src/main/res/values-pl/array.xml
+++ b/common/src/main/res/values-pl/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Mile</item>
     <item>Kilometry</item>
@@ -37,14 +37,6 @@
     <item>Bieg na orientację</item>
     <item>Chodzenie</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Nie</item>
-    <item>Tak</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>nie</item>
-    <item>tak</item>
-  </string-array>
   <string-array name="types">
     <item>Czas</item>
     <item>Dystans</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Mężczyzna</item>
     <item>Kobieta</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Angielski</item>
-    <item>Holenderski</item>
-    <item>Niemiecki</item>
-    <item>Japoński</item>
-    <item>Arabski</item>
-    <item>Rosyjski</item>
-    <item>Hiszpański</item>
-    <item>Francuski</item>
-    <item>Włoski</item>
-    <item>Polski</item>
-    <item>Turecki</item>
-    <item>Portugalski</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Użyj słuchawek do rozpoczynania/wstrzymania treningu</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Konwertuj interwał \"odpoczynek (dystans)\" na interwał \"regeneracja\" na zakładce \"Interwałowy\"</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Konwertuj interwał \"odpoczynek (dystans)\" na interwał \"regeneracja\" na zakładce \"Rozszerzony\"</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Eksportuj bazę danych na kartę SD (np. przed aktualizacjią)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importuj bazę danych z karty SD (np. po aktualizacji)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Trener wspomoże Cię w osiągnięciu założonego celu</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Dodaj powtórzenie</string>
   <string name="Discard">Anuluj</string>
   <string name="Failed_to_create_workout">Błąd przy zapisie treningu</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Język komunikatów</string>
   <string name="Website">Witryna</string>
   <string name="Automatic_upload">Autosynchronizacja</string>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -156,9 +156,9 @@
   <string name="Dismiss">Zamknij</string>
   <string name="No_way">No way</string>
   <string name="No">Nie</string>
-  <string name="Loading">Ładuje...</string>
+  <string name="Loading">Ładuje…</string>
   <string name="Saving">Zapisuje</string>
-  <string name="Cancellingplease_wait">Anuluje...</string>
+  <string name="Cancellingplease_wait">Anuluje…</string>
   <string name="try_again_later">spróbuj później</string>
   <string name="Are_you_sure">Jesteś pewien?</string>
   <string name="Configure_audio_cues">Konfiguruj wskazówki audio</string>
@@ -206,7 +206,7 @@
   <string name="Experimental_HRM_devices">Eksperymentalne urządzenia HRM</string>
   <string name="Experimental_features">Eksperymentalne funkcje</string>
   <string name="Mock_HRM_devices">Imituj urządzenie HRM</string>
-  <string name="About">O...</string>
+  <string name="About">O…</string>
   <string name="About_RunnerUp">O RunnerUp</string>
   <string name="Triggers">Wyzwalacze</string>
   <string name="Time_triggered_audio_cue">Wskazówki wyzwalane czasowo</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">Usuń trening</string>
   <string name="RunnerUp_workout">Trening RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">To jest trening, który możesz polubić.</string>
-  <string name="Share_workout">Podziel się treningiem...</string>
+  <string name="Share_workout">Podziel się treningiem…</string>
   <string name="New_audio_scheme">Nowy schemat wskazówek</string>
   <string name="Default">Domyślne</string>
   <string name="Notes_about_your_workout">Notatki</string>

--- a/common/src/main/res/values-pt-rBR/array.xml
+++ b/common/src/main/res/values-pt-rBR/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Milhas</item>
     <item>Quilômetros</item>
@@ -37,14 +37,6 @@
     <item>Orientação</item>
     <item>Caminhada</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>Não</item>
-    <item>Sim</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>não</item>
-    <item>sim</item>
-  </string-array>
   <string-array name="types">
     <item>Tempo</item>
     <item>Distância</item>
@@ -52,35 +44,5 @@
   <string-array name="sexes">
     <item>Masculino</item>
     <item>Feminino</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Inglês</item>
-    <item>Holandês</item>
-    <item>Alemão</item>
-    <item>Japonês</item>
-    <item>Árabe</item>
-    <item>Russo</item>
-    <item>Espanhol</item>
-    <item>Francês</item>
-    <item>Italiano</item>
-    <item>Polonês</item>
-    <item>Turco</item>
-    <item>Português</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -156,9 +156,9 @@
   <string name="Dismiss">Descartar</string>
   <string name="No_way">Nem pensar</string>
   <string name="No">Não</string>
-  <string name="Loading">Carregando...</string>
+  <string name="Loading">Carregando…</string>
   <string name="Saving">Guardar</string>
-  <string name="Cancellingplease_wait">Cancelando... por favor, espere</string>
+  <string name="Cancellingplease_wait">Cancelando… por favor, espere</string>
   <string name="try_again_later">tente novamente mais tarde!</string>
   <string name="Are_you_sure">Você tem certeza?</string>
   <string name="Configure_audio_cues">Configurar avisos de áudio</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">Excluir treinos</string>
   <string name="RunnerUp_workout">Exercício do RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Olá\nAqui está um exercício que eu acho que você pode gostar.</string>
-  <string name="Share_workout">Compartilhar exercício...</string>
+  <string name="Share_workout">Compartilhar exercício…</string>
   <string name="New_audio_scheme">Novo esquema de áudio</string>
   <string name="Default">Padrão</string>
   <string name="Notes_about_your_workout">Anotações sobre seu exercício</string>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Usar o seu headset para iniciar/pausar/recomeçar o RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Converter passada de descanso com tipo de distância para passada de recuperação, na aba Intervalo</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Converter passada de descanso com tipo de distância para passada de recuperação, na aba Avançado</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exporta banco de dados para o cartão SD (por exemplo, para atualização)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importar banco de dados do cartão SD (por exemplo, após atualização)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Treinador para ajudá-lo a atingir a meta (caso tenha definido a meta)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Adicionar repetição</string>
   <string name="Discard">Descartar</string>
   <string name="Failed_to_create_workout">Falha ao criar o exercício</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Idioma do aviso de áudio</string>
   <string name="Website">Site web</string>
   <string name="Automatic_upload">Envio automático</string>

--- a/common/src/main/res/values-pt/array.xml
+++ b/common/src/main/res/values-pt/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Milhas</item>
     <item>Quilómetros</item>

--- a/common/src/main/res/values-pt/strings.xml
+++ b/common/src/main/res/values-pt/strings.xml
@@ -105,7 +105,7 @@
   <string name="Darn">Raios!</string>
   <string name="No_way">Nem pensar</string>
   <string name="No">Não</string>
-  <string name="Loading">Carregando...</string>
+  <string name="Loading">Carregando…</string>
   <string name="Saving">Gravando</string>
   <string name="Are_you_sure">Tem certeza?</string>
   <string name="Downloadeditremove_workouts">Baixar/editar/apagar exercícios</string>

--- a/common/src/main/res/values-pt/strings.xml
+++ b/common/src/main/res/values-pt/strings.xml
@@ -129,8 +129,6 @@
   <string name="Save">Gravar</string>
   <string name="Add_step">Adicionar passo</string>
   <string name="Add_repeat">Adicionar repetição</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Website">Website</string>
   <string name="Automatic_upload">Carregar automaticamente</string>
   <string name="Live">Ao vivo</string>

--- a/common/src/main/res/values-ru-rRU/strings.xml
+++ b/common/src/main/res/values-ru-rRU/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Пользуйся кнопкой гарнитуры для пуска/остановки RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Для интервальной тренировки по дистанции переводить остановки в интервалы восстановления</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Для продвинутой тренировки по дистанции переводить </string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Экспорт базы данных на карту памяти (перед обновлением)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Импорт базы данных с карты памяти (после обновления)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Помощь голосового тренера в достижении целевых показателей тренировки (если выбран пульс/темп)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">+ Повторить</string>
   <string name="Discard">Отмена</string>
   <string name="Failed_to_create_workout">Ошибка при создании тренировки</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Голосовые схемы - язык</string>
   <string name="Website">Вебсайт</string>
   <string name="Automatic_upload">Автоматическая выгрузка</string>
@@ -291,7 +288,6 @@
   <string name="RunnerUp_workout">Тренировка RunnerUp:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Привет!\nВот тренировки. Я думаю ты можешь так же .</string>
   <string name="Share_workout">Опубликовать</string>
-  <string name="Not_much_to_say_at_this_point">Автору программы нечего сказать о этом пункте</string>
   <string name="New_audio_scheme">Новая голосовая схема</string>
   <string name="Default">Стандартная</string>
   <string name="Notes_about_your_workout">Примечания о этом занятии</string>

--- a/common/src/main/res/values-ru-rRU/strings.xml
+++ b/common/src/main/res/values-ru-rRU/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Возраст</string>
   <string name="edit">Настройка</string>
   <string name="Synchronizing">Синхронизация:</string>
-  <string name="synchronizing_feed">синхронизируем фитнес аккаунты...</string>
+  <string name="synchronizing_feed">синхронизируем фитнес аккаунты…</string>
   <string name="OK">ОК</string>
   <string name="Table_format">Табличное представление</string>
   <string name="Clear_uploads">Очистить загруженные</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Отклонить</string>
   <string name="No_way">Ни за что</string>
   <string name="No">Нет</string>
-  <string name="Loading">Загрузка...</string>
+  <string name="Loading">Загрузка…</string>
   <string name="Saving">Сохранение</string>
-  <string name="Cancellingplease_wait">Отмена... подождите</string>
+  <string name="Cancellingplease_wait">Отмена… подождите</string>
   <string name="try_again_later">попытайся позже</string>
   <string name="Are_you_sure">Уверен?</string>
   <string name="Configure_audio_cues">Настройка голосового сопровождения</string>
@@ -183,7 +183,7 @@
   <string name="Enable_RunnerUpLive">Включить RunnerUpLive</string>
   <string name="Headset_key_startstop">Кнопка гарнитуры старт/стоп</string>
   <string name="Activity_countdown">Отсчёт до начала тренировки</string>
-  <string name="Countdown_time_s">Отсчитывать время (c)</string>
+  <string name="Countdown_time_s">Отсчитывать время ©</string>
   <string name="Unit_preference">Единицы измерений</string>
   <string name="Auto_start_GPS">Автоматически включать GPS</string>
   <string name="Advanced_options">Продвинутые настройки</string>

--- a/common/src/main/res/values-ru/array.xml
+++ b/common/src/main/res/values-ru/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Мили</item>
     <item>Километры</item>
@@ -34,21 +34,8 @@
     <item>Бег</item>
     <item>Велосипед</item>
     <item>Прочее</item>
-  </string-array>
-  <string-array name="sportEntriesExperimental">
-    <item>Бег</item>
-    <item>Велосипед</item>
-    <item>Прочее</item>
     <item>Ориентирование</item>
     <item>Ходьба</item>
-  </string-array>
-  <string-array name="muteEntries">
-    <item>Нет</item>
-    <item>Да</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>Нет</item>
-    <item>Да</item>
   </string-array>
   <string-array name="types">
     <item>Время</item>
@@ -57,35 +44,5 @@
   <string-array name="sexes">
     <item>Мужской</item>
     <item>Женский</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Английский</item>
-    <item>Нидерландский</item>
-    <item>Немецкий</item>
-    <item>Японский</item>
-    <item>Арабский</item>
-    <item>Русский</item>
-    <item>Испанский</item>
-    <item>Французский</item>
-    <item>Итальянский</item>
-    <item>Польский</item>
-    <item>Турецкий</item>
-    <item>Португальский</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>Английский</item>
-    <item>Голландский</item>
-    <item>Немецкий</item>
-    <item>Японский</item>
-    <item>Арабский</item>
-    <item>Русский</item>
-    <item>Испанский</item>
-    <item>Французский</item>
-    <item>Итальянский</item>
-    <item>Польский</item>
-    <item>Турецкий</item>
-    <item>Португальский</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Возраст</string>
   <string name="edit">Настройка</string>
   <string name="Synchronizing">Синхронизация:</string>
-  <string name="synchronizing_feed">синхронизируем фитнес аккаунты...</string>
+  <string name="synchronizing_feed">синхронизируем фитнес аккаунты…</string>
   <string name="OK">ОК</string>
   <string name="Table_format">Табличное представление</string>
   <string name="Clear_uploads">Очистить загруженные</string>
@@ -156,9 +156,9 @@
   <string name="Dismiss">Отклонить</string>
   <string name="No_way">Ни за что</string>
   <string name="No">Нет</string>
-  <string name="Loading">Загрузка...</string>
+  <string name="Loading">Загрузка…</string>
   <string name="Saving">Сохранение</string>
-  <string name="Cancellingplease_wait">Отмена... подождите</string>
+  <string name="Cancellingplease_wait">Отмена… подождите</string>
   <string name="try_again_later">попытайся позже</string>
   <string name="Are_you_sure">Уверен?</string>
   <string name="Configure_audio_cues">Настройка голосового сопровождения</string>
@@ -183,7 +183,7 @@
   <string name="Enable_RunnerUpLive">Включить Live</string>
   <string name="Headset_key_startstop">Кнопка гарнитуры старт/стоп</string>
   <string name="Activity_countdown">Отсчёт до начала тренировки</string>
-  <string name="Countdown_time_s">Отсчитывать время (c)</string>
+  <string name="Countdown_time_s">Отсчитывать время ©</string>
   <string name="Unit_preference">Единицы измерений</string>
   <string name="Auto_start_GPS">Автоматически включать GPS</string>
   <string name="Advanced_options">Продвинутые настройки</string>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Пользуйся кнопкой гарнитуры для пуска/остановки RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Для интервальной тренировки по дистанции переводить остановки в интервалы восстановления</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Для продвинутой тренировки по дистанции переводить </string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Экспорт базы данных на карту памяти (перед обновлением)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Импорт базы данных с карты памяти (после обновления)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Помощь голосового тренера в достижении целевых показателей тренировки (если выбран пульс/темп)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">+ Повторить</string>
   <string name="Discard">Отмена</string>
   <string name="Failed_to_create_workout">Ошибка при создании тренировки</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Голосовые схемы - язык</string>
   <string name="Website">Вебсайт</string>
   <string name="Automatic_upload">Автоматическая выгрузка</string>

--- a/common/src/main/res/values-sv/array.xml
+++ b/common/src/main/res/values-sv/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string-array name="unitEntries">
     <item>Miles</item>
     <item>Kilometer</item>
@@ -44,45 +44,5 @@
   <string-array name="sexes">
     <item>Man</item>
     <item>Kvinna</item>
-  </string-array>
-  <!--Audio cue languages-->
-  <string-array name="cueLanguageNames">
-    <item>Svenska</item>
-    <item>Engelska</item>
-    <item>Holländska</item>
-    <item>Tyska</item>
-    <item>Japanska</item>
-    <item>Arabiska</item>
-    <item>Ryska</item>
-    <item>Spanska</item>
-    <item>Franska</item>
-    <item>Italienska</item>
-    <item>Polska</item>
-    <item>Turkiska</item>
-    <item>Portugisiska</item>
-    <item>Norska</item>
-    <item>Katalanska</item>
-    <item>Indonesiska</item>
-    <item>Litauiska</item>
-  </string-array>
-  <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes">
-    <item>sv</item>
-    <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
-    <item>ar</item>
-    <item>ru</item>
-    <item>es</item>
-    <item>fr</item>
-    <item>it</item>
-    <item>pl</item>
-    <item>tr</item>
-    <item>pt</item>
-    <item>nb</item>
-    <item>ca</item>
-    <item>id</item>
-    <item>lt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -167,7 +167,6 @@
   <string name="Use_your_headset_to_startpauseresume_RunnerUp">Använd dina lurar för att starta/pausa/återuppta RunnerUp</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Intervaltab">Konvertera vilosteg med distans typ till återhämtningssteg för Interval-tabben</string>
   <string name="Convert_reststep_with_type_distance_to_recoverystep_for_Advancedtab">Konvertera vilosteg med distans typ till återhämtningssteg för Avancerat-tabben</string>
-  <string name="mm31kz513sg5">mm(31);kz(5,13);sg(5)</string>
   <string name="Export_database_to_sdcard_eg_for_upgrade">Exportera databas till sdkort (t.ex. före uppgradering)</string>
   <string name="Import_database_from_sdcard_eg_after_upgrade">Importera databas från sdkort (t.ex. efter uppgradering)</string>
   <string name="Coach_to_help_you_reach_target_if_having_set_target">Coach för att hjälpa dig nå målet (om mål är satt)</string>
@@ -270,8 +269,6 @@
   <string name="Add_repeat">Lägg till repetition</string>
   <string name="Discard">Ta bort</string>
   <string name="Failed_to_create_workout">Kunde inte skapa träningspass</string>
-  <string name="_sign_plus">+</string>
-  <string name="_sign_minus">-</string>
   <string name="Audio_cue_language">Språk för ljudmedelanden</string>
   <string name="Website">Hemsida</string>
   <string name="Automatic_upload">Automatisk uppladdning</string>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -198,8 +198,8 @@
   <string name="Step_countdown_time_s">Nedräkningssteg (s)</string>
   <string name="Smooth_pace_graph">Utjämning tempograf</string>
   <string name="Smooth_pace_filters">Utjämningsfilter tempo (s)</string>
-  <string name="Poll_interval_ms">Uppdaterings intervall (ms)</string>
-  <string name="Poll_distance_m">Uppdaterings distans (m)</string>
+  <string name="Poll_interval_ms">GPS Uppdaterings intervall (ms)</string>
+  <string name="Poll_distance_m">GPS Uppdaterings distans (m)</string>
   <string name="Export">Exportera</string>
   <string name="Import">Importera</string>
   <string name="Experimental_HRM_devices">Experimentella pulsmätare</string>
@@ -300,4 +300,12 @@
   <string name="Map_not_available_on_Froyo">Karta inte tillgänglig i Froyo</string>
   <string name="No_feed_to_show">Inget flöde att visa</string>
   <string name="Unused_currently">Används ej för närvarande</string>
+  <string name="Maintenance">Underhåll</string>
+  <string name="Mapbox_default_style">Mapbox stil</string>
+  <string name="Recording">Inspelning</string>
+  <string name="RunningFreeOnlinePasswordNotice">Notera: Använd den hemliga nyckel som lösenord från Add > Sync Training > SportTracks.</string>
+  <string name="Sensors">Sensorer</string>
+  <string name="formatting_date_at_time">%1$s %2$s</string>
+  <string name="latest_feed_click_to_refresh">Senaste flöde (klicka för att uppdatera)</string>
+  <string name="Adjust_altitude">Justera GPS höjd till geoid (EGM96)</string>
 </resources>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -118,7 +118,7 @@
   <string name="Age">Ålder</string>
   <string name="edit">redigera</string>
   <string name="Synchronizing">Synkroniserar:</string>
-  <string name="synchronizing_feed">synkroniserar flöde...</string>
+  <string name="synchronizing_feed">synkroniserar flöde…</string>
   <string name="OK">Ok</string>
   <string name="Table_format">Tabellformat</string>
   <string name="Clear_uploads">Rensa uppladdningar</string>
@@ -149,16 +149,16 @@
   <string name="Edit_step">Redigera steg</string>
   <string name="Create_new_audio_cue_scheme">Skapa nytt schema för ljudmeddelande</string>
   <string name="Great">Kanon!</string>
-  <string name="OK_darn">Ok... typiskt!</string>
+  <string name="OK_darn">Ok… typiskt!</string>
   <string name="Yes">Ja</string>
   <string name="Create">Skapa</string>
   <string name="Darn">Nedrans!</string>
   <string name="Dismiss">Avslå</string>
   <string name="No_way">Inte alls</string>
   <string name="No">Nej</string>
-  <string name="Loading">Laddar...</string>
+  <string name="Loading">Laddar…</string>
   <string name="Saving">Sparar</string>
-  <string name="Cancellingplease_wait">Avbryter... vänta</string>
+  <string name="Cancellingplease_wait">Avbryter… vänta</string>
   <string name="try_again_later">försök igen senare!</string>
   <string name="Are_you_sure">Är du säker?</string>
   <string name="Configure_audio_cues">Konfigurera ljudmeddelanden</string>
@@ -290,7 +290,7 @@
   <string name="Delete_workout">Ta bort träningspass</string>
   <string name="RunnerUp_workout">RunnerUp träningspass:</string>
   <string name="HinHere_is_a_workout_I_think_you_might_like">Hej\nHär är ett träningspass jag tror du skulle gilla.</string>
-  <string name="Share_workout">Dela träningspass...</string>
+  <string name="Share_workout">Dela träningspass…</string>
   <string name="New_audio_scheme">Nytt ljudschema</string>
   <string name="Default">Standard</string>
   <string name="Notes_about_your_workout">Anteckningar om ditt träningspass</string>

--- a/common/src/main/res/values-tr/array.xml
+++ b/common/src/main/res/values-tr/array.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Note: keep in same order as DB.INTENSITY-->
   <!--same order as above, same values as Intensity-->
   <!--same order as above, same values as Dimension-->

--- a/common/src/main/res/values/array.xml
+++ b/common/src/main/res/values/array.xml
@@ -102,10 +102,10 @@
     <item>Swedish</item>
     <item>Turkish</item>
     <item>Portuguese</item>
-      <item>Norwegian</item>
-      <item>Catalan</item>
-      <item>Indonesian</item>
-      <item>Lithuanian</item>
+    <item>Norwegian</item>
+    <item>Catalan</item>
+    <item>Indonesian</item>
+    <item>Lithuanian</item>
   </string-array>
   <!--Note: keep in same order as languagesNames-->
   <string-array name="cueLanguageCodes" tools:ignore="InconsistentArrays">
@@ -124,8 +124,8 @@
     <item>tr</item>
     <item>pt</item>
     <item>nb</item>
-      <item>ca</item>
-      <item>id</item>
-      <item>lt</item>
+    <item>ca</item>
+    <item>id</item>
+    <item>lt</item>
   </string-array>
 </resources>

--- a/common/src/main/res/values/array.xml
+++ b/common/src/main/res/values/array.xml
@@ -70,14 +70,6 @@
     <item>Orienteering</item>
     <item>Walking</item>
   </string-array>
-  <string-array name="muteEntries">
-    <item>No</item>
-    <item>Yes</item>
-  </string-array>
-  <string-array name="muteValues">
-    <item>no</item>
-    <item>yes</item>
-  </string-array>
   <string-array name="types">
     <item>Time</item>
     <item>Distance</item>
@@ -87,45 +79,45 @@
     <item>Female</item>
   </string-array>
   <!--Audio cue languages-->
-  <string-array name="cueLanguageNames" tools:ignore="InconsistentArrays">
+  <string-array name="cueLanguageNames" translatable="false">
     <item>English</item>
-    <item>Dutch</item>
-    <item>German</item>
-    <item>Japanese</item>
-    <item>Arabic</item>
-    <item>Russian</item>
-    <item>Spanish</item>
-    <item>French</item>
-    <item>Italian</item>
-    <item>Polish</item>
-    <item>Hungarian</item>
-    <item>Swedish</item>
-    <item>Turkish</item>
-    <item>Portuguese</item>
-    <item>Norwegian</item>
-    <item>Catalan</item>
-    <item>Indonesian</item>
-    <item>Lithuanian</item>
+    <item>العَرَبِيَّة‎‎</item>
+    <item>Bahasa Indonesia</item>
+    <item>Català</item>
+    <item>Deutsch</item>
+    <item>Español</item>
+    <item>Français</item>
+    <item>Italiano</item>
+    <item>日本語</item>
+    <item>Lietuvių</item>
+    <item>Magyar</item>
+    <item>Nederlands</item>
+    <item>Norska</item>
+    <item>Polski</item>
+    <item>Português</item>
+    <item>Русский</item>
+    <item>Svenska</item>
+    <item>Türkçe</item>
   </string-array>
   <!--Note: keep in same order as languagesNames-->
-  <string-array name="cueLanguageCodes" tools:ignore="InconsistentArrays">
+  <string-array name="cueLanguageCodes" translatable="false">
     <item>en</item>
-    <item>nl</item>
-    <item>de</item>
-    <item>ja</item>
     <item>ar</item>
-    <item>ru</item>
+    <item>id</item>
+    <item>ca</item>
+    <item>de</item>
     <item>es</item>
     <item>fr</item>
     <item>it</item>
-    <item>pl</item>
+    <item>ja</item>
+    <item>lt</item>
     <item>hu</item>
+    <item>nl</item>
+    <item>nb</item>
+    <item>pl</item>
+    <item>pt</item>
+    <item>ru</item>
     <item>sv</item>
     <item>tr</item>
-    <item>pt</item>
-    <item>nb</item>
-    <item>ca</item>
-    <item>id</item>
-    <item>lt</item>
-  </string-array>
+   </string-array>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -312,4 +312,5 @@
   <string name="Recording">Recording</string>
   <string name="Sensors">Sensors</string>
   <string name="Maintenance">Maintenance</string>
+  <string name="latest_feed_click_to_refresh">Latest feed (click to refresh)</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@
   <string name="Unit_preference">Unit preference</string>
   <string name="Auto_start_GPS">Auto start GPS</string>
   <string name="Advanced_options">Advanced options</string>
-  <string name="Mapbox_default_style">Mapbox default style</string>
+  <string name="Mapbox_default_style">Mapbox style</string>
   <string name="RunnerUp_live_address">RunnerUp live address</string>
   <string name="Autopause_after_s">Autopause after (s)</string>
   <string name="Autopause_min_pace_minkm">Autopause min pace (min/km)</string>
@@ -204,7 +204,7 @@
   <string name="Smooth_pace_filters">Smooth pace filter (s)</string>
   <string name="Poll_interval_ms">GPS Poll interval (ms)</string>
   <string name="Poll_distance_m">GPS Poll distance (m)</string>
-  <string name="Adjust_altitude">Adjust altitude to geoid (EGM96)</string>
+  <string name="Adjust_altitude">Adjust GPS altitude to geoid (EGM96)</string>
   <string name="Export">Export</string>
   <string name="Import">Import</string>
   <string name="Experimental_HRM_devices">Experimental HRM devices</string>
@@ -307,7 +307,7 @@
   <string name="No_feed_to_show">No feed to show</string>
   <string name="Unused_currently">Unused currently.</string>
   <string name="Unknown">Unknown</string>
-  <string name="RunningFreeOnlinePasswordNotice">Note: As password, use the \"secret key\" set on website under Add > Sync Training > SportTracks.</string>
+  <string name="RunningFreeOnlinePasswordNotice">Note: Use the \"secret key\" as password set on website under Add > Sync Training > SportTracks.</string>
   <string name="GoToWebsite">Go to website</string>
   <string name="Recording">Recording</string>
   <string name="Sensors">Sensors</string>


### PR DESCRIPTION
Cleanup of resources in translations

Remove now unused mute arrays
set cue languages as translate=false, use original in array
Lint check and adjustments
Sync with Transifex. Only Swedish is 100%