### PR TITLE
Transifex and Android Lint does not agree on plurals for Polish

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -14,6 +14,7 @@
     <issue id="MissingQuantity">
         <!-- Transifex refuses quantity="one" for tr, (gradle) lint requires it, Inspect allows both-->
         <warning path="res/values-tr/cues.xml" />
+        <warning path="res/values-pl/cues.xml" />
     </issue>
     <issue id="InvalidPackage">
         <ignore regexp=".*okio.*" />

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -9,12 +9,12 @@
         <ignore path="**/com.vividsolutions/**" />
     </issue>
     <issue id="ResourceType">
-        <warning path="src/org/runnerup/view/MainLayout.java" />
+        <ignore path="src/org/runnerup/view/MainLayout.java" />
     </issue>
     <issue id="MissingQuantity">
         <!-- Transifex refuses quantity="one" for tr, (gradle) lint requires it, Inspect allows both-->
-        <warning path="res/values-tr/cues.xml" />
-        <warning path="res/values-pl/cues.xml" />
+        <ignore path="res/values-tr/cues.xml" />
+        <ignore path="res/values-pl/cues.xml" />
     </issue>
     <issue id="InvalidPackage">
         <ignore regexp=".*okio.*" />

--- a/app/res/values-pl/cues.xml
+++ b/app/res/values-pl/cues.xml
@@ -32,43 +32,36 @@
   <plurals name="cue_hour">
     <item quantity="one">%d godzina</item>
     <item quantity="few">%d godziny</item>
-    <item quantity="many">%d godzin</item>
     <item quantity="other">%d godzin</item>
   </plurals>
   <plurals name="cue_minute">
     <item quantity="one">%d minuta</item>
     <item quantity="few">%d minuty</item>
-    <item quantity="many">%d minut</item>
     <item quantity="other">%d minut</item>
   </plurals>
   <plurals name="cue_second">
     <item quantity="one">%d sekunda</item>
     <item quantity="few">%d sekundy</item>
-    <item quantity="many">%d sekund</item>
     <item quantity="other">%d sekund</item>
   </plurals>
   <plurals name="cue_meter">
     <item quantity="one">%d metr</item>
     <item quantity="few">%d metry</item>
-    <item quantity="many">%d metrów</item>
     <item quantity="other">%d metrów</item>
   </plurals>
   <plurals name="cue_kilometer">
     <item quantity="one">%d kilometr</item>
     <item quantity="few">%d kilometry</item>
-    <item quantity="many">%d kilometrów</item>
     <item quantity="other">%d kilometrów</item>
   </plurals>
   <plurals name="cue_mile">
     <item quantity="one">%d mila</item>
     <item quantity="few">%d mile</item>
-    <item quantity="many">%d mil</item>
     <item quantity="other">%d mil</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d uderzenie na minutę</item>
     <item quantity="few">%d uderzenia na minutę</item>
-    <item quantity="many">%d uderzeń na minutę</item>
     <item quantity="other">%d uderzeń na minutę</item>
   </plurals>
   <string name="cue_activity_paused">Trening wstrzymany</string>


### PR DESCRIPTION
Lint want one,few,many,other, Transifex do not accept "many".
Transifex seem to be correct, cannot suppress Transifex anyway
http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html?id=l10n/pluralforms

Adopting to Transifex, suppress lint error. Handpatching in Transifex sync is a pain.
Similar to Turkish

Puzzled: Why did Turkish appear some weeks ago and Polish now?