### PR TITLE
Hide preferencescreen for for map/graph on Froyo, not available there

### DIFF
--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -85,6 +85,8 @@ public class SettingsActivity extends PreferenceActivity
         //Geoid correction is not included in Froyo
         if (BuildConfig.FLAVOR.equals("froyo")) {
             getPreferenceManager().findPreference(res.getString(R.string.pref_altitude_adjust)).setEnabled(false);
+            getPreferenceScreen().removePreference(getPreferenceManager().findPreference("map_preferencescreen"));
+            getPreferenceScreen().removePreference(getPreferenceManager().findPreference("graph_preferencescreen"));
         }
 
         if (!hasHR(this)) {


### PR DESCRIPTION
Should be included in next release