### PR TITLE
Lint: GradleCompatible, force support-v4 version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,20 +84,20 @@ android {
         checkReleaseBuilds true
         //promote to error, must be handled
         fatal 'InlinedApi', 'InconsistentArrays'
-        //Lint check cannot handle that there are different support lib versions in different apk
-        //check manually with ./gradlew app:dependencies
+        //TODO: See GradleCompatible comments, check manually with ./gradlew app:dependencies
         warning 'GradleCompatible'
-        //Support lib > 25.0.1 _sometimes_ raises this issue. Should be fixed though
-        //Suppress before Android Studio 2.3
-        //warning 'RestrictedApi'
         //All translations will not be complete
         ignore 'MissingTranslation'
-        //icon with all densities are not included - dont bother
+        //icon with all densities are not included - don't bother
         ignore 'IconMissingDensityFolder'
         //apply() is supported from SDK 9, but min version is 8
         //Suppress before Android Studio 2.3
         //ignore 'ApplySharedPref'
+
         showAll true
+        //debug issues in Travis
+        textReport true
+        textOutput 'stdout'
     }
 }
 
@@ -109,18 +109,28 @@ repositories {
 }
 
 dependencies {
-    //design uses com.android.support:appcompat, not explicitly required
+    compile project(':common')
+    compile project(':hrdevice')
+    latestWearApp project(':wear')
+
+    //Lint bug: To avoid the issue GradleDependency in Froyo, both Latest/Froyo must be suppressed
+    //(Latest dependency check on the other libraries)
+    //noinspection GradleDependency
     latestCompile "com.android.support:design:${rootProject.ext.supportLibrary}"
+    //GradleCompatible: support-v4 is not used by app source but mapbox, graphview, play-services-wearable
+    //force same version as in the app
+    latestCompile "com.android.support:support-v4:${rootProject.ext.supportLibrary}"
+
+    //noinspection GradleDependency
     froyoCompile 'com.android.support:design:24.1.0' //SDK <10 dropped in 24.2
+
     latestCompile "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesVersion}"
     latestCompile 'com.getpebble:pebblekit:4.0.1'
     latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0@aar'){
         transitive=true
     }
     compile 'com.jjoe64:graphview:4.2.1'
-    compile project(':common')
-    compile project(':hrdevice')
-    latestWearApp project(':wear')
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.3.7'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -31,12 +31,38 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    lintOptions {
+        //disable specific checks for specific paths
+        lintConfig file("lint.xml")
+        checkReleaseBuilds true
+        //promote to error
+        fatal 'InlinedApi', 'InconsistentArrays'
+        //Must be suppressed for com.google.android.support:wearable
+        warning 'GradleCompatible'
+        // Ignore some specific checks completely
+        ignore 'MissingTranslation'
+        //icon with all densities are not included - don't bother
+        ignore 'IconMissingDensityFolder'
+
+        showAll true
+        //debug issues in Travis
+        textReport true
+        textOutput 'stdout'
+    }
 }
 
 dependencies {
+    compile project(':common')
+
+    //recyclerview-v7, support-v4 is not used by wear app source but wearable
+    //force same version as in the app
+    compile "com.android.support:support-v4:${rootProject.ext.supportLibrary}"
+    compile "com.android.support:recyclerview-v7:${rootProject.ext.supportLibrary}"
+
+    //TODO: Suppress warning for GradleCompatible
     compile "com.google.android.support:wearable:${rootProject.ext.googleWearVersion}"
     compile "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesVersion}"
-    compile project(':common')
 }
 
 def props = new Properties()


### PR DESCRIPTION
GradleCompatible: support-v4 is not used directly by app source but mapbox, graphview, play-services-wearable
force same version as in the app

Handle GradleDependency in Froyo

Replaces PR #519 
