### PR TITLE
account exception after rebuild

### DIFF
--- a/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
+++ b/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
@@ -178,10 +178,9 @@ public class FeedWidgetService extends RemoteViewsService {
                 };
                 Cursor c = mDB.query(Constants.DB.ACCOUNT.TABLE, from, "_id = ?",
                         args, null, null, null, null);
-                String name = "?";
                 c.moveToFirst();
                 ContentValues config = DBHelper.get(c);
-                name = config.getAsString("name");
+                String name = config.getAsString(Constants.DB.ACCOUNT.NAME);
                 c.close();
                 return name;
             }

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -134,7 +134,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ")
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
             + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
-            + (DB.ACCOUNT.ICON + " integer null, ")
+            + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
             + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
 
     private static final String CREATE_TABLE_REPORT = "create table "
@@ -391,7 +391,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
         values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -399,7 +399,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "runkeeper");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
         values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -407,7 +407,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
         values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -415,7 +415,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
         values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -423,7 +423,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
         values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -431,7 +431,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
         values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -439,7 +439,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
         values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -447,7 +447,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
         values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -455,7 +455,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
         values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -463,7 +463,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
         values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -471,7 +471,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "none");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
         values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         insertAccount(arg0, values);
@@ -480,7 +480,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
         values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -497,7 +497,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
         values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -506,7 +506,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
         values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -515,7 +515,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
@@ -525,7 +525,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
         values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
 
@@ -534,7 +534,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
         values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
     }

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -133,7 +133,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,")
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
-            + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
+            + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ") //no longer used
             + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
             + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
 
@@ -517,7 +517,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
-        values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
+        //values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
 
         //DBVERSION 29

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -392,7 +392,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
-        values.put(DB.ACCOUNT.URL, "http://connect.garmin.com/");
+        values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -400,7 +400,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "runkeeper");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
-        values.put(DB.ACCOUNT.URL, "http://runkeeper.com/");
+        values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -408,7 +408,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
-        values.put(DB.ACCOUNT.URL, "http://jogg.se/");
+        values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -416,7 +416,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
-        values.put(DB.ACCOUNT.URL, "http://www.funbeat.se/");
+        values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -424,7 +424,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
-        values.put(DB.ACCOUNT.URL, "http://www.mapmyrun.com/");
+        values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -432,7 +432,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
-        values.put(DB.ACCOUNT.URL, "http://nikeplus.nike.com");
+        values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -440,7 +440,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
-        values.put(DB.ACCOUNT.URL, "http://www.endomondo.com");
+        values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -448,7 +448,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
-        values.put(DB.ACCOUNT.URL, "http://www.runningahead.com");
+        values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -456,7 +456,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
-        values.put(DB.ACCOUNT.URL, "http://www.digifit.com");
+        values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -464,7 +464,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
-        values.put(DB.ACCOUNT.URL, "http://www.strava.com");
+        values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -472,7 +472,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "none");
         values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
-        values.put(DB.ACCOUNT.URL, "http://weide.devsparkles.se/Demo/Map");
+        values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         insertAccount(arg0, values);
 
@@ -481,7 +481,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
-        values.put(DB.ACCOUNT.URL, "http://www.facebook.com");
+        values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
@@ -498,7 +498,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-        values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
+        values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         //DBVERSION 27
@@ -507,7 +507,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-        values.put(DB.ACCOUNT.URL, "https://fit.google.com");
+        values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         //DBVERSION 28
@@ -516,7 +516,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-        values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
+        values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
 

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -385,8 +385,6 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     public void insertAccounts(SQLiteDatabase arg0) {
-        final boolean notyet = false;
-
         ContentValues values;
 
         values = new ContentValues();
@@ -486,66 +484,59 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.URL, "http://www.facebook.com");
         insertAccount(arg0, values);
 
-        if (notyet) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-            values.put(DB.ACCOUNT.URL, "https://plus.google.com");
-            insertAccount(arg0, values);
-        }
+//      values = new ContentValues();
+//      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
+//      values.put(DB.ACCOUNT.FORMAT, "");
+//      values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+//      values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
+//      values.put(DB.ACCOUNT.URL, "https://plus.google.com");
+//      insertAccount(arg0, values);
 
