### PR TITLE
Sport type handling cleanup

### DIFF
--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -37,6 +37,7 @@ import org.runnerup.export.util.Part;
 import org.runnerup.export.util.StringWritable;
 import org.runnerup.export.util.SyncHelper;
 import org.runnerup.util.Bitfield;
+import org.runnerup.view.FeedActivity;
 import org.runnerup.workout.Sport;
 
 import java.io.BufferedInputStream;
@@ -316,17 +317,16 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
     }
 
     private static URL getSportEndPoint(Sport s) throws Exception {
-        if (s == Sport.RUNNING) return new URL(RUN_ENDPOINT);
-        else if (s == Sport.BIKING) return new URL(BIKE_ENDPOINT);
-        else if (s == Sport.ORIENTEERING) return new URL(RUN_ENDPOINT);
-        else if (s == Sport.WALKING) return new URL(WALK_ENDPOINT);
+        if (s.IsWalking()) return new URL(WALK_ENDPOINT);
+        else if (s.IsRunning()) return new URL(RUN_ENDPOINT);
+        else if (s.IsCycling()) return new URL(BIKE_ENDPOINT);
         return null;
     }
 
 
     private JSONObject createRun(JSONObject ref, JSONObject runObj) throws Exception {
-        int sport = runObj.optInt("sport", DB.ACTIVITY.SPORT_OTHER);
-        URL url = getSportEndPoint(Sport.valueOf(sport));
+        Sport sport = Sport.valueOf(runObj.optInt("sport", DB.ACTIVITY.SPORT_OTHER));
+        URL url = getSportEndPoint(sport);
         if (url == null) {
             /* only running/biking/walking and similar are supported */
             return null;
@@ -356,7 +356,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
         Part<?> parts[] = new Part<?>[list.size()];
         list.toArray(parts);
 
-        URL url2 = new URL(sport == DB.ACTIVITY.SPORT_BIKING ? BIKE_ENDPOINT : RUN_ENDPOINT);
+        URL url2 = new URL(sport.IsCycling() ? BIKE_ENDPOINT : RUN_ENDPOINT);
         return createObj(url2, parts);
     }
 

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -399,7 +399,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
                     c.put(FEED.ACCOUNT_ID, getId());
                     c.put(FEED.EXTERNAL_ID, e.getString("entityId"));
                     c.put(FEED.FEED_TYPE, FEED.FEED_TYPE_ACTIVITY);
-                    c.put(FEED.FEED_SUBTYPE, DB.ACTIVITY.SPORT_RUNNING); // TODO
+                    c.put(FEED.FEED_SUBTYPE, DB.ACTIVITY.SPORT_RUNNING); // TODO, dummy type
                     c.put(FEED.START_TIME, df.parse(e.getString("entityDate")).getTime());
                     if (e.has("payload")) {
                         JSONObject p = e.getJSONObject("payload");
@@ -445,7 +445,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
                     c.put(FEED.ACCOUNT_ID, getId());
                     c.put(FEED.EXTERNAL_ID, e.getString("entityId"));
                     c.put(FEED.FEED_TYPE, FEED.FEED_TYPE_ACTIVITY);
-                    c.put(FEED.FEED_SUBTYPE, DB.ACTIVITY.SPORT_RUNNING); // TODO
+                    c.put(FEED.FEED_SUBTYPE, DB.ACTIVITY.SPORT_RUNNING); // TODO, dummy type
                     c.put(FEED.START_TIME, df.parse(e.getString("entityDate")).getTime());
                     if (e.has("payload")) {
                         JSONObject p = e.getJSONObject("payload");

--- a/app/src/org/runnerup/export/format/GoogleFitData.java
+++ b/app/src/org/runnerup/export/format/GoogleFitData.java
@@ -29,6 +29,7 @@ import org.runnerup.R;
 import org.runnerup.export.GoogleFitSynchronizer;
 import org.runnerup.export.util.SyncHelper;
 import org.runnerup.util.JsonWriter;
+import org.runnerup.workout.Sport;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -49,15 +50,15 @@ public class GoogleFitData {
     public static final int SECONDS_TO_MILLIS = 1000;
     public static final int MICRO_TO_NANOS = 1000000;
     public static final int SECONDS_TO_NANOS = 1000000000;
-    private static final Map<Integer, Integer> ACTIVITY_TYPE;
+    private static final Map<Sport, Integer> ACTIVITY_TYPE;
     static {
-        Map<Integer, Integer> aMap = new HashMap<Integer, Integer>();
+        Map<Sport, Integer> aMap = new HashMap<>();
         // sports list can be found at https://developers.google.com/fit/rest/v1/reference/activity-types
-        aMap.put(DB.ACTIVITY.SPORT_RUNNING, 8);
-        aMap.put(DB.ACTIVITY.SPORT_BIKING, 1);
-        aMap.put(DB.ACTIVITY.SPORT_OTHER, 4);
-        aMap.put(DB.ACTIVITY.SPORT_ORIENTEERING, 4); //not supported so considering unknown
-        aMap.put(DB.ACTIVITY.SPORT_WALKING, 7);
+        aMap.put(Sport.RUNNING, 8);
+        aMap.put(Sport.BIKING, 1);
+        aMap.put(Sport.OTHER, 4);
+        aMap.put(Sport.ORIENTEERING, 4); //not supported so considering unknown
+        aMap.put(Sport.WALKING, 7);
         ACTIVITY_TYPE = Collections.unmodifiableMap(aMap);
     }
     private static final Map<DataSourceType, List<DataTypeField>> DATA_TYPE_FIELDS;
@@ -248,7 +249,7 @@ public class GoogleFitData {
             w.name("value");
             w.beginArray();
             w.beginObject();
-            w.name("intVal").value(ACTIVITY_TYPE.get(cursor.getInt(2)));
+            w.name("intVal").value(ACTIVITY_TYPE.get(Sport.valueOf((cursor.getInt(2)))));
             w.endObject();
             w.endArray();
             w.name("rawTimestampNanos").value(startTime);
@@ -426,7 +427,7 @@ public class GoogleFitData {
             w.name("endTimeMillis").value(endTime);
             w.name("application");
             addApplicationObject(w);
-            w.name("activityType").value(ACTIVITY_TYPE.get(cursor.getInt(cursor.getColumnIndex(DB.ACTIVITY.SPORT))));
+            w.name("activityType").value(ACTIVITY_TYPE.get(Sport.valueOf(cursor.getInt(cursor.getColumnIndex(DB.ACTIVITY.SPORT)))));
             w.endObject();
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/org/runnerup/export/format/RunalyzePost.java
+++ b/app/src/org/runnerup/export/format/RunalyzePost.java
@@ -21,6 +21,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
 
 import org.runnerup.common.util.Constants;
+import org.runnerup.workout.Sport;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -289,21 +290,19 @@ public class RunalyzePost {
      * |  5 | Other
      * </pre>
      *
-     * @param sport The sport as used in runnerup
+     * @param dbValue The sport as used in runnerup
      * @return The id of the sport in a string
      */
-    public String runnerupSport2RunalyzeSport(int sport) {
-        switch(sport) {
-            case Constants.DB.ACTIVITY.SPORT_RUNNING:
-                return "1";
-            case Constants.DB.ACTIVITY.SPORT_BIKING:
-                return "3";
-            case Constants.DB.ACTIVITY.SPORT_OTHER:
-            case Constants.DB.ACTIVITY.SPORT_ORIENTEERING:
-            case Constants.DB.ACTIVITY.SPORT_WALKING:
-            default:
-                return "5";
+    public String runnerupSport2RunalyzeSport(int dbValue) {
+        Sport sport = Sport.valueOf(dbValue);
+        if (sport.IsRunning()) {
+            return "1";
         }
+        if (sport.IsCycling()) {
+            return "3";
+        }
+
+        return "5";
     }
 
     /**
@@ -321,22 +320,16 @@ public class RunalyzePost {
      * |  8 | Warm-up            | WU   |       1 |
      * </pre>
      *
-     * @param sport The sport id used in runnerup
+     * @param dbValue The sport id used in runnerup
      * @return The sport id for runalyze in a string
      */
-    public String runnerupSport2RunalyzeType(int sport) {
-        switch(sport) {
-            case Constants.DB.ACTIVITY.SPORT_RUNNING:
-                return "1";
-            case Constants.DB.ACTIVITY.SPORT_BIKING:
-            case Constants.DB.ACTIVITY.SPORT_OTHER:
-            case Constants.DB.ACTIVITY.SPORT_ORIENTEERING:
-            case Constants.DB.ACTIVITY.SPORT_WALKING:
-            default:
-                return "";
+    public String runnerupSport2RunalyzeType(int dbValue) {
+        Sport sport = Sport.valueOf(dbValue);
+        if (sport.IsRunning()) {
+            return "1";
         }
+        return "";
     }
-
     /**
      * <em>Runalyze</em> calculates the calories using the table of sports. By default they
      * are using this:
@@ -348,24 +341,21 @@ public class RunalyzePost {
      * |  4 | Gymnastics |  280 |
      * |  5 | Other      |  500 |
      * </pre>
-     * @param sport The sport id used in runnerup
+     * @param dbValue The sport id used in runnerup
      * @param seconds The time of the activity for the calculation
      * @return The kCal used in string
      */
-    public String calculateKCal(int sport, long seconds) {
-        switch(sport) {
-            case Constants.DB.ACTIVITY.SPORT_RUNNING:
-                return Integer.toString(Math.round((880.0F/3600.0F) * seconds));
-            case Constants.DB.ACTIVITY.SPORT_BIKING:
-                return Integer.toString(Math.round((770.0F/3600.0F) * seconds));
-            case Constants.DB.ACTIVITY.SPORT_OTHER:
-            case Constants.DB.ACTIVITY.SPORT_ORIENTEERING:
-            case Constants.DB.ACTIVITY.SPORT_WALKING:
-            default:
-                return Integer.toString(Math.round((500.0F/3600.0F) * seconds));
+    public String calculateKCal(int dbValue, long seconds) {
+        Sport sport = Sport.valueOf(dbValue);
+        if (sport.IsRunning()) {
+            return Integer.toString(Math.round((880.0F / 3600.0F) * seconds));
         }
+        if (sport.IsCycling()) {
+            return Integer.toString(Math.round((770.0F / 3600.0F) * seconds));
+        }
+        //Constants.DB.ACTIVITY.SPORT_OTHER:
+        return Integer.toString(Math.round((500.0F / 3600.0F) * seconds));
     }
-
     /**
      * Method that writes all the fields that are related to the activity information.
      * @param activityId The activity id to export

--- a/app/src/org/runnerup/export/format/TCX.java
+++ b/app/src/org/runnerup/export/format/TCX.java
@@ -24,8 +24,10 @@ import android.location.Location;
 import android.os.Build;
 import android.util.Pair;
 
+import org.runnerup.common.util.Constants;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.util.KXmlSerializer;
+import org.runnerup.view.FeedActivity;
 import org.runnerup.workout.Sport;
 
 import java.io.IOException;
@@ -104,16 +106,14 @@ public class TCX {
             } else {
                 // TCX supports only these 3 sports...(cf http://www8.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd)
                 sport = Sport.valueOf(cursor.getInt(3));
-                switch (sport.getDbValue()) {
-                    case DB.ACTIVITY.SPORT_RUNNING:
-                        mXML.attribute("", "Sport", "Running");
-                        break;
-                    case DB.ACTIVITY.SPORT_BIKING:
-                        mXML.attribute("", "Sport", "Biking");
-                        break;
-                    default:
-                        mXML.attribute("", "Sport", "Other");
-                        break;
+                if (sport.IsRunning()) {
+                    mXML.attribute("", "Sport", "Running");
+                }
+                else if (sport.IsCycling()) {
+                    mXML.attribute("", "Sport", "Biking");
+                }
+                else {
+                    mXML.attribute("", "Sport", "Other");
                 }
             }
             mXML.startTag("", "Id");

--- a/app/src/org/runnerup/workout/Sport.java
+++ b/app/src/org/runnerup/workout/Sport.java
@@ -63,4 +63,17 @@ public enum Sport {
                 return OTHER;
         }
     }
+
+    public boolean IsWalking() {
+        return dbValue == DB.ACTIVITY.SPORT_WALKING;
+    }
+
+    public boolean IsRunning() {
+        return dbValue == DB.ACTIVITY.SPORT_RUNNING ||
+                dbValue == DB.ACTIVITY.SPORT_ORIENTEERING;
+    }
+
+    public boolean IsCycling() {
+        return dbValue == DB.ACTIVITY.SPORT_BIKING;
+    }
 }


### PR DESCRIPTION
Fixes that Orieenteering is handled as Running rather than Other in .tcx, Google Fit
The main benefit is though a cleanup in the handling of the raw dbValues like DB.ACTIVITY.SPORT_RUNNING
The enabling of sporttypes had a big uncertainity here, many manual checks (the cleanup was partial, I had done a little separately that is now separated)

As there is more or less one-to-one mapping dbValue to Sport, it is still not easy to add new sporttypes, but at least the db value is checked.