### PR TITLE
Lint: Update workaround for GradleCompatible warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,9 @@ android {
         checkReleaseBuilds true
         //promote to error
         fatal 'InlinedApi', 'InconsistentArrays'
-        //Required as Froyo support dropped in com.android.support:design:24.1.0
+        //Lint check cannot handle that there are different versions
+        //TODO: Find how this should be handled
+        //check manually with ./gradlew app:dependencies
         warning 'GradleCompatible'
         // Ignore some specific checks, also some specific with path in lint.xml
         ignore 'MissingTranslation'
@@ -100,7 +102,6 @@ repositories {
 }
 
 dependencies {
-    //design uses com.android.support:appcompat, not explicitly required
     latestCompile 'com.android.support:design:25.1.0'
     froyoCompile 'com.android.support:design:24.1.0' //SDK <10 dropped in 24.2
     latestCompile 'com.google.android.gms:play-services-wearable:10.0.1'
@@ -108,7 +109,11 @@ dependencies {
     latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0@aar'){
         transitive=true
     }
-    compile 'com.jjoe64:graphview:4.2.1'
+    //Adding GraphView twice is done to force two inclusions and 'upgrade' the version of
+    //Android support library that GraphView was compiled with twice
+    //(GraphView is not used in 2.2 (but 2.3 "Froyo" builds). A wrapper will maybe suppress for Froyo.)
+    latestCompile 'com.jjoe64:graphview:4.2.1'
+    froyoCompile 'com.jjoe64:graphview:4.2.1'
     compile project(':common')
     compile project(':hrdevice')
     latestWearApp project(':wear')


### PR DESCRIPTION
Will require manual checks or rewrite code

Adding GraphView twice is done to force two inclusions and 'upgrade' the version of
Android support library that GraphView was compiled with twice
(GraphView is not used in 2.2 (but 2.3 "Froyo" builds). A wrapper will maybe suppress for Froyo.)

TODO: Find how this should be handled without suppressions. The real benefit of a separate PR is to raise awareness.

Note: RunnerUp, MapBox, GraphView, Play Services all uses different versions of Support Lib. One solution may be to compile MapBox and GraphView separately and adapt to PlayServices version....

latestCompile - Classpath for compiling the latest sources.
+--- com.android.support:design:25.1.0
|    +--- com.android.support:support-v4:25.1.0
|    |    +--- com.android.support:support-compat:25.1.0
|    |    |    \--- com.android.support:support-annotations:25.1.0
|    |    +--- com.android.support:support-media-compat:25.1.0
|    |    |    +--- com.android.support:support-annotations:25.1.0
|    |    |    \--- com.android.support:support-compat:25.1.0 (*)
|    |    +--- com.android.support:support-core-utils:25.1.0
|    |    |    +--- com.android.support:support-annotations:25.1.0
|    |    |    \--- com.android.support:support-compat:25.1.0 (*)
|    |    +--- com.android.support:support-core-ui:25.1.0
|    |    |    +--- com.android.support:support-annotations:25.1.0
|    |    |    \--- com.android.support:support-compat:25.1.0 (*)
|    |    \--- com.android.support:support-fragment:25.1.0
|    |         +--- com.android.support:support-compat:25.1.0 (*)
|    |         +--- com.android.support:support-media-compat:25.1.0 (*)
|    |         +--- com.android.support:support-core-ui:25.1.0 (*)
|    |         \--- com.android.support:support-core-utils:25.1.0 (*)
|    +--- com.android.support:appcompat-v7:25.1.0
|    |    +--- com.android.support:support-annotations:25.1.0
|    |    +--- com.android.support:support-v4:25.1.0 (*)
|    |    +--- com.android.support:support-vector-drawable:25.1.0
|    |    |    +--- com.android.support:support-annotations:25.1.0
|    |    |    \--- com.android.support:support-compat:25.1.0 (*)
|    |    \--- com.android.support:animated-vector-drawable:25.1.0
|    |         \--- com.android.support:support-vector-drawable:25.1.0 (*)
|    +--- com.android.support:recyclerview-v7:25.1.0
|    |    +--- com.android.support:support-annotations:25.1.0
|    |    +--- com.android.support:support-compat:25.1.0 (*)
|    |    \--- com.android.support:support-core-ui:25.1.0 (*)
|    \--- com.android.support:transition:25.1.0
|         +--- com.android.support:support-annotations:25.1.0
|         \--- com.android.support:support-v4:25.1.0 (*)
+--- com.google.android.gms:play-services-wearable:10.0.1
|    +--- com.google.android.gms:play-services-base:10.0.1
|    |    +--- com.google.android.gms:play-services-basement:10.0.1
|    |    |    \--- com.android.support:support-v4:24.0.0 -> 25.1.0 (*)
|    |    \--- com.google.android.gms:play-services-tasks:10.0.1
|    |         \--- com.google.android.gms:play-services-basement:10.0.1 (*)
|    \--- com.google.android.gms:play-services-basement:10.0.1 (*)
+--- com.getpebble:pebblekit:4.0.1
+--- com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0
|    +--- com.android.support:support-annotations:23.4.0 -> 25.1.0
|    +--- com.android.support:support-v4:23.4.0 -> 25.1.0 (*)
|    +--- com.android.support:design:23.4.0 -> 25.1.0 (*)
|    +--- com.squareup.okhttp3:okhttp:3.4.1
|    |    \--- com.squareup.okio:okio:1.9.0
|    +--- com.mapzen.android:lost:1.1.1
|    |    +--- com.android.support:appcompat-v7:22.2.0 -> 25.1.0 (*)
|    |    +--- com.android.support:support-v4:22.2.0 -> 25.1.0 (*)
|    |    \--- com.google.guava:guava:18.0
|    \--- com.mapbox.mapboxsdk:mapbox-java-services:1.3.1
|         +--- com.squareup.retrofit2:retrofit:2.1.0
|         |    \--- com.squareup.okhttp3:okhttp:3.3.0 -> 3.4.1 (*)
|         +--- com.squareup.retrofit2:converter-gson:2.1.0
|         |    +--- com.squareup.retrofit2:retrofit:2.1.0 (*)
|         |    \--- com.google.code.gson:gson:2.7
|         \--- com.squareup.okhttp3:logging-interceptor:3.3.1
|              \--- com.squareup.okhttp3:okhttp:3.3.1 -> 3.4.1 (*)
\--- com.jjoe64:graphview:4.2.1
     \--- com.android.support:support-v4:22.1.1 -> 25.1.0 (*)