### PR TITLE
Button visual refresh

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -73,20 +73,16 @@
 
 		<activity android:name=".view.SettingsActivity"/>
 
-		<activity android:name=".view.AudioCueSettingsActivity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".view.AudioCueSettingsActivity"/>
 
 		<activity android:name=".view.DetailActivity"
-			android:configChanges="orientation|screenSize|uiMode"
-		    android:theme="@style/Theme.AppCompat" />
+			android:configChanges="orientation|screenSize|uiMode" />
 
 		<activity android:name=".view.HistoryActivity"/>
 
-		<activity android:name=".view.AccountListActivity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".view.AccountListActivity"/>
 
-		<activity android:name=".view.AccountActivity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".view.AccountActivity"/>
 
 		<activity android:name=".view.UploadActivity"/>
 
@@ -116,14 +112,11 @@
             android:grantUriPermissions="true"
             tools:ignore="ExportedContentProvider" />
 
-		<activity android:name=".export.oauth2client.OAuth2Activity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".export.oauth2client.OAuth2Activity"/>
 
-		<activity android:name=".view.HRSettingsActivity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".view.HRSettingsActivity"/>
 
-		<activity android:name=".view.HRZonesActivity"
-			android:theme="@style/Theme.AppCompat" />
+		<activity android:name=".view.HRZonesActivity"/>
 
 		<service android:name=".tracker.Tracker" />
 		<service android:name=".export.RunnerUpLiveSynchronizer$LiveService" />

--- a/app/res/drawable/btn_blue.xml
+++ b/app/res/drawable/btn_blue.xml
@@ -22,18 +22,7 @@
                 android:startColor="#112244"
                 android:endColor="#001122"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
     <item android:state_enabled="false">
@@ -42,18 +31,7 @@
                 android:startColor="#777777"
                 android:endColor="#171717"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 	<item>
@@ -62,18 +40,7 @@
                 android:startColor="#113366"
                 android:endColor="#001122"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 </selector>

--- a/app/res/drawable/btn_green.xml
+++ b/app/res/drawable/btn_green.xml
@@ -22,18 +22,7 @@
                 android:startColor="#15743C"
                 android:endColor="#1b5934"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
     <item android:state_enabled="false">
@@ -42,18 +31,7 @@
                 android:startColor="#777777"
                 android:endColor="#171717"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 	<item>
@@ -62,18 +40,7 @@
                 android:startColor="#7fb883"
                 android:endColor="#1b5934"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 </selector>

--- a/app/res/drawable/btn_grey.xml
+++ b/app/res/drawable/btn_grey.xml
@@ -22,18 +22,7 @@
                 android:startColor="#818284"
                 android:endColor="#2b2c2d"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
     <item android:state_enabled="false">
@@ -42,18 +31,7 @@
                 android:startColor="#777777"
                 android:endColor="#171717"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 	<item>
@@ -62,18 +40,7 @@
                 android:startColor="#d8d9db"
                 android:endColor="#2b2c2d"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 </selector>

--- a/app/res/drawable/btn_red.xml
+++ b/app/res/drawable/btn_red.xml
@@ -22,18 +22,7 @@
                 android:startColor="#7b2641"
                 android:endColor="#ab373a"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
     <item android:state_enabled="false">
@@ -42,18 +31,7 @@
                 android:startColor="#777777"
                 android:endColor="#171717"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 	<item>
@@ -62,18 +40,7 @@
                 android:startColor="#ab5671"
                 android:endColor="#ab373a"
                 android:angle="270" />
-            <stroke
-                android:width="2dp"
-                android:color="#777777" />
-          <corners android:bottomRightRadius="15dp"
-                   android:bottomLeftRadius="15dp"
-                   android:topRightRadius="15dp"
-                   android:topLeftRadius="15dp"/>
-            <padding
-                android:left="10dp"
-                android:top="10dp"
-                android:right="10dp"
-                android:bottom="10dp" />
+            <corners android:radius="5dp"/>
         </shape>
     </item>
 </selector>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -17,8 +17,4 @@
   -->
 <resources>
      <color name="black">#000</color>
-     <color name="blue">#00f</color>
-     <color name="red">#f00</color>
-     <color name="green">#0f8</color>
-     <color name="workoutbg">#171717</color>
 </resources>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -26,31 +26,13 @@
             <item name="colorAccent">@color/colorAccent</item>
          -->
     </style>
-<style name="ButtonText" parent="AppTheme">
-        <item name="android:layout_width">fill_parent</item>
-        <item name="android:layout_height">wrap_content</item>
+    <style name="ButtonText" parent="Widget.AppCompat.Button.Colored">
         <item name="android:textColor">@color/btn_text_color</item>
-        <item name="android:gravity">center</item>
         <item name="android:layout_margin">3dp</item>
         <item name="android:textSize">20sp</item>
-        <item name="android:textStyle">bold</item>
-        <item name="android:shadowColor">#000000</item>
-        <item name="android:shadowDx">1</item>
-        <item name="android:shadowDy">1</item>
-        <item name="android:shadowRadius">2</item>
-</style>
-<style name="ButtonTextGrey" parent="AppTheme">
-    <item name="android:layout_width">fill_parent</item>
-    <item name="android:layout_height">wrap_content</item>
-    <item name="android:gravity">center</item>
+    </style>
+<style name="ButtonTextGrey" parent="ButtonText">
     <item name="android:textColor">#000000</item>
-    <item name="android:layout_margin">3dp</item>
-    <item name="android:textSize">20sp</item>
-    <item name="android:textStyle">bold</item>
-    <item name="android:shadowColor">#222222</item>
-    <item name="android:shadowDx">1</item>
-    <item name="android:shadowDy">1</item>
-    <item name="android:shadowRadius">2</item>
 </style>
 <style name="RunHeader" parent="AppTheme">
     <item name="android:layout_width">0dp</item>
@@ -58,7 +40,7 @@
     <item name="android:layout_weight">1</item>
     <item name="android:textColor">@android:color/white</item>
     <item name="android:textSize">15sp</item>
-    <item name="android:textStyle">bold|italic</item>
+    <item name="android:textStyle">italic</item>
 </style>
 <style name="RunInfo" parent="AppTheme">
     <item name="android:layout_width">0dp</item>
@@ -67,7 +49,6 @@
     <item name="android:gravity">right</item>
     <item name="android:textColor">@android:color/white</item>
     <item name="android:textSize">20sp</item>
-    <item name="android:textStyle">bold</item>
 </style>
 <style name="FeedDateHeader" parent="AppTheme">
     <item name="android:layout_width">fill_parent</item>
@@ -75,7 +56,6 @@
     <item name="android:layout_margin">10dp</item>
     <item name="android:textColor">@android:color/white</item>
     <item name="android:textSize">20sp</item>
-    <item name="android:textStyle">bold</item>
 </style>
 <style name="FeedActivitySource" parent="AppTheme">
     <item name="android:layout_width">fill_parent</item>


### PR DESCRIPTION
Using AppCompat buttons, removing borders, limiting radius.
The app looks a little more like a standard app

The interface is just changed slightly. Intention was to make a bigger refresh (before changing "start tabs"), but there are too many limitations before 4.0.
The title spinners are a bigger issue, the radius (now 5, before 15dp) is an adjustment the spinners (radius 10dp?)