### PR TITLE
Lint: extractNativeLibs to reduce app size downloaded/stored

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -19,11 +19,7 @@
 	package="org.runnerup"
 	xmlns:tools="http://schemas.android.com/tools">
 
-        <uses-sdk
-            android:minSdkVersion="15"
-			tools:ignore="GradleOverrides" />
-
-		<uses-feature
+ 		<uses-feature
   			android:glEsVersion="0x00020000"
   			android:required="true"/>
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -20,7 +20,8 @@
 	xmlns:tools="http://schemas.android.com/tools">
 
         <uses-sdk
-            android:minSdkVersion="15" />
+            android:minSdkVersion="15"
+			tools:ignore="GradleOverrides" />
 
 		<uses-feature
   			android:glEsVersion="0x00020000"
@@ -43,6 +44,7 @@
 	<application
 	    android:icon="@drawable/icon"
 	    android:label="@string/app_name"
+		android:extractNativeLibs="false"
 		android:theme="@style/AppTheme">
 
 		<activity

--- a/app/froyo/AndroidManifest.xml
+++ b/app/froyo/AndroidManifest.xml
@@ -19,8 +19,7 @@
     package="org.runnerup" xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk
-        tools:overrideLibrary="com.mapbox.mapboxsdk, com.jjoe64.graphview"
-        android:minSdkVersion="8" android:targetSdkVersion="24"/>
+        tools:overrideLibrary="com.mapbox.mapboxsdk, com.jjoe64.graphview"/>
 
     <application
         android:icon="@drawable/icon"

--- a/app/latest/AndroidManifest.xml
+++ b/app/latest/AndroidManifest.xml
@@ -18,9 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="org.runnerup">
 
-        <uses-sdk
-            android:minSdkVersion="15" />
-
 	<application
 	    android:icon="@drawable/icon"
 	    android:label="@string/app_name">


### PR DESCRIPTION
For 6.0 and later, Play can extract and exclude unneeded native libs. (The compress strategies are better too, unrelated here)
This should reduce the MapBox size requirements

Can only be tested with Play...