### PR TITLE
MapBox 5.0.1 updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
 
     latestCompile "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesVersion}"
     latestCompile 'com.getpebble:pebblekit:4.0.1'
-    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0@aar'){
+    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar'){
         transitive=true
     }
     compile 'com.jjoe64:graphview:4.2.1'

--- a/app/froyo/java/org/runnerup/util/MapWrapper.java
+++ b/app/froyo/java/org/runnerup/util/MapWrapper.java
@@ -52,6 +52,12 @@ public class MapWrapper implements Constants {
     public void onCreate(Bundle savedInstanceState) {
     }
 
+    public void onStart() {
+    }
+
+    public void onStop() {
+    }
+
     public void onResume() {
     }
 

--- a/app/latest/AndroidManifest.xml
+++ b/app/latest/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 android:exported="false"
                 android:permission="android.permission.BIND_REMOTEVIEWS" />
 
-        <service android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService" />
+        <service android:name="com.mapbox.services.android.telemetry.service.TelemetryService" />
 	</application>
 
 </manifest>

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -265,6 +265,18 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+        mapWrapper.onStart();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mapWrapper.onStop();
+    }
+
+    @Override
     public void onPause() {
         super.onPause();
         mapWrapper.onPause();


### PR DESCRIPTION
Some API changes
The most important change is an update regarding a workaround for a problem in 4.2 (a redesign is required to drop the change)
There are no changes that I can see
Note: The .apk size for users will be reduced significantly when downloading from Play vs the raw app size as android:extractNativeLibs="true" is now set in the manifest