-        if (DBVERSION >= 26) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-            values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 26
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
+        values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 27) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-            values.put(DB.ACCOUNT.URL, "https://fit.google.com");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 27
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
+        values.put(DB.ACCOUNT.URL, "https://fit.google.com");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 28) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-            values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
-            values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 28
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
+        values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
+        values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 29) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
-            values.put(DB.ACCOUNT.URL, "");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 29
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
+        values.put(DB.ACCOUNT.URL, "");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 30) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
-            values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 30
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
+        values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
+        insertAccount(arg0, values);
     }
 
     void insertAccount(SQLiteDatabase arg0, ContentValues arg1) {

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -128,10 +128,10 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.NAME + " text not null, ")
             + (DB.ACCOUNT.DESCRIPTION + " text, ")
             + (DB.ACCOUNT.URL + " text, ")
-            + (DB.ACCOUNT.FORMAT + " text not null, ")
+            + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,")
-            + (DB.ACCOUNT.AUTH_METHOD + " text not null, ")
+            + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
             + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
             + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
@@ -267,7 +267,7 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         if (oldVersion > 0 && oldVersion < 18 && newVersion >= 18) {
             echoDo(arg0,
-                    "update account set auth_config = '{ \"access_token\":\"' || auth_config || '\" }' where auth_config is not null and auth_method='oauth2';");
+                    "update account set " + DB.ACCOUNT.AUTH_CONFIG + " = '{ \"access_token\":\"' || " + DB.ACCOUNT.AUTH_CONFIG + " || '\" }' where " + DB.ACCOUNT.AUTH_CONFIG + " is not null and " + DB.ACCOUNT.AUTH_METHOD +"='oauth2';");
         }
 
         if (oldVersion > 0 && oldVersion < 19 && newVersion >= 19) {
@@ -389,88 +389,88 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
         values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "runkeeper");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "runkeeper");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
         values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "gpx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "gpx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
         values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
         values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
         values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
         values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
         values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
         values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
         values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
         values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "none");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "none");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
         values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
@@ -478,25 +478,25 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
         values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
 //      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-//      values.put(DB.ACCOUNT.FORMAT, "");
-//      values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-//      values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-//      values.put(DB.ACCOUNT.URL, "https://plus.google.com");
+//      //values.put(DB.ACCOUNT.FORMAT, "");
+//      //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+//      //values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
+//      values.put(DB.ACCOUNT.URL, GooglePlusSynchronizer.PUBLIC_URL);
 //      insertAccount(arg0, values);
 
         //DBVERSION 26
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
         values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -504,8 +504,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 27
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
         values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -513,8 +513,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 28
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
@@ -524,7 +524,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
         values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
@@ -532,8 +532,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 30
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
         values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -546,6 +546,13 @@ public class DBHelper extends SQLiteOpenHelper implements
         String arr[] = {
             arg1.getAsString(DB.ACCOUNT.NAME)
         };
+        //non null in db, used in few synchronizers
+        if (arg1.getAsString(DB.ACCOUNT.FORMAT) == null) {
+            arg1.put(DB.ACCOUNT.FORMAT, "");
+        }
+        if (arg1.getAsString(DB.ACCOUNT.AUTH_METHOD) == null) {
+            arg1.put(DB.ACCOUNT.AUTH_METHOD, "");
+        }
         Cursor c = arg0.query(DB.ACCOUNT.TABLE, cols, DB.ACCOUNT.NAME + " = ?",
                 arr, null, null, null);
         if (!c.moveToFirst())

