### PR TITLE
Remove dependency of samsung_ble_sdk_200.jar via project proterty.

### DIFF
--- a/hrdevice/build.gradle
+++ b/hrdevice/build.gradle
@@ -16,6 +16,9 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
+            if (project.hasProperty('org.runnerup.hr.disableSamsungBLE')) {
+                java.excludes = ['org/runnerup/hr/SamsungBLEHRProvider.java']
+            }
             resources.srcDirs = ['src']
             aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
@@ -33,7 +36,9 @@ android {
 }
 
 dependencies {
-    provided files('libs/samsung_ble_sdk_200.jar')
+    if (!project.hasProperty('org.runnerup.hr.disableSamsungBLE')) {
+        provided files('libs/samsung_ble_sdk_200.jar')
+    }
     compile files('../ANT-Android-SDKs/ANT+_Android_SDK/API/antpluginlib_3-6-0.jar')
 }
 
@@ -41,7 +46,9 @@ task downloadSamsungBleSdk(type: DownloadTask) {
     sourceUrl = 'https://github.com/fishkingsin/BLEDialogTool/raw/master/lib/samsung_ble_sdk_200.jar'
     target = file('libs/samsung_ble_sdk_200.jar')
 }
-preBuild.dependsOn downloadSamsungBleSdk
+if (!project.hasProperty('org.runnerup.hr.disableSamsungBLE')) {
+    preBuild.dependsOn downloadSamsungBleSdk
+}
 
 class DownloadTask extends DefaultTask {
     @Input

--- a/hrdevice/src/org/runnerup/hr/SamsungBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/SamsungBLEHRProvider.java
@@ -47,30 +47,6 @@ import java.util.UUID;
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class SamsungBLEHRProvider extends BtHRBase implements HRProvider {
 
-    /**
-     * @return true if device is 4.2, 4.2.1 and 4.2.2 AND the samsung ble sdk is available,
-     *          false otherwise
-     */
-    public static boolean checkLibrary() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2)
-            return false;
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN)
-            return false;
-
-        try {
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGatt");
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGattAdapter");
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGattCallback");
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGattCharacteristic");
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGattDescriptor");
-            Class.forName("com.samsung.android.sdk.bt.gatt.BluetoothGattService");
-            return true;
-        } catch (Exception e) {
-        }
-        return false;
-    }
-
     static final String NAME = "SamsungBLE";
     static final String DISPLAY_NAME = "Bluetooth SMART (BLE)";
 


### PR DESCRIPTION
Fix for issue #385. The idea is using a project property that, if defined, avoid downloading the library and compiling the SamsungBLEHRProvider for the Heart Rate manager. The property can be defined like this:

    ./gradlew build -Porg.runnerup.hr.disableSamsungBLE=true
    or
    ./gradlew build --project-prop org.runnerup.hr.disableSamsungBLE=true 