--- a/app/src/org/runnerup/export/DefaultSynchronizer.java
+++ b/app/src/org/runnerup/export/DefaultSynchronizer.java
@@ -53,8 +53,6 @@ public abstract class DefaultSynchronizer implements Synchronizer {
     protected final Set<String> cookies = new HashSet<String>();
     protected final FormValues formValues = new FormValues();
 
-    private Integer authNotice;
-
     public DefaultSynchronizer() {
         super();
         logout();
@@ -243,11 +241,6 @@ public abstract class DefaultSynchronizer implements Synchronizer {
 
     @Override
     public Integer getAuthNotice() {
-        return authNotice;
-    }
-
-    @Override
-    public void setAuthNotice(Integer authNotice) {
-        this.authNotice = authNotice;
+        return 0;
     }
 }

--- a/app/src/org/runnerup/export/DefaultSynchronizer.java
+++ b/app/src/org/runnerup/export/DefaultSynchronizer.java
@@ -71,6 +71,12 @@ public abstract class DefaultSynchronizer implements Synchronizer {
     }
 
     @Override
+    public int getIconId() {
+        //0 is used if the resource id cannot be found
+        return 0;
+    }
+
+    @Override
     public void init(ContentValues config) {
         //Note that only auth_config can be expected here
         //Other config can be retrieved from db in Upload()

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -68,6 +68,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     public static final String DIGIFIT_URL = "http://my.digifit.com";
 
     public static final String NAME = "Digifit";
+    public static final String PUBLIC_URL = "http://www.digifit.com";
 
     public static void main(String args[]) throws Exception {
         if (args.length < 2) {

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -35,6 +35,7 @@ import android.util.Pair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.Part;
@@ -310,6 +311,10 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         return NAME;
     }
 
+    @Override
+    public int getIconId() {return R.drawable.a9_digifit;}
+
+    private String getUploadUrl() throws IOException,
     private String getUploadUrl() throws IOException, MalformedURLException, ProtocolException,
             JSONException {
         String getUploadUrl = DIGIFIT_URL + "/rpc/json/workout/import_workouts_url";

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -314,7 +314,6 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     @Override
     public int getIconId() {return R.drawable.a9_digifit;}
 
-    private String getUploadUrl() throws IOException,
     private String getUploadUrl() throws IOException, MalformedURLException, ProtocolException,
             JSONException {
         String getUploadUrl = DIGIFIT_URL + "/rpc/json/workout/import_workouts_url";

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.EndomondoTrack;
@@ -101,6 +102,9 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a6_endomondo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -63,9 +63,10 @@ import java.util.zip.GZIPOutputStream;
 public class EndomondoSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Endomondo";
-    public static final String AUTH_URL = "https://api.mobile.endomondo.com/mobile/auth";
-    public static final String UPLOAD_URL = "http://api.mobile.endomondo.com/mobile/track";
-    public static final String FEED_URL = "http://api.mobile.endomondo.com/mobile/api/feed";
+    public static final String PUBLIC_URL = "http://www.endomondo.com";
+    private static final String AUTH_URL = "https://api.mobile.endomondo.com/mobile/auth";
+    private static final String UPLOAD_URL = "http://api.mobile.endomondo.com/mobile/track";
+    private static final String FEED_URL = "http://api.mobile.endomondo.com/mobile/api/feed";
 
     long id = 0;
     private String username = null;

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -29,6 +29,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.FacebookCourse;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -141,6 +142,9 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a11_facebook;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -54,6 +54,7 @@ import java.util.Locale;
 public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "Facebook";
+    public static final String PUBLIC_URL = "http://www.facebook.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.text.TextUtils;
 
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.export.format.TCX;
@@ -55,6 +56,9 @@ public class FileSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a16_localfile;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.TCX;
@@ -118,6 +119,9 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a2_funbeatlogo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -61,10 +61,11 @@ import java.util.Map;
 public class FunBeatSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "FunBeat";
-    public static final String BASE_URL = "http://www.funbeat.se";
-    public static final String START_URL = BASE_URL + "/index.aspx";
-    public static final String LOGIN_URL = BASE_URL + "/index.aspx";
-    public static final String UPLOAD_URL = BASE_URL
+    public static final String PUBLIC_URL = "http://www.funbeat.se";
+    private static final String BASE_URL = PUBLIC_URL;
+    private static final String START_URL = BASE_URL + "/index.aspx";
+    private static final String LOGIN_URL = BASE_URL + "/index.aspx";
+    private static final String UPLOAD_URL = BASE_URL
             + "/importexport/upload.aspx";
 
     public static final String API_URL = "http://1.0.0.android.api.funbeat.se/json/Default.asmx/";

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Pair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -96,6 +97,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a0_garminlogo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -57,8 +57,9 @@ import java.util.Map;
 public class GarminSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Garmin";
+    public static final String PUBLIC_URL = "http://connect.garmin.com";
 
-    public static final String CHOOSE_URL = "http://connect.garmin.com/";
+    private static final String CHOOSE_URL = PUBLIC_URL + "/";
 
     public static final String START_URL = "https://connect.garmin.com/signin";
     public static final String LOGIN_URL = "https://connect.garmin.com/signin";

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.export.format.GoogleFitData;
 import org.runnerup.export.util.SyncHelper;
 
@@ -73,8 +74,10 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
         return NAME;
     }
 
-    public Context getContext() {
-        return context;
+    @Override
+    public int getIconId() {return R.drawable.a14_googlefit;}
+
+    private Context getContext() {        return context;
     }
 
     @Override

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -42,7 +42,8 @@ import java.util.zip.GZIPOutputStream;
 public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
 
     public static final String NAME = "GoogleFit";
-    public static final String REST_URL = "https://www.googleapis.com/fitness/v1/users/me/";
+    public static final String PUBLIC_URL = "https://fit.google.com";
+    private static final String REST_URL = "https://www.googleapis.com/fitness/v1/users/me/";
     public static final String REST_DATASOURCE = "dataSources";
     public static final String REST_DATASETS = "datasets";
     public static final String REST_SESSIONS = "sessions";

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -77,7 +77,8 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
     @Override
     public int getIconId() {return R.drawable.a14_googlefit;}
 
-    private Context getContext() {        return context;
+    private Context getContext() {
+        return context;
     }
 
     @Override

--- a/app/src/org/runnerup/export/GooglePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/GooglePlusSynchronizer.java
@@ -44,6 +44,7 @@ import java.net.URL;
 public class GooglePlusSynchronizer extends DefaultSynchronizer implements Synchronizer, OAuth2Server {
 
     public static final String NAME = "Google+";
+    public static final String PUBLIC_URL = "https://plus.google.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/GooglePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/GooglePlusSynchronizer.java
@@ -26,6 +26,7 @@ import android.os.Build;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -161,6 +162,9 @@ public class GooglePlusSynchronizer extends DefaultSynchronizer implements Synch
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a12_googleplus;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/org/runnerup/export/JoggSESynchronizer.java
@@ -55,6 +55,7 @@ import javax.xml.parsers.ParserConfigurationException;
 public class JoggSESynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "jogg.se";
+    public static final String PUBLIC_URL = "http://jogg.se";
     private static String MASTER_USER = null;
     private static String MASTER_KEY = null;
 

--- a/app/src/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/org/runnerup/export/JoggSESynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.util.KXmlSerializer;
@@ -87,6 +88,9 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a5_jogg;}
 
     @Override
     public void init(final ContentValues config) {

--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Pair;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -97,6 +98,9 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a3_mapmyrun_logo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -50,6 +50,7 @@ import java.util.Map;
 public class MapMyRunSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "MapMyRun";
+    public static final String PUBLIC_URL = "http://www.mapmyrun.com";
     private static String CONSUMER_KEY;
     private static final String BASE_URL = "https://api.mapmyfitness.com/3.1";
     private static final String GET_USER_URL = BASE_URL + "/users/get_user";

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.GPX;
@@ -107,6 +108,9 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a4_nikeplus;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -60,6 +60,7 @@ import java.util.TimeZone;
 public class NikePlusSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Nike+";
+    public static final String PUBLIC_URL = "http://nikeplus.nike.com";
     private static String CLIENT_ID = null;
     private static String CLIENT_SECRET = null;
     private static String APP_ID = null;

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -190,6 +190,9 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
     }
 
     @Override
+    public int getIconId() {return R.drawable.a1_rklogo;}
+
+    @Override
     public void init(ContentValues config) {
         String authConfig = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);
         id = config.getAsLong("_id");

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -72,7 +72,8 @@ import java.util.concurrent.TimeUnit;
 public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchronizer, OAuth2Server {
 
     public static final String NAME = "RunKeeper";
-    private static Context context = null;
+    public static final String PUBLIC_URL = "http://runkeeper.com";
+    private Context context = null;
     /**
      * @todo register OAuth2Server
      */

--- a/app/src/org/runnerup/export/RunalyzeSynchronizer.java
+++ b/app/src/org/runnerup/export/RunalyzeSynchronizer.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.export.format.RunalyzePost;
 
@@ -76,6 +77,9 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
         _sports = new HashMap<>();
         _types = new HashMap<>();
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a17_runalyze;}
 
     /**
      * Initialzes the synchronizer with the information stored in the DB and passed.

--- a/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -80,6 +80,9 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
     }
 
     @Override
+    public int getIconId() {return R.drawable.a8_runneruplive;}
+
+    @Override
     public void init(ContentValues config) {
         id = config.getAsLong("_id");
         String auth = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);

--- a/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -49,6 +49,7 @@ import org.runnerup.workout.WorkoutInfo;
 public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements WorkoutObserver {
 
     public static final String NAME = "RunnerUp LIVE";
+    public static final String PUBLIC_URL = "http://weide.devsparkles.se/Demo/Map";
     private static final String POST_URL = "http://weide.devsparkles.se/api/Resource/";
     private final Context context;
 

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -121,6 +122,9 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a7_runningahead;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -47,6 +47,7 @@ import java.util.zip.GZIPOutputStream;
 public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "RunningAHEAD";
+    public static final String PUBLIC_URL = "http://www.runningahead.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -65,6 +65,9 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     public int getIconId() {return R.drawable.a15_runningfreeonline;}
 
     @Override
+    public Integer getAuthNotice() { return R.string.RunningFreeOnlinePasswordNotice; }
+
+    @Override
     public void init(ContentValues config) {
         id = config.getAsLong("_id");
         final String authToken = config.getAsString(Constants.DB.ACCOUNT.AUTH_CONFIG);

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.export.format.TCX;
 import org.runnerup.util.KXmlSerializer;
@@ -59,6 +60,9 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     public long getId() {
         return id;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a15_runningfreeonline;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -47,6 +47,7 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     private boolean isConnected = false;
 
     public static final String NAME = "RunningFreeOnline";
+    public static final String PUBLIC_URL = "http://www.runningfreeonline.com";
     private static final String BASE_URL = "http://www.runsaturday.com/runsaturday/SportTrackSync.asmx";
     private static final String LOG_TAG = RunningFreeOnlineSynchronizer.class.getName();
 

--- a/app/src/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/org/runnerup/export/RuntasticSynchronizer.java
@@ -50,11 +50,12 @@ import java.util.regex.Matcher;
 public class RuntasticSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Runtastic";
-    public static final String BASE_URL = "https://www.runtastic.com";
-    public static final String START_URL = BASE_URL + "/en/login";
-    public static final String LOGIN_URL = BASE_URL + "/en/d/users/sign_in";
-    public static final String UPLOAD_URL = BASE_URL + "/import/upload_session";
-    public static final String UPDATE_SPORTS_TYPE = BASE_URL + "/import/update_sport_type";
+    public static final String PUBLIC_URL = "http://www.runtastic.com";
+    private static final String BASE_URL = "https://www.runtastic.com";
+    private static final String START_URL = BASE_URL + "/en/login";
+    private static final String LOGIN_URL = BASE_URL + "/en/d/users/sign_in";
+    private static final String UPLOAD_URL = BASE_URL + "/import/upload_session";
+    private static final String UPDATE_SPORTS_TYPE = BASE_URL + "/import/update_sport_type";
 
     long id = 0;
     private String username = null;

--- a/app/src/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/org/runnerup/export/RuntasticSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Patterns;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -87,6 +88,9 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a13_runtastic;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -121,6 +122,9 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a10_strava;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -48,6 +48,7 @@ import java.util.Locale;
 public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "Strava";
+    public static final String PUBLIC_URL = "http://www.strava.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -240,7 +240,6 @@ public class SyncManager {
                 }
             }
             synchronizer.init(config);
-            synchronizer.setAuthNotice(config.getAsInteger(Constants.DB.ACCOUNT.AUTH_NOTICE));
             synchronizers.put(synchronizerName, synchronizer);
             synchronizersById.put(synchronizer.getId(), synchronizer);
         }
@@ -406,7 +405,7 @@ public class SyncManager {
                         : InputType.TYPE_TEXT_VARIATION_PASSWORD));
             }
         });
-        if (sync.getAuthNotice() != null) {
+        if (sync.getAuthNotice() != 0) {
             tvAuthNotice.setVisibility(View.VISIBLE);
             tvAuthNotice.setText(sync.getAuthNotice());
         } else {
@@ -514,16 +513,14 @@ public class SyncManager {
         path += File.separator + "RunnerUp";
         tv1.setText(path);
 
-        String s = "";
         if(!checkStoragePermissions(mActivity)) {
-            s = "Note: Storage permission must be granted in Android settings";
-        }
-        if (sync.getAuthNotice() != null) {
-            s += sync.getAuthNotice();
-        }
-        if ("".equals(s)) {
+            String s = "Note: Storage permission must be granted in Android settings";
             tvAuthNotice.setVisibility(View.VISIBLE);
             tvAuthNotice.setText(s);
+        }
+        else if (sync.getAuthNotice() != 0) {
+            tvAuthNotice.setVisibility(View.VISIBLE);
+            tvAuthNotice.setText(sync.getAuthNotice());
         } else {
             tvAuthNotice.setVisibility(View.GONE);
         }
@@ -1297,7 +1294,6 @@ public class SyncManager {
         String[] from = new String[] {
                 "_id",
                 DB.ACCOUNT.NAME,
-                DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.FLAGS
         };

--- a/app/src/org/runnerup/export/Synchronizer.java
+++ b/app/src/org/runnerup/export/Synchronizer.java
@@ -173,10 +173,4 @@ public interface Synchronizer {
      * @return A string resource id or null.
      */
     Integer getAuthNotice();
-
-    /**
-     * Set any authorization user notice to be shown when user enters username/password.
-     * @param authNotice String resource id or null.
-     */
-    void setAuthNotice(Integer authNotice);
 }

--- a/app/src/org/runnerup/export/Synchronizer.java
+++ b/app/src/org/runnerup/export/Synchronizer.java
@@ -67,6 +67,11 @@ public interface Synchronizer {
     String getName();
 
     /**
+     * @return The icon resource id
+     */
+    int getIconId();
+
+    /**
      * Init synchronizer
      *
      * @param config

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -137,7 +137,6 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
-                DB.ACCOUNT.ICON,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.AUTH_METHOD
         };
@@ -158,14 +157,14 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 ImageView im = (ImageView) findViewById(R.id.account_list_icon);
                 TextView tv = (TextView) findViewById(R.id.account_list_name);
                 tv.setText(tmp.getAsString(DB.ACCOUNT.NAME));
-                if (c.isNull(c.getColumnIndex(DB.ACCOUNT.ICON))) {
+                if (synchronizer.getIconId() == 0) {
                     im.setVisibility(View.GONE);
                     tv.setVisibility(View.VISIBLE);
                 } else {
                     im.setVisibility(View.VISIBLE);
                     tv.setVisibility(View.GONE);
-                    im.setBackgroundResource(tmp.getAsInteger(DB.ACCOUNT.ICON));
-                    synchronizerIcon = tmp.getAsInteger(DB.ACCOUNT.ICON);
+                    im.setBackgroundResource(synchronizer.getIconId());
+                    synchronizerIcon = synchronizer.getIconId();
                 }
             }
 

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -49,6 +49,7 @@ import android.widget.TextView;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.db.DBHelper;
+import org.runnerup.export.FileSynchronizer;
 import org.runnerup.export.RunnerUpLiveSynchronizer;
 import org.runnerup.export.SyncManager;
 import org.runnerup.export.Synchronizer;
@@ -137,8 +138,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
-                DB.ACCOUNT.AUTH_CONFIG,
-                DB.ACCOUNT.AUTH_METHOD
+                DB.ACCOUNT.AUTH_CONFIG
         };
 
         String args[] = {
@@ -173,9 +173,9 @@ public class AccountActivity extends AppCompatActivity implements Constants {
             if (tmp.containsKey(DB.ACCOUNT.URL)) {
                 Button btn = new Button(this);
                 btn.setText(tmp.getAsString(DB.ACCOUNT.URL));
-                //TODO SDK 24 requires the file URI to be handled as FileProvider, don't care yet
-                //For <= 24, something like OI File Manager is needed too
-                if(Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.AUTH_METHOD).contains("filepermission")) {
+                //TODO SDK 24 requires the file URI to be handled as FileProvider
+                //Something like OI File Manager is needed too
+                if(Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.NAME).equals(FileSynchronizer.NAME)) {
                     btn.setOnClickListener(urlButtonClick);
                 }
                 btn.setTag(tmp.getAsString(DB.ACCOUNT.URL));

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -113,7 +113,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
-                DB.ACCOUNT.AUTH_NOTICE,
                 DB.ACCOUNT.FLAGS
         };
 

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -112,7 +112,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 DB.ACCOUNT.URL,
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
-                DB.ACCOUNT.ICON,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.AUTH_NOTICE,
                 DB.ACCOUNT.FLAGS
@@ -175,15 +174,14 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
 
             boolean configured = mSyncManager.isConfigured(id);
             if (!mTabFormat) {
-                if (cursor.isNull(cursor.getColumnIndex(DB.ACCOUNT.ICON))) {
+                if (synchronizer.getIconId() == 0) {
                     accountIcon.setVisibility(View.GONE);
                     accountNameText.setVisibility(View.VISIBLE);
                     accountNameText.setText(tmp.getAsString(DB.ACCOUNT.NAME));
                 } else {
                     accountIcon.setVisibility(View.VISIBLE);
                     accountNameText.setVisibility(View.GONE);
-                    accountIcon.setBackgroundResource(tmp
-                            .getAsInteger(DB.ACCOUNT.ICON));
+                    accountIcon.setBackgroundResource(synchronizer.getIconId());
                 }
                 accountUploadBox.setVisibility(View.GONE);
                 accountFeedBox.setVisibility(View.GONE);

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -600,7 +600,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
             }
 
             ContentValues tmp = reports.get(position);
-            String name = tmp.getAsString("name");
+            String name = tmp.getAsString(DB.ACCOUNT.NAME);
             viewHolder.cb.setChecked(false);
             viewHolder.cb.setEnabled(false);
             viewHolder.cb.setTag(name);

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -336,7 +336,6 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
-                    + ("  acc." + DB.ACCOUNT.AUTH_METHOD + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
                     + ("  rep._id as repid, ")

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -351,7 +351,6 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
                     + "  acc._id, " // 0
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
-                    + ("  acc." + DB.ACCOUNT.AUTH_METHOD + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + " ")


### PR DESCRIPTION
In the db, the Accounts table store resources for the icons (and a few strings). The resources may be updated when rebuilding and can give exceptions (accounts fail to load) or incorrect icons (in best case). The user must clear the database or await a db update to resolve this.

The resources do not need to be stored in the db, they are related to the code so they have been broken out.
Similar, some data like auth_method and format were stored in the database without ever being used. This handling was cleaned up.

The database should be cleaned up, will be done later.
This PR is related to a "disable non working accounts" PR.