### PR TITLE
Remove DB.ACCOUNTS unused columns

### DIFF
--- a/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
+++ b/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
@@ -135,35 +135,6 @@ public class FeedWidgetService extends RemoteViewsService {
                     } else {
                         rv.setViewVisibility(R.id.feed_widget_item_notes, View.GONE);
                     }
-
-                    // c.put(FEED.FEED_TYPE, FEED.FEED_TYPE_ACTIVITY);
-                    // c.put(FEED.FEED_SUBTYPE,
-                    // getTrainingType(o.getInt("TrainingTypeID"),
-                    // o.getString("TrainingTypeName")));
-                    // c.put(FEED.FEED_TYPE_STRING,
-                    // o.getString("TrainingTypeName"));
-                    // c.put(FEED.START_TIME,
-                    // parseDateTime(o.getString("DateTime")));
-                    // if (!o.isNull("Distance"))
-                    // c.put(FEED.DISTANCE, 1000 * o.getDouble("Distance"));
-                    // if (!o.isNull("Duration"))
-                    // c.put(FEED.DURATION,
-                    // getDuration(o.getJSONObject("Duration")));
-                    // if (!o.isNull("PersonID"))
-                    // c.put(FEED.USER_ID, o.getInt("PersonID"));
-                    // if (!o.isNull("Firstname"))
-                    // c.put(FEED.USER_FIRST_NAME, o.getString("Firstname"));
-                    // if (!o.isNull("Lastname"))
-                    // c.put(FEED.USER_LAST_NAME, o.getString("Lastname"));
-                    // if (!o.isNull("PictureURL"))
-                    // c.put(FEED.USER_IMAGE_URL,
-                    // o.getString("PictureURL").replace("~/",
-                    // "http://www.funbeat.se/"));
-                    // if (!o.isNull("Description"))
-                    // c.put(FEED.NOTES, o.getString("Description"));
-                    // c.put(FEED.URL,
-                    // "http://www.funbeat.se/training/show.aspx?TrainingID="
-                    // + Long.toString(o.getLong("ID")));
                 } else {
                     Log.e(getClass().getSimpleName(), "Unexpected feed type");
                 }

--- a/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
+++ b/app/latest/java/org/runnerup/feedwidget/FeedWidgetService.java
@@ -178,10 +178,9 @@ public class FeedWidgetService extends RemoteViewsService {
                 };
                 Cursor c = mDB.query(Constants.DB.ACCOUNT.TABLE, from, "_id = ?",
                         args, null, null, null, null);
-                String name = "?";
                 c.moveToFirst();
                 ContentValues config = DBHelper.get(c);
-                name = config.getAsString("name");
+                String name = config.getAsString(Constants.DB.ACCOUNT.NAME);
                 c.close();
                 return name;
             }

--- a/app/res/layout/account_row.xml
+++ b/app/res/layout/account_row.xml
@@ -22,6 +22,7 @@
 
     <TableRow
         android:id="@+id/table_row1"
+        android:longClickable="true"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"

--- a/app/res/menu/account_list_menu.xml
+++ b/app/res/menu/account_list_menu.xml
@@ -20,4 +20,8 @@
         android:id="@+id/menu_tab_format"
         android:orderInCategory="100"
         android:title="@string/Table_format" />
+    <item
+        android:id="@+id/menu_show_disabled"
+        android:title="@string/Show_disabled_accounts"
+        android:checkable="true" />
 </menu>

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -134,7 +134,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ")
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
             + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
-            + (DB.ACCOUNT.ICON + " integer null, ")
+            + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
             + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
 
     private static final String CREATE_TABLE_REPORT = "create table "
@@ -391,7 +391,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
         values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -399,7 +399,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "runkeeper");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
         values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -407,7 +407,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
         values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -415,7 +415,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
         values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -423,7 +423,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
         values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -431,7 +431,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
         values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -439,7 +439,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
         values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -447,7 +447,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
         values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -455,7 +455,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
         values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -463,7 +463,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
         values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -471,7 +471,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "none");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
         values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         insertAccount(arg0, values);
@@ -480,7 +480,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
         values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -497,7 +497,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
         values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -506,7 +506,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
         values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
@@ -515,7 +515,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
@@ -525,7 +525,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
         values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
 
@@ -534,7 +534,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
+        //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
         values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
     }

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -126,7 +126,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + DB.ACCOUNT.TABLE + " ( "
             + ("_id integer primary key autoincrement, ")
             + (DB.ACCOUNT.NAME + " text not null, ")
-            + (DB.ACCOUNT.DESCRIPTION + " text, ")
+            + (DB.ACCOUNT.DESCRIPTION + " text, ") //no longer used
             + (DB.ACCOUNT.URL + " text, ")
             + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -319,7 +319,6 @@ public class DBHelper extends SQLiteOpenHelper implements
 
             if (c.moveToFirst()) {
                 ContentValues tmp = DBHelper.get(c);
-                c.close();
                 //URL was stored in AUTH_CONFIG previously, FORMAT migrated too
                 tmp.put(DB.ACCOUNT.URL, tmp.getAsString(DB.ACCOUNT.AUTH_CONFIG));
                 String authConfig = FileSynchronizer.contentValuesToAuthConfig(tmp);
@@ -327,6 +326,7 @@ public class DBHelper extends SQLiteOpenHelper implements
                 tmp.put(DB.ACCOUNT.AUTH_CONFIG, authConfig);
                 arg0.update(DB.ACCOUNT.TABLE, tmp, DB.ACCOUNT.NAME + " = ?", args);
             }
+            c.close();
             recreateAccount(arg0);
         }
 
@@ -339,22 +339,6 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     private void recreateAccount(SQLiteDatabase arg0) {
-        Cursor c = null;
-        try {
-            String cols[] = {
-                "method"
-            };
-            c = arg0.query(DB.ACCOUNT.TABLE, cols, null, null, null, null, null);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return;
-        }
-        finally {
-            if (c != null) {
-                c.close();
-            }
-        }
-
         StringBuilder newtab = new StringBuilder();
         newtab.append(CREATE_TABLE_ACCOUNT);
         newtab.replace(0,

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -130,7 +130,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.URL + " text, ")
             + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
-            + (DB.ACCOUNT.ENABLED + " integer not null default 1,")
+            + (DB.ACCOUNT.ENABLED + " integer not null default 1,") //Account is not hidden/disabled
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
             + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ") //no longer used
@@ -393,6 +393,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
         values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
+        values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -474,6 +475,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
         values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
+        values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -499,6 +501,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
         values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
+        values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 27
@@ -508,6 +511,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
         values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
+        values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 28
@@ -518,6 +522,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         //values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
+        values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 29

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -127,7 +127,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + ("_id integer primary key autoincrement, ")
             + (DB.ACCOUNT.NAME + " text not null, ")
             + (DB.ACCOUNT.DESCRIPTION + " text, ") //no longer used
-            + (DB.ACCOUNT.URL + " text, ")
+            + (DB.ACCOUNT.URL + " text, ") //no longer used
             + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,") //Account is not hidden/disabled
@@ -392,7 +392,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
-        values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
@@ -401,7 +401,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "runkeeper");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
-        values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -409,7 +409,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "gpx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
-        values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -417,7 +417,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
-        values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -425,7 +425,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
-        values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -433,7 +433,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
-        values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -441,7 +441,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
-        values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -449,7 +449,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
-        values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -457,7 +457,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
-        values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -465,7 +465,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
-        values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -473,7 +473,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "none");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
-        values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
@@ -483,7 +483,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
-        values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
@@ -491,7 +491,7 @@ public class DBHelper extends SQLiteOpenHelper implements
 //      //values.put(DB.ACCOUNT.FORMAT, "");
 //      //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
 //      //values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-//      values.put(DB.ACCOUNT.URL, GooglePlusSynchronizer.PUBLIC_URL);
+//      //values.put(DB.ACCOUNT.URL, GooglePlusSynchronizer.PUBLIC_URL);
 //      insertAccount(arg0, values);
 
         //DBVERSION 26
@@ -500,7 +500,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-        values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
@@ -510,7 +510,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-        values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
@@ -520,7 +520,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-        values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         //values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
@@ -531,7 +531,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
-        values.put(DB.ACCOUNT.URL, "");
+        //values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
 
         //DBVERSION 30
@@ -540,7 +540,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.FORMAT, "tcx");
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
-        values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
+        //values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
     }
 

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -133,7 +133,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,")
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
-            + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
+            + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ") //no longer used
             + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
             + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
 
@@ -517,7 +517,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
-        values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
+        //values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
 
         //DBVERSION 29

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -131,14 +131,18 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,") //Account is not hidden/disabled
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
-            + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
+            + "UNIQUE (" + DB.ACCOUNT.NAME + ")"
+            + ");";
 
     private static final String CREATE_TABLE_REPORT = "create table "
             + DB.EXPORT.TABLE + " ( "
-            + "_id integer primary key autoincrement, " + DB.EXPORT.ACTIVITY
-            + " integer not null, " + DB.EXPORT.ACCOUNT + " integer not null, "
-            + DB.EXPORT.STATUS + " text, " + DB.EXPORT.EXTERNAL_ID + " text, "
-            + DB.EXPORT.EXTRA + " integer not null default 1" + ");";
+            + "_id integer primary key autoincrement, "
+            + DB.EXPORT.ACTIVITY + " integer not null, "
+            + DB.EXPORT.ACCOUNT + " integer not null, "
+            + DB.EXPORT.STATUS + " text, "
+            + DB.EXPORT.EXTERNAL_ID + " text, "
+            + DB.EXPORT.EXTRA + " integer not null default 1"
+            + ");";
 
     private static final String CREATE_TABLE_AUDIO_SCHEMES = "create table "
             + DB.AUDIO_SCHEMES.TABLE + " ( "
@@ -169,8 +173,10 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.FEED.FLAGS + " text ")
             + ");";
 
-    private static final String CREATE_INDEX_FEED = "create index if not exists FEED_START_TIME " +
-            (" on " + DB.FEED.TABLE + " (" + DB.FEED.START_TIME + ")");
+    private static final String CREATE_INDEX_FEED = "create index "
+            + "if not exists FEED_START_TIME "
+            + (" on " + DB.FEED.TABLE + " (" + DB.FEED.START_TIME
+            + ")");
 
     private static DBHelper sInstance = null;
 
@@ -371,94 +377,47 @@ public class DBHelper extends SQLiteOpenHelper implements
         }
     }
 
-    public void insertAccounts(SQLiteDatabase arg0) {
-        ContentValues values;
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
-        values.put(DB.ACCOUNT.ENABLED, 0);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
-        values.put(DB.ACCOUNT.ENABLED, 0);
-        insertAccount(arg0, values);
-
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
-        insertAccount(arg0, values);
-
-//      values = new ContentValues();
-//      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-//      insertAccount(arg0, values);
-
+    public static void insertAccounts(SQLiteDatabase arg0) {
+        //The accounts must exist in the database, but normally the default values are sufficient
+        //ENABLED, FLAGS need to be set if ever changed (like disabled or later enabled)
+        insertAccount(arg0, GarminSynchronizer.NAME, 0, -1);
+        insertAccount(arg0, RunKeeperSynchronizer.NAME);
+        insertAccount(arg0, JoggSESynchronizer.NAME);
+        insertAccount(arg0, FunBeatSynchronizer.NAME);
+        insertAccount(arg0, MapMyRunSynchronizer.NAME);
+        insertAccount(arg0, NikePlusSynchronizer.NAME);
+        insertAccount(arg0, EndomondoSynchronizer.NAME);
+        insertAccount(arg0, RunningAHEADSynchronizer.NAME);
+        insertAccount(arg0, DigifitSynchronizer.NAME);
+        insertAccount(arg0, StravaSynchronizer.NAME);
+        insertAccount(arg0, RunnerUpLiveSynchronizer.NAME, 0, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
+        insertAccount(arg0, FacebookSynchronizer.NAME);
+        //insertAccount(arg0, GooglePlusSynchronizer.NAME);
         //DBVERSION 26
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-        values.put(DB.ACCOUNT.ENABLED, 0);
-        insertAccount(arg0, values);
-
+        insertAccount(arg0, RuntasticSynchronizer.NAME, 0, -1);
         //DBVERSION 27
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-        values.put(DB.ACCOUNT.ENABLED, 0);
-        insertAccount(arg0, values);
-
+        insertAccount(arg0, GoogleFitSynchronizer.NAME, 0, -1);
         //DBVERSION 28
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-        values.put(DB.ACCOUNT.ENABLED, 0);
-        insertAccount(arg0, values);
-
+        insertAccount(arg0, RunningFreeOnlineSynchronizer.NAME, 0, -1);
         //DBVERSION 29
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
-        insertAccount(arg0, values);
-
+        insertAccount(arg0, FileSynchronizer.NAME);
         //DBVERSION 30
-        values = new ContentValues();
-        values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-        insertAccount(arg0, values);
+        insertAccount(arg0, RunalyzeSynchronizer.NAME);
     }
 
-    void insertAccount(SQLiteDatabase arg0, ContentValues arg1) {
+    private static void insertAccount(SQLiteDatabase arg0, String name) {
+        insertAccount(arg0, name, -1, -1);
+    }
+    private static void insertAccount(SQLiteDatabase arg0, String name, int enabled, int flags) {
+        ContentValues arg1 = new ContentValues();
+        arg1.put(DB.ACCOUNT.NAME, name);
+        if(enabled>=0) {
+            arg1.put(DB.ACCOUNT.ENABLED, enabled);
+        }
+        if(flags>=0) {
+            arg1.put(DB.ACCOUNT.ENABLED, flags);
+        }
+
         String cols[] = {
             "_id"
         };
@@ -471,10 +430,9 @@ public class DBHelper extends SQLiteOpenHelper implements
             arg0.insert(DB.ACCOUNT.TABLE, null, arg1);
         else {
             arg0.update(DB.ACCOUNT.TABLE, arg1, DB.ACCOUNT.NAME + " = ?", arr);
-            Log.e(getClass().getName(), "update: " + arg1);
+            Log.e("DBhelper", "update: " + arg1);
         }
         c.close();
-        c = null;
     }
 
     public static ContentValues get(Cursor c) {

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -392,7 +392,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
-        values.put(DB.ACCOUNT.URL, "http://connect.garmin.com/");
+        values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -400,7 +400,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "runkeeper");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
-        values.put(DB.ACCOUNT.URL, "http://runkeeper.com/");
+        values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -408,7 +408,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
-        values.put(DB.ACCOUNT.URL, "http://jogg.se/");
+        values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -416,7 +416,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
-        values.put(DB.ACCOUNT.URL, "http://www.funbeat.se/");
+        values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -424,7 +424,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
-        values.put(DB.ACCOUNT.URL, "http://www.mapmyrun.com/");
+        values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -432,7 +432,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
-        values.put(DB.ACCOUNT.URL, "http://nikeplus.nike.com");
+        values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -440,7 +440,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
-        values.put(DB.ACCOUNT.URL, "http://www.endomondo.com");
+        values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -448,7 +448,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
-        values.put(DB.ACCOUNT.URL, "http://www.runningahead.com");
+        values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -456,7 +456,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
-        values.put(DB.ACCOUNT.URL, "http://www.digifit.com");
+        values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -464,7 +464,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
-        values.put(DB.ACCOUNT.URL, "http://www.strava.com");
+        values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
@@ -472,7 +472,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "none");
         values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
-        values.put(DB.ACCOUNT.URL, "http://weide.devsparkles.se/Demo/Map");
+        values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         insertAccount(arg0, values);
 
@@ -481,7 +481,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
-        values.put(DB.ACCOUNT.URL, "http://www.facebook.com");
+        values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
@@ -498,7 +498,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-        values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
+        values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         //DBVERSION 27
@@ -507,7 +507,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "");
         values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-        values.put(DB.ACCOUNT.URL, "https://fit.google.com");
+        values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         //DBVERSION 28
@@ -516,7 +516,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.FORMAT, "tcx");
         values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-        values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
+        values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         insertAccount(arg0, values);
 

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -385,8 +385,6 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     public void insertAccounts(SQLiteDatabase arg0) {
-        final boolean notyet = false;
-
         ContentValues values;
 
         values = new ContentValues();
@@ -486,66 +484,59 @@ public class DBHelper extends SQLiteOpenHelper implements
         values.put(DB.ACCOUNT.URL, "http://www.facebook.com");
         insertAccount(arg0, values);
 
-        if (notyet) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-            values.put(DB.ACCOUNT.URL, "https://plus.google.com");
-            insertAccount(arg0, values);
-        }
+//      values = new ContentValues();
+//      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
+//      values.put(DB.ACCOUNT.FORMAT, "");
+//      values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+//      values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
+//      values.put(DB.ACCOUNT.URL, "https://plus.google.com");
+//      insertAccount(arg0, values);
 
-        if (DBVERSION >= 26) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-            values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 26
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
+        values.put(DB.ACCOUNT.URL, "http://www.runtastic.com");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 27) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-            values.put(DB.ACCOUNT.URL, "https://fit.google.com");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 27
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
+        values.put(DB.ACCOUNT.URL, "https://fit.google.com");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 28) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-            values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
-            values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 28
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
+        values.put(DB.ACCOUNT.URL, "http://www.runningfreeonline.com");
+        values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 29) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
-            values.put(DB.ACCOUNT.URL, "");
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 29
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
+        values.put(DB.ACCOUNT.URL, "");
+        insertAccount(arg0, values);
 
-        if (DBVERSION >= 30) {
-            values = new ContentValues();
-            values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-            values.put(DB.ACCOUNT.FORMAT, "tcx");
-            values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-            values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
-            values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
-            insertAccount(arg0, values);
-        }
+        //DBVERSION 30
+        values = new ContentValues();
+        values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
+        values.put(DB.ACCOUNT.FORMAT, "tcx");
+        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
+        values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
+        insertAccount(arg0, values);
     }
 
     void insertAccount(SQLiteDatabase arg0, ContentValues arg1) {

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -52,6 +52,8 @@ import org.runnerup.export.RunningAHEADSynchronizer;
 import org.runnerup.export.RunningFreeOnlineSynchronizer;
 import org.runnerup.export.RuntasticSynchronizer;
 import org.runnerup.export.StravaSynchronizer;
+import org.runnerup.export.SyncManager;
+import org.runnerup.export.Synchronizer;
 import org.runnerup.util.FileUtil;
 
 import java.io.File;
@@ -63,7 +65,7 @@ import java.util.List;
 public class DBHelper extends SQLiteOpenHelper implements
         Constants {
 
-    private static final int DBVERSION = 31;
+    private static final int DBVERSION = 32;
     private static final String DBNAME = "runnerup.db";
 
     private static final String CREATE_TABLE_ACTIVITY = "create table "
@@ -126,15 +128,9 @@ public class DBHelper extends SQLiteOpenHelper implements
             + DB.ACCOUNT.TABLE + " ( "
             + ("_id integer primary key autoincrement, ")
             + (DB.ACCOUNT.NAME + " text not null, ")
-            + (DB.ACCOUNT.DESCRIPTION + " text, ") //no longer used
-            + (DB.ACCOUNT.URL + " text, ") //no longer used
-            + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,") //Account is not hidden/disabled
-            + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
-            + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ") //no longer used
-            + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
             + "UNIQUE (" + DB.ACCOUNT.NAME + ")" + ");";
 
     private static final String CREATE_TABLE_REPORT = "create table "
@@ -254,9 +250,10 @@ public class DBHelper extends SQLiteOpenHelper implements
                     + " int");
         }
 
-        if (oldVersion > 0 && oldVersion < 10 && newVersion >= 10) {
-            recreateAccount(arg0);
-        }
+        //Recreated DBVERSION 31->32
+        //if (oldVersion > 0 && oldVersion < 10 && newVersion >= 10) {
+        //    recreateAccount(arg0);
+        //}
 
         if (oldVersion > 0 && oldVersion < 17 && newVersion >= 17) {
             arg0.execSQL(CREATE_TABLE_FEED);
@@ -267,7 +264,7 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         if (oldVersion > 0 && oldVersion < 18 && newVersion >= 18) {
             echoDo(arg0,
-                    "update account set " + DB.ACCOUNT.AUTH_CONFIG + " = '{ \"access_token\":\"' || " + DB.ACCOUNT.AUTH_CONFIG + " || '\" }' where " + DB.ACCOUNT.AUTH_CONFIG + " is not null and " + DB.ACCOUNT.AUTH_METHOD +"='oauth2';");
+                    "update account set " + DB.ACCOUNT.AUTH_CONFIG + " = '{ \"access_token\":\"' || " + DB.ACCOUNT.AUTH_CONFIG + " || '\" }' where " + DB.ACCOUNT.AUTH_CONFIG + " is not null and " + "auth_method" +"='oauth2';");
         }
 
         if (oldVersion > 0 && oldVersion < 19 && newVersion >= 19) {
@@ -295,11 +292,6 @@ public class DBHelper extends SQLiteOpenHelper implements
                     + DB.ACTIVITY.AVG_CADENCE + " real");
         }
 
-        if (oldVersion > 0 && oldVersion < 28 && newVersion >= 28) {
-            echoDo(arg0, "alter table " + DB.ACCOUNT.TABLE + " add column " + DB.ACCOUNT.AUTH_NOTICE
-                    + " integer");
-        }
-
         if (oldVersion > 0 && oldVersion < 31 && newVersion >= 31) {
             echoDo(arg0, "alter table " + DB.LOCATION.TABLE + " add column " + DB.LOCATION.TEMPERATURE
                     + " real");
@@ -315,6 +307,27 @@ public class DBHelper extends SQLiteOpenHelper implements
                     + " real");
             echoDo(arg0, "alter table " + DB.ACTIVITY.TABLE + " add column " + DB.ACTIVITY.META_DATA
                     + " text");
+        }
+
+        if (oldVersion > 0 && oldVersion < 32 && newVersion >= 32) {
+            //Migrate storage of parameters, FORMAT is removed
+            String from[] = { "_id", DB.ACCOUNT.FORMAT, DB.ACCOUNT.AUTH_CONFIG };
+            String args[] = { FileSynchronizer.NAME };
+            Cursor c = arg0.query(DB.ACCOUNT.TABLE, from,
+                    DB.ACCOUNT.NAME + " = ? and " + DB.ACCOUNT.AUTH_CONFIG + " is not null", args,
+                    null, null, null);
+
+            if (c.moveToFirst()) {
+                ContentValues tmp = DBHelper.get(c);
+                c.close();
+                //URL was stored in AUTH_CONFIG previously, FORMAT migrated too
+                tmp.put(DB.ACCOUNT.URL, tmp.getAsString(DB.ACCOUNT.AUTH_CONFIG));
+                String authConfig = FileSynchronizer.contentValuesToAuthConfig(tmp);
+                tmp = new ContentValues();
+                tmp.put(DB.ACCOUNT.AUTH_CONFIG, authConfig);
+                arg0.update(DB.ACCOUNT.TABLE, tmp, DB.ACCOUNT.NAME + " = ?", args);
+            }
+            recreateAccount(arg0);
         }
 
         insertAccounts(arg0);
@@ -351,20 +364,14 @@ public class DBHelper extends SQLiteOpenHelper implements
                 "insert into " + DB.ACCOUNT.TABLE + "_new" +
                         "(_id, " +
                         DB.ACCOUNT.NAME + ", " +
-                        DB.ACCOUNT.URL + ", " +
-                        DB.ACCOUNT.DESCRIPTION + ", " +
-                        DB.ACCOUNT.FORMAT + ", " +
+                        DB.ACCOUNT.FLAGS + ", " +
                         DB.ACCOUNT.ENABLED + ", " +
-                        DB.ACCOUNT.AUTH_METHOD + ", " +
                         DB.ACCOUNT.AUTH_CONFIG + ") " +
                         "select " +
                         "_id, " +
                         DB.ACCOUNT.NAME + ", " +
-                        DB.ACCOUNT.URL + ", " +
-                        DB.ACCOUNT.DESCRIPTION + ", " +
-                        DB.ACCOUNT.FORMAT + ", " +
+                        DB.ACCOUNT.FLAGS + ", " +
                         DB.ACCOUNT.ENABLED + ", " +
-                        DB.ACCOUNT.AUTH_METHOD + ", " +
                         DB.ACCOUNT.AUTH_CONFIG + " " +
                         "FROM " + DB.ACCOUNT.TABLE;
         try {
@@ -385,158 +392,85 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
-        //values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "runkeeper");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
-        //values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "gpx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
-        //values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
-        //values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
-        //values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
-        //values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
-        //values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
-        //values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
-        //values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
-        //values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "none");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
-        //values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
-        //values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
 //      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-//      //values.put(DB.ACCOUNT.FORMAT, "");
-//      //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-//      //values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-//      //values.put(DB.ACCOUNT.URL, GooglePlusSynchronizer.PUBLIC_URL);
 //      insertAccount(arg0, values);
 
         //DBVERSION 26
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
-        //values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 27
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
-        //values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 28
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
-        //values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
-        //values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
         values.put(DB.ACCOUNT.ENABLED, 0);
         insertAccount(arg0, values);
 
         //DBVERSION 29
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
-        //values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
 
         //DBVERSION 30
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-        //values.put(DB.ACCOUNT.FORMAT, "tcx");
-        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
-        //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
-        //values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
     }
 
@@ -547,13 +481,6 @@ public class DBHelper extends SQLiteOpenHelper implements
         String arr[] = {
             arg1.getAsString(DB.ACCOUNT.NAME)
         };
-        //non null in db, used in few synchronizers
-        if (arg1.getAsString(DB.ACCOUNT.FORMAT) == null) {
-            arg1.put(DB.ACCOUNT.FORMAT, "");
-        }
-        if (arg1.getAsString(DB.ACCOUNT.AUTH_METHOD) == null) {
-            arg1.put(DB.ACCOUNT.AUTH_METHOD, "");
-        }
         Cursor c = arg0.query(DB.ACCOUNT.TABLE, cols, DB.ACCOUNT.NAME + " = ?",
                 arr, null, null, null);
         if (!c.moveToFirst())

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -411,28 +411,23 @@ public class DBHelper extends SQLiteOpenHelper implements
     private static void insertAccount(SQLiteDatabase arg0, String name, int enabled, int flags) {
         ContentValues arg1 = new ContentValues();
         arg1.put(DB.ACCOUNT.NAME, name);
-        if(enabled>=0) {
+        if (enabled >= 0) {
             arg1.put(DB.ACCOUNT.ENABLED, enabled);
         }
-        if(flags>=0) {
+        if (flags >= 0) {
             arg1.put(DB.ACCOUNT.ENABLED, flags);
         }
 
-        String cols[] = {
-            "_id"
-        };
-        String arr[] = {
-            arg1.getAsString(DB.ACCOUNT.NAME)
-        };
-        Cursor c = arg0.query(DB.ACCOUNT.TABLE, cols, DB.ACCOUNT.NAME + " = ?",
-                arr, null, null, null);
-        if (!c.moveToFirst())
-            arg0.insert(DB.ACCOUNT.TABLE, null, arg1);
-        else {
+        //SQLite has no UPSERT command. Optimize for no change.
+        long newId = arg0.insertWithOnConflict(DB.ACCOUNT.TABLE, null, arg1, SQLiteDatabase.CONFLICT_IGNORE);
+        if (newId == -1 && arg1.size() > 1) {
+            //values could be updated
+            String arr[] = {
+                    arg1.getAsString(DB.ACCOUNT.NAME)
+            };
             arg0.update(DB.ACCOUNT.TABLE, arg1, DB.ACCOUNT.NAME + " = ?", arr);
-            Log.e("DBhelper", "update: " + arg1);
+            Log.v("DBhelper", "update: " + arg1);
         }
-        c.close();
     }
 
     public static ContentValues get(Cursor c) {

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -354,22 +354,18 @@ public class DBHelper extends SQLiteOpenHelper implements
                         DB.ACCOUNT.URL + ", " +
                         DB.ACCOUNT.DESCRIPTION + ", " +
                         DB.ACCOUNT.FORMAT + ", " +
-                        DB.ACCOUNT.FLAGS + ", " +
                         DB.ACCOUNT.ENABLED + ", " +
                         DB.ACCOUNT.AUTH_METHOD + ", " +
-                        DB.ACCOUNT.AUTH_CONFIG + ", " +
-                        DB.ACCOUNT.AUTH_NOTICE + ") " +
+                        DB.ACCOUNT.AUTH_CONFIG + ") " +
                         "select " +
                         "_id, " +
                         DB.ACCOUNT.NAME + ", " +
                         DB.ACCOUNT.URL + ", " +
                         DB.ACCOUNT.DESCRIPTION + ", " +
                         DB.ACCOUNT.FORMAT + ", " +
-                        DB.ACCOUNT.FLAGS + ", " +
                         DB.ACCOUNT.ENABLED + ", " +
                         DB.ACCOUNT.AUTH_METHOD + ", " +
                         DB.ACCOUNT.AUTH_CONFIG + " " +
-                        DB.ACCOUNT.AUTH_NOTICE + " " +
                         "FROM " + DB.ACCOUNT.TABLE;
         try {
             echoDo(arg0, newtab.toString());

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -128,10 +128,10 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.NAME + " text not null, ")
             + (DB.ACCOUNT.DESCRIPTION + " text, ")
             + (DB.ACCOUNT.URL + " text, ")
-            + (DB.ACCOUNT.FORMAT + " text not null, ")
+            + (DB.ACCOUNT.FORMAT + " text not null, ") //Remove not null
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ")
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,")
-            + (DB.ACCOUNT.AUTH_METHOD + " text not null, ")
+            + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //no longer used
             + (DB.ACCOUNT.AUTH_CONFIG + " text, ")
             + (DB.ACCOUNT.AUTH_NOTICE + " integer null, ")
             + (DB.ACCOUNT.ICON + " integer null, ") //no longer used
@@ -267,7 +267,7 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         if (oldVersion > 0 && oldVersion < 18 && newVersion >= 18) {
             echoDo(arg0,
-                    "update account set auth_config = '{ \"access_token\":\"' || auth_config || '\" }' where auth_config is not null and auth_method='oauth2';");
+                    "update account set " + DB.ACCOUNT.AUTH_CONFIG + " = '{ \"access_token\":\"' || " + DB.ACCOUNT.AUTH_CONFIG + " || '\" }' where " + DB.ACCOUNT.AUTH_CONFIG + " is not null and " + DB.ACCOUNT.AUTH_METHOD +"='oauth2';");
         }
 
         if (oldVersion > 0 && oldVersion < 19 && newVersion >= 19) {
@@ -389,88 +389,88 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GarminSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a0_garminlogo);
         values.put(DB.ACCOUNT.URL, GarminSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunKeeperSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "runkeeper");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "runkeeper");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a1_rklogo);
         values.put(DB.ACCOUNT.URL, RunKeeperSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, JoggSESynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "gpx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "gpx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a5_jogg);
         values.put(DB.ACCOUNT.URL, JoggSESynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FunBeatSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a2_funbeatlogo);
         values.put(DB.ACCOUNT.URL, FunBeatSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, MapMyRunSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a3_mapmyrun_logo);
         values.put(DB.ACCOUNT.URL, MapMyRunSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, NikePlusSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "nikeplus,gpx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a4_nikeplus);
         values.put(DB.ACCOUNT.URL, NikePlusSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, EndomondoSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "endomondotrack");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a6_endomondo);
         values.put(DB.ACCOUNT.URL, EndomondoSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningAHEADSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a7_runningahead);
         values.put(DB.ACCOUNT.URL, RunningAHEADSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, DigifitSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a9_digifit);
         values.put(DB.ACCOUNT.URL, DigifitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, StravaSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a10_strava);
         values.put(DB.ACCOUNT.URL, StravaSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunnerUpLiveSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "none");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "none");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a8_runneruplive);
         values.put(DB.ACCOUNT.URL, RunnerUpLiveSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.FLAGS, (int) (1 << DB.ACCOUNT.FLAG_LIVE));
@@ -478,25 +478,25 @@ public class DBHelper extends SQLiteOpenHelper implements
 
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FacebookSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a11_facebook);
         values.put(DB.ACCOUNT.URL, FacebookSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
 
 //      values = new ContentValues();
 //      values.put(DB.ACCOUNT.NAME, GooglePlusSynchronizer.NAME);
-//      values.put(DB.ACCOUNT.FORMAT, "");
-//      values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
-//      values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
-//      values.put(DB.ACCOUNT.URL, "https://plus.google.com");
+//      //values.put(DB.ACCOUNT.FORMAT, "");
+//      //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+//      //values.put(DB.ACCOUNT.ICON, R.drawable.a12_googleplus);
+//      values.put(DB.ACCOUNT.URL, GooglePlusSynchronizer.PUBLIC_URL);
 //      insertAccount(arg0, values);
 
         //DBVERSION 26
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RuntasticSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a13_runtastic);
         values.put(DB.ACCOUNT.URL, RuntasticSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -504,8 +504,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 27
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, GoogleFitSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
+        //values.put(DB.ACCOUNT.FORMAT, "");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "oauth2");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a14_googlefit);
         values.put(DB.ACCOUNT.URL, GoogleFitSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -513,8 +513,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 28
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunningFreeOnlineSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a15_runningfreeonline);
         values.put(DB.ACCOUNT.URL, RunningFreeOnlineSynchronizer.PUBLIC_URL);
         values.put(DB.ACCOUNT.AUTH_NOTICE, R.string.RunningFreeOnlinePasswordNotice);
@@ -524,7 +524,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, FileSynchronizer.NAME);
         values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "filepermission");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a16_localfile);
         values.put(DB.ACCOUNT.URL, "");
         insertAccount(arg0, values);
@@ -532,8 +532,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         //DBVERSION 30
         values = new ContentValues();
         values.put(DB.ACCOUNT.NAME, RunalyzeSynchronizer.NAME);
-        values.put(DB.ACCOUNT.FORMAT, "tcx");
-        values.put(DB.ACCOUNT.AUTH_METHOD, "post");
+        //values.put(DB.ACCOUNT.FORMAT, "tcx");
+        //values.put(DB.ACCOUNT.AUTH_METHOD, "post");
         //values.put(DB.ACCOUNT.ICON, R.drawable.a17_runalyze);
         values.put(DB.ACCOUNT.URL, RunalyzeSynchronizer.PUBLIC_URL);
         insertAccount(arg0, values);
@@ -546,6 +546,13 @@ public class DBHelper extends SQLiteOpenHelper implements
         String arr[] = {
             arg1.getAsString(DB.ACCOUNT.NAME)
         };
+        //non null in db, used in few synchronizers
+        if (arg1.getAsString(DB.ACCOUNT.FORMAT) == null) {
+            arg1.put(DB.ACCOUNT.FORMAT, "");
+        }
+        if (arg1.getAsString(DB.ACCOUNT.AUTH_METHOD) == null) {
+            arg1.put(DB.ACCOUNT.AUTH_METHOD, "");
+        }
         Cursor c = arg0.query(DB.ACCOUNT.TABLE, cols, DB.ACCOUNT.NAME + " = ?",
                 arr, null, null, null);
         if (!c.moveToFirst())

--- a/app/src/org/runnerup/export/DefaultSynchronizer.java
+++ b/app/src/org/runnerup/export/DefaultSynchronizer.java
@@ -53,8 +53,6 @@ public abstract class DefaultSynchronizer implements Synchronizer {
     protected final Set<String> cookies = new HashSet<String>();
     protected final FormValues formValues = new FormValues();
 
-    private Integer authNotice;
-
     public DefaultSynchronizer() {
         super();
         logout();
@@ -243,11 +241,6 @@ public abstract class DefaultSynchronizer implements Synchronizer {
 
     @Override
     public Integer getAuthNotice() {
-        return authNotice;
-    }
-
-    @Override
-    public void setAuthNotice(Integer authNotice) {
-        this.authNotice = authNotice;
+        return 0;
     }
 }

--- a/app/src/org/runnerup/export/DefaultSynchronizer.java
+++ b/app/src/org/runnerup/export/DefaultSynchronizer.java
@@ -243,4 +243,9 @@ public abstract class DefaultSynchronizer implements Synchronizer {
     public Integer getAuthNotice() {
         return 0;
     }
+
+    @Override
+    public String getUrl() {
+        return PUBLIC_URL;
+    }
 }

--- a/app/src/org/runnerup/export/DefaultSynchronizer.java
+++ b/app/src/org/runnerup/export/DefaultSynchronizer.java
@@ -71,6 +71,12 @@ public abstract class DefaultSynchronizer implements Synchronizer {
     }
 
     @Override
+    public int getIconId() {
+        //0 is used if the resource id cannot be found
+        return 0;
+    }
+
+    @Override
     public void init(ContentValues config) {
         //Note that only auth_config can be expected here
         //Other config can be retrieved from db in Upload()

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -68,6 +68,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     public static final String DIGIFIT_URL = "http://my.digifit.com";
 
     public static final String NAME = "Digifit";
+    public static final String PUBLIC_URL = "http://www.digifit.com";
 
     public static void main(String args[]) throws Exception {
         if (args.length < 2) {

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -35,6 +35,7 @@ import android.util.Pair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.Part;
@@ -310,6 +311,10 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         return NAME;
     }
 
+    @Override
+    public int getIconId() {return R.drawable.a9_digifit;}
+
+    private String getUploadUrl() throws IOException,
     private String getUploadUrl() throws IOException, MalformedURLException, ProtocolException,
             JSONException {
         String getUploadUrl = DIGIFIT_URL + "/rpc/json/workout/import_workouts_url";

--- a/app/src/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/org/runnerup/export/DigifitSynchronizer.java
@@ -314,7 +314,6 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     @Override
     public int getIconId() {return R.drawable.a9_digifit;}
 
-    private String getUploadUrl() throws IOException,
     private String getUploadUrl() throws IOException, MalformedURLException, ProtocolException,
             JSONException {
         String getUploadUrl = DIGIFIT_URL + "/rpc/json/workout/import_workouts_url";

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.EndomondoTrack;
@@ -101,6 +102,9 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a6_endomondo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/org/runnerup/export/EndomondoSynchronizer.java
@@ -63,9 +63,10 @@ import java.util.zip.GZIPOutputStream;
 public class EndomondoSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Endomondo";
-    public static final String AUTH_URL = "https://api.mobile.endomondo.com/mobile/auth";
-    public static final String UPLOAD_URL = "http://api.mobile.endomondo.com/mobile/track";
-    public static final String FEED_URL = "http://api.mobile.endomondo.com/mobile/api/feed";
+    public static final String PUBLIC_URL = "http://www.endomondo.com";
+    private static final String AUTH_URL = "https://api.mobile.endomondo.com/mobile/auth";
+    private static final String UPLOAD_URL = "http://api.mobile.endomondo.com/mobile/track";
+    private static final String FEED_URL = "http://api.mobile.endomondo.com/mobile/api/feed";
 
     long id = 0;
     private String username = null;

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -29,6 +29,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.FacebookCourse;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -141,6 +142,9 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a11_facebook;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/org/runnerup/export/FacebookSynchronizer.java
@@ -54,6 +54,7 @@ import java.util.Locale;
 public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "Facebook";
+    public static final String PUBLIC_URL = "http://www.facebook.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -42,7 +42,8 @@ public class FileSynchronizer extends DefaultSynchronizer {
     public static final String NAME = "File";
 
     private long id = 0;
-    private String mPath = null;
+    private String mPath;
+    private String mFormat;
     
     FileSynchronizer() {
     }
@@ -65,12 +66,19 @@ public class FileSynchronizer extends DefaultSynchronizer {
         return mPath;
     }
 
+    static public String contentValuesToAuthConfig(ContentValues config) {
+        FileSynchronizer f = new FileSynchronizer();
+        f.mPath = config.getAsString(DB.ACCOUNT.URL);
+        f.mFormat = config.getAsString(DB.ACCOUNT.FORMAT);
+        
+        return f.getAuthConfig();
+    }
+
     @Override
     public void init(ContentValues config) {
-        //Note: config contains a subset of account, primarily AUTH_CONFIG
-        //Reuse AUTH_CONFIG to communicate with SyncManager to not change structure too much
-        //path is also in URL (used for display), path is needed in connect()
+        //Temporary format until database is updated, URL is in AUTH_CONFIG
         mPath = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);
+        mFormat = config.getAsString(DB.ACCOUNT.FORMAT);
         id = config.getAsLong("_id");
     }
 
@@ -81,7 +89,7 @@ public class FileSynchronizer extends DefaultSynchronizer {
 
     @Override
     public boolean isConfigured() {
-        return !TextUtils.isEmpty(mPath);
+        return !TextUtils.isEmpty(mPath) && !TextUtils.isEmpty(mFormat);
     }
 
     @Override
@@ -115,19 +123,17 @@ public class FileSynchronizer extends DefaultSynchronizer {
         if ((s = connect()) != Status.OK) {
             return s;
         }
-        ContentValues config = SyncManager.loadConfig(db, this.getName());
-        String format = config.getAsString(DB.ACCOUNT.FORMAT);
 
         try {
             String fileBase = new File(mPath).getAbsolutePath() + File.separator +
             String.format(Locale.getDefault(), "RunnerUp_%04d.", mID);
-            if (format.contains("tcx")) {
+            if (mFormat.contains("tcx")) {
                 TCX tcx = new TCX(db);
                 File file = new File(fileBase + "tcx");
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
                 tcx.export(mID, new OutputStreamWriter(out));
             }
-            if (format.contains("gpx")) {
+            if (mFormat.contains("gpx")) {
                 GPX gpx = new GPX(db, true, true);
                 File file = new File(fileBase + "gpx");
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(file));

--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -23,6 +23,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.text.TextUtils;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
@@ -44,7 +46,7 @@ public class FileSynchronizer extends DefaultSynchronizer {
     private long id = 0;
     private String mPath;
     private String mFormat;
-    
+
     FileSynchronizer() {
     }
 
@@ -76,15 +78,31 @@ public class FileSynchronizer extends DefaultSynchronizer {
 
     @Override
     public void init(ContentValues config) {
-        //Temporary format until database is updated, URL is in AUTH_CONFIG
-        mPath = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);
-        mFormat = config.getAsString(DB.ACCOUNT.FORMAT);
+        String authConfig = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);
+        if (authConfig != null) {
+            try {
+                JSONObject tmp = new JSONObject(authConfig);
+                mPath = tmp.optString(DB.ACCOUNT.URL, null);
+                mFormat = tmp.optString(DB.ACCOUNT.FORMAT);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
         id = config.getAsLong("_id");
     }
 
     @Override
     public String getAuthConfig() {
-        return mPath;
+        JSONObject tmp = new JSONObject();
+        if (isConfigured()) {
+            try {
+                tmp.put(DB.ACCOUNT.URL, mPath);
+                tmp.put(DB.ACCOUNT.FORMAT, mFormat);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+        return tmp.toString();
     }
 
     @Override

--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.text.TextUtils;
 
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.export.format.TCX;
@@ -55,6 +56,9 @@ public class FileSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a16_localfile;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/org/runnerup/export/FileSynchronizer.java
@@ -61,6 +61,11 @@ public class FileSynchronizer extends DefaultSynchronizer {
     public int getIconId() {return R.drawable.a16_localfile;}
 
     @Override
+    public String getUrl() {
+        return mPath;
+    }
+
+    @Override
     public void init(ContentValues config) {
         //Note: config contains a subset of account, primarily AUTH_CONFIG
         //Reuse AUTH_CONFIG to communicate with SyncManager to not change structure too much

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.TCX;
@@ -118,6 +119,9 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a2_funbeatlogo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/org/runnerup/export/FunBeatSynchronizer.java
@@ -61,10 +61,11 @@ import java.util.Map;
 public class FunBeatSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "FunBeat";
-    public static final String BASE_URL = "http://www.funbeat.se";
-    public static final String START_URL = BASE_URL + "/index.aspx";
-    public static final String LOGIN_URL = BASE_URL + "/index.aspx";
-    public static final String UPLOAD_URL = BASE_URL
+    public static final String PUBLIC_URL = "http://www.funbeat.se";
+    private static final String BASE_URL = PUBLIC_URL;
+    private static final String START_URL = BASE_URL + "/index.aspx";
+    private static final String LOGIN_URL = BASE_URL + "/index.aspx";
+    private static final String UPLOAD_URL = BASE_URL
             + "/importexport/upload.aspx";
 
     public static final String API_URL = "http://1.0.0.android.api.funbeat.se/json/Default.asmx/";

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Pair;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -96,6 +97,9 @@ public class GarminSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a0_garminlogo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/org/runnerup/export/GarminSynchronizer.java
@@ -57,8 +57,9 @@ import java.util.Map;
 public class GarminSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Garmin";
+    public static final String PUBLIC_URL = "http://connect.garmin.com";
 
-    public static final String CHOOSE_URL = "http://connect.garmin.com/";
+    private static final String CHOOSE_URL = PUBLIC_URL + "/";
 
     public static final String START_URL = "https://connect.garmin.com/signin";
     public static final String LOGIN_URL = "https://connect.garmin.com/signin";

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.export.format.GoogleFitData;
 import org.runnerup.export.util.SyncHelper;
 
@@ -73,8 +74,10 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
         return NAME;
     }
 
-    public Context getContext() {
-        return context;
+    @Override
+    public int getIconId() {return R.drawable.a14_googlefit;}
+
+    private Context getContext() {        return context;
     }
 
     @Override

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -42,7 +42,8 @@ import java.util.zip.GZIPOutputStream;
 public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
 
     public static final String NAME = "GoogleFit";
-    public static final String REST_URL = "https://www.googleapis.com/fitness/v1/users/me/";
+    public static final String PUBLIC_URL = "https://fit.google.com";
+    private static final String REST_URL = "https://www.googleapis.com/fitness/v1/users/me/";
     public static final String REST_DATASOURCE = "dataSources";
     public static final String REST_DATASETS = "datasets";
     public static final String REST_SESSIONS = "sessions";

--- a/app/src/org/runnerup/export/GoogleFitSynchronizer.java
+++ b/app/src/org/runnerup/export/GoogleFitSynchronizer.java
@@ -77,7 +77,8 @@ public class GoogleFitSynchronizer extends GooglePlusSynchronizer {
     @Override
     public int getIconId() {return R.drawable.a14_googlefit;}
 
-    private Context getContext() {        return context;
+    private Context getContext() {
+        return context;
     }
 
     @Override

--- a/app/src/org/runnerup/export/GooglePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/GooglePlusSynchronizer.java
@@ -44,6 +44,7 @@ import java.net.URL;
 public class GooglePlusSynchronizer extends DefaultSynchronizer implements Synchronizer, OAuth2Server {
 
     public static final String NAME = "Google+";
+    public static final String PUBLIC_URL = "https://plus.google.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/GooglePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/GooglePlusSynchronizer.java
@@ -26,6 +26,7 @@ import android.os.Build;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -161,6 +162,9 @@ public class GooglePlusSynchronizer extends DefaultSynchronizer implements Synch
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a12_googleplus;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/org/runnerup/export/JoggSESynchronizer.java
@@ -55,6 +55,7 @@ import javax.xml.parsers.ParserConfigurationException;
 public class JoggSESynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "jogg.se";
+    public static final String PUBLIC_URL = "http://jogg.se";
     private static String MASTER_USER = null;
     private static String MASTER_KEY = null;
 

--- a/app/src/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/org/runnerup/export/JoggSESynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.util.KXmlSerializer;
@@ -87,6 +88,9 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a5_jogg;}
 
     @Override
     public void init(final ContentValues config) {

--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Pair;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -97,6 +98,9 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a3_mapmyrun_logo;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -50,6 +50,7 @@ import java.util.Map;
 public class MapMyRunSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "MapMyRun";
+    public static final String PUBLIC_URL = "http://www.mapmyrun.com";
     private static String CONSUMER_KEY;
     private static final String BASE_URL = "https://api.mapmyfitness.com/3.1";
     private static final String GET_USER_URL = BASE_URL + "/users/get_user";

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
 import org.runnerup.export.format.GPX;
@@ -107,6 +108,9 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a4_nikeplus;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/org/runnerup/export/NikePlusSynchronizer.java
@@ -60,6 +60,7 @@ import java.util.TimeZone;
 public class NikePlusSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Nike+";
+    public static final String PUBLIC_URL = "http://nikeplus.nike.com";
     private static String CLIENT_ID = null;
     private static String CLIENT_SECRET = null;
     private static String APP_ID = null;

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -190,6 +190,9 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
     }
 
     @Override
+    public int getIconId() {return R.drawable.a1_rklogo;}
+
+    @Override
     public void init(ContentValues config) {
         String authConfig = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);
         id = config.getAsLong("_id");

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -72,7 +72,8 @@ import java.util.concurrent.TimeUnit;
 public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchronizer, OAuth2Server {
 
     public static final String NAME = "RunKeeper";
-    private static Context context = null;
+    public static final String PUBLIC_URL = "http://runkeeper.com";
+    private Context context = null;
     /**
      * @todo register OAuth2Server
      */

--- a/app/src/org/runnerup/export/RunalyzeSynchronizer.java
+++ b/app/src/org/runnerup/export/RunalyzeSynchronizer.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.export.format.RunalyzePost;
 
@@ -76,6 +77,9 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
         _sports = new HashMap<>();
         _types = new HashMap<>();
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a17_runalyze;}
 
     /**
      * Initialzes the synchronizer with the information stored in the DB and passed.

--- a/app/src/org/runnerup/export/RunalyzeSynchronizer.java
+++ b/app/src/org/runnerup/export/RunalyzeSynchronizer.java
@@ -81,6 +81,11 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
     @Override
     public int getIconId() {return R.drawable.a17_runalyze;}
 
+    @Override
+    public String getUrl() {
+        return _url;
+    }
+
     /**
      * Initialzes the synchronizer with the information stored in the DB and passed.
      * @param config The auth config stored in the ddbb

--- a/app/src/org/runnerup/export/RunalyzeSynchronizer.java
+++ b/app/src/org/runnerup/export/RunalyzeSynchronizer.java
@@ -197,7 +197,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
             while ((bytesRead = input.read(buffer)) != -1) {
                 output.write(buffer, 0, bytesRead);
             }
-            result =new String(output.toByteArray());
+            result = new String(output.toByteArray());
         } finally {
             try {
                 if (input != null) {
@@ -214,7 +214,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
                 Log.e(getName(), "Error closing output", e);
             }
         }
-        Log.d(getName(), result);
+        //Log.v(getName(), "getResponse: " + result);
         return result;
     }
 
@@ -229,7 +229,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
         for (Map.Entry<String, List<String>> e : headers.entrySet()) {
             if ("Set-Cookie".equalsIgnoreCase(e.getKey())) {
                 for (String v : e.getValue()) {
-                    Log.d(getName(), "cookie found = " + e);
+                    Log.d(getName(), "cookie found = " + v);
                     if (v.indexOf(";") > 0) {
                         v = v.substring(0, v.indexOf(";"));
                     }
@@ -244,7 +244,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
             this.cookies.add(e.getKey() + "=" + e.getValue() + "; ");
         }
         // cookies
-        Log.d(getName(), "cookies=" + cookies);
+        Log.v(getName(), "cookies=" + cookies);
     }
 
     protected void getCSRFToken(String response) {
@@ -252,7 +252,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
         Matcher matcher = pattern.matcher(response);
         if (matcher.find()) {
             _csrf_token = matcher.group(1);
-            Log.d(getName(), "CSRF token = " + _csrf_token);
+            Log.v(getName(), "CSRF token = " + _csrf_token);
         } else {
             Log.e(getName(), "Failed to get CSRF token");
         }
@@ -267,7 +267,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
     protected int prepareLogin() {
         try {
             URL url = new URL(_url + "/en/login");
-            Log.d(getName(), "URL=" + url);
+            //Log.v(getName(), "URL=" + url);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setInstanceFollowRedirects(false);
@@ -276,7 +276,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
             clearCookies();
             String response = getResponse(conn.getInputStream());
             if (conn.getResponseCode() == 200) {
-                Log.d(getName(), response);
+                //Log.d(getName(), response);
                 getCookies(conn);
                 getCSRFToken(response);
             }
@@ -299,9 +299,9 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
     protected Status login() {
         OutputStreamWriter writer = null;
         try {
-            Log.d(getName(), "Login enter");
+            Log.v(getName(), "Login enter");
             URL url = new URL(_url + (_version3? "/en/login_check" : "/login.php"));
-            Log.d(getName(), "URL=" + url);
+            //Log.v(getName(), "URL=" + url);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setInstanceFollowRedirects(false);
@@ -322,7 +322,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
             if (conn.getResponseCode() == 302 && !response.contains("/en/login")) {
                 clearCookies();
                 getCookies(conn);
-                Log.d(getName(), "Login exit OK");
+                Log.v(getName(), "Login exit OK");
                 return Status.OK;
             } else {
                 Log.e(getName(), "Invalid response code " + conn.getResponseCode());
@@ -454,8 +454,8 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
                 _sports = parseSelect(response, "sportid");
                 _types = parseSelect(response, "typeid");
             }
-            Log.d(getName(), "sports=" + _sports);
-            Log.d(getName(), "types=" + _types);
+            Log.v(getName(), "sports=" + _sports);
+            Log.v(getName(), "types=" + _types);
         } catch(MalformedURLException e) {
             Log.e(getName(), "Could not parse sportid and typeid. Malformed URL", e);
         } catch (ProtocolException e) {
@@ -486,11 +486,11 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
             int rc = prepareLogin();
             if (rc == 404) {
                 // it's a v2 version
-                Log.d(getName(), "Detected version 2.x");
+                Log.v(getName(), "Detected version 2.x");
                 _version3 = false;
             } else if (rc == 200) {
                 // it's v3 version
-                Log.d(getName(), "Detected version 3.x");
+                Log.v(getName(), "Detected version 3.x");
                 _version3 = true;
             } else {
                 // strange error
@@ -520,7 +520,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer {
         try {
             RunalyzePost post = new RunalyzePost(db, _sports, _types);
             URL url = new URL(_url + (_version3? "/activity/add" : "/call/call.Training.create.php"));
-            Log.d(getName(), "URL=" + url);
+            //Log.v(getName(), "URL=" + url);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setInstanceFollowRedirects(false);

--- a/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -80,6 +80,9 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
     }
 
     @Override
+    public int getIconId() {return R.drawable.a8_runneruplive;}
+
+    @Override
     public void init(ContentValues config) {
         id = config.getAsLong("_id");
         String auth = config.getAsString(DB.ACCOUNT.AUTH_CONFIG);

--- a/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -49,6 +49,7 @@ import org.runnerup.workout.WorkoutInfo;
 public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements WorkoutObserver {
 
     public static final String NAME = "RunnerUp LIVE";
+    public static final String PUBLIC_URL = "http://weide.devsparkles.se/Demo/Map";
     private static final String POST_URL = "http://weide.devsparkles.se/api/Resource/";
     private final Context context;
 

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -121,6 +122,9 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a7_runningahead;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -47,6 +47,7 @@ import java.util.zip.GZIPOutputStream;
 public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "RunningAHEAD";
+    public static final String PUBLIC_URL = "http://www.runningahead.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -65,6 +65,9 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     public int getIconId() {return R.drawable.a15_runningfreeonline;}
 
     @Override
+    public Integer getAuthNotice() { return R.string.RunningFreeOnlinePasswordNotice; }
+
+    @Override
     public void init(ContentValues config) {
         id = config.getAsLong("_id");
         final String authToken = config.getAsString(Constants.DB.ACCOUNT.AUTH_CONFIG);

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.export.format.TCX;
 import org.runnerup.util.KXmlSerializer;
@@ -59,6 +60,9 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     public long getId() {
         return id;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a15_runningfreeonline;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -47,6 +47,7 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     private boolean isConnected = false;
 
     public static final String NAME = "RunningFreeOnline";
+    public static final String PUBLIC_URL = "http://www.runningfreeonline.com";
     private static final String BASE_URL = "http://www.runsaturday.com/runsaturday/SportTrackSync.asmx";
     private static final String LOG_TAG = RunningFreeOnlineSynchronizer.class.getName();
 

--- a/app/src/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/org/runnerup/export/RuntasticSynchronizer.java
@@ -50,11 +50,12 @@ import java.util.regex.Matcher;
 public class RuntasticSynchronizer extends DefaultSynchronizer {
 
     public static final String NAME = "Runtastic";
-    public static final String BASE_URL = "https://www.runtastic.com";
-    public static final String START_URL = BASE_URL + "/en/login";
-    public static final String LOGIN_URL = BASE_URL + "/en/d/users/sign_in";
-    public static final String UPLOAD_URL = BASE_URL + "/import/upload_session";
-    public static final String UPDATE_SPORTS_TYPE = BASE_URL + "/import/update_sport_type";
+    public static final String PUBLIC_URL = "http://www.runtastic.com";
+    private static final String BASE_URL = "https://www.runtastic.com";
+    private static final String START_URL = BASE_URL + "/en/login";
+    private static final String LOGIN_URL = BASE_URL + "/en/d/users/sign_in";
+    private static final String UPLOAD_URL = BASE_URL + "/import/upload_session";
+    private static final String UPDATE_SPORTS_TYPE = BASE_URL + "/import/update_sport_type";
 
     long id = 0;
     private String username = null;

--- a/app/src/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/org/runnerup/export/RuntasticSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Patterns;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
@@ -87,6 +88,9 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a13_runtastic;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.format.GPX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -121,6 +122,9 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
     public String getName() {
         return NAME;
     }
+
+    @Override
+    public int getIconId() {return R.drawable.a10_strava;}
 
     @Override
     public void init(ContentValues config) {

--- a/app/src/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/org/runnerup/export/StravaSynchronizer.java
@@ -48,6 +48,7 @@ import java.util.Locale;
 public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Server {
 
     public static final String NAME = "Strava";
+    public static final String PUBLIC_URL = "http://www.strava.com";
 
     /**
      * @todo register OAuth2Server

--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -240,7 +240,6 @@ public class SyncManager {
                 }
             }
             synchronizer.init(config);
-            synchronizer.setAuthNotice(config.getAsInteger(Constants.DB.ACCOUNT.AUTH_NOTICE));
             synchronizers.put(synchronizerName, synchronizer);
             synchronizersById.put(synchronizer.getId(), synchronizer);
         }
@@ -406,7 +405,7 @@ public class SyncManager {
                         : InputType.TYPE_TEXT_VARIATION_PASSWORD));
             }
         });
-        if (sync.getAuthNotice() != null) {
+        if (sync.getAuthNotice() != 0) {
             tvAuthNotice.setVisibility(View.VISIBLE);
             tvAuthNotice.setText(sync.getAuthNotice());
         } else {
@@ -514,16 +513,14 @@ public class SyncManager {
         path += File.separator + "RunnerUp";
         tv1.setText(path);
 
-        String s = "";
         if(!checkStoragePermissions(mActivity)) {
-            s = "Note: Storage permission must be granted in Android settings";
-        }
-        if (sync.getAuthNotice() != null) {
-            s += sync.getAuthNotice();
-        }
-        if ("".equals(s)) {
+            String s = "Note: Storage permission must be granted in Android settings";
             tvAuthNotice.setVisibility(View.VISIBLE);
             tvAuthNotice.setText(s);
+        }
+        else if (sync.getAuthNotice() != 0) {
+            tvAuthNotice.setVisibility(View.VISIBLE);
+            tvAuthNotice.setText(sync.getAuthNotice());
         } else {
             tvAuthNotice.setVisibility(View.GONE);
         }
@@ -1297,7 +1294,6 @@ public class SyncManager {
         String[] from = new String[] {
                 "_id",
                 DB.ACCOUNT.NAME,
-                DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.FLAGS
         };

--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -242,6 +242,8 @@ public class SyncManager {
             synchronizer.init(config);
             synchronizers.put(synchronizerName, synchronizer);
             synchronizersById.put(synchronizer.getId(), synchronizer);
+        } else {
+            Log.e(getClass().getName(), "Synchronizer not found for " + synchronizerName);
         }
         return synchronizer;
     }

--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -143,7 +143,7 @@ public class SyncManager {
 
     public long load(String synchronizerName) {
         String from[] = new String[] {
-                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS, DB.ACCOUNT.FORMAT
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS
         };
         String args[] = {
                 synchronizerName
@@ -512,22 +512,14 @@ public class SyncManager {
                 if (cbgpx.isChecked()) {
                     format += "gpx,";
                 }
-
+                
                 ContentValues tmp = new ContentValues();
                 tmp.put(DB.ACCOUNT.FORMAT, format);
                 tmp.put(DB.ACCOUNT.URL, tv1.getText().toString());
-
                 ContentValues config = new ContentValues();
                 config.put("_id", sync.getId());
                 config.put(DB.ACCOUNT.AUTH_CONFIG, FileSynchronizer.contentValuesToAuthConfig(tmp));
-                config.put(DB.ACCOUNT.FORMAT, format);
                 sync.init(config);
-
-                //temporary, until FORMAT moved to AUTH_CONFIG
-                String args[] = {
-                    Long.toString(sync.getId())
-                };
-                mDB.update(DB.ACCOUNT.TABLE, config, "_id = ?", args);
 
                 handleAuthComplete(sync, sync.connect());
             }
@@ -1243,7 +1235,7 @@ public class SyncManager {
         }
 
         String from[] = new String[] {
-                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS, DB.ACCOUNT.FORMAT
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS
         };
 
         Cursor c = null;
@@ -1270,7 +1262,7 @@ public class SyncManager {
     public Set<String> feedSynchronizersSet(Context ctx) {
         Set<String> set = new HashSet<>();
         String from[] = new String[] {
-                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS, DB.ACCOUNT.FORMAT
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS
         };
 
         SQLiteDatabase db = DBHelper.getReadableDatabase(ctx);

--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -353,9 +353,6 @@ public class SyncManager {
                 ContentValues tmp = new ContentValues();
                 tmp.put("_id", synchronizer.getId());
                 tmp.put(DB.ACCOUNT.AUTH_CONFIG, synchronizer.getAuthConfig());
-                if (!TextUtils.isEmpty(url)) {
-                    tmp.put(DB.ACCOUNT.URL, url);
-                }
                 if (!TextUtils.isEmpty(format)) {
                     tmp.put(DB.ACCOUNT.FORMAT, format);
                 }
@@ -546,15 +543,7 @@ public class SyncManager {
                 }
                 sync.init(config);
 
-                //Set URL used for displaying
-                String url;
-                try {
-                    url = (new File(sync.getAuthConfig())).toURI().toURL().toString();
-                } catch (MalformedURLException e) {
-                    url = "";
-                }
-
-                handleAuthComplete(sync, sync.connect(), url, format);
+                handleAuthComplete(sync, sync.connect(), null, format);
             }
         });
         builder.setNegativeButton(getResources().getString(R.string.Cancel), new OnClickListener() {

--- a/app/src/org/runnerup/export/Synchronizer.java
+++ b/app/src/org/runnerup/export/Synchronizer.java
@@ -57,6 +57,11 @@ public interface Synchronizer {
     }
 
     /**
+     * The default URL, most synchronizers returns this with getUrl()
+     */
+    String PUBLIC_URL = "";
+
+    /**
      * @return
      */
     long getId();
@@ -173,4 +178,9 @@ public interface Synchronizer {
      * @return A string resource id or null.
      */
     Integer getAuthNotice();
+
+    /**
+     * Get the public URL
+     */
+    String getUrl();
 }

--- a/app/src/org/runnerup/export/Synchronizer.java
+++ b/app/src/org/runnerup/export/Synchronizer.java
@@ -173,10 +173,4 @@ public interface Synchronizer {
      * @return A string resource id or null.
      */
     Integer getAuthNotice();
-
-    /**
-     * Set any authorization user notice to be shown when user enters username/password.
-     * @param authNotice String resource id or null.
-     */
-    void setAuthNotice(Integer authNotice);
 }

--- a/app/src/org/runnerup/export/Synchronizer.java
+++ b/app/src/org/runnerup/export/Synchronizer.java
@@ -67,6 +67,11 @@ public interface Synchronizer {
     String getName();
 
     /**
+     * @return The icon resource id
+     */
+    int getIconId();
+
+    /**
      * Init synchronizer
      *
      * @param config

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -135,7 +135,6 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 "_id",
                 DB.ACCOUNT.NAME,
                 DB.ACCOUNT.URL,
-                DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
                 DB.ACCOUNT.AUTH_CONFIG

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -32,6 +32,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -134,8 +135,6 @@ public class AccountActivity extends AppCompatActivity implements Constants {
         String[] from = new String[]{
                 "_id",
                 DB.ACCOUNT.NAME,
-                DB.ACCOUNT.URL,
-                DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
                 DB.ACCOUNT.AUTH_CONFIG
         };
@@ -169,15 +168,15 @@ public class AccountActivity extends AppCompatActivity implements Constants {
 
             addRow("", null);
 
-            if (tmp.containsKey(DB.ACCOUNT.URL)) {
+            if (!TextUtils.isEmpty(synchronizer.getUrl())) {
                 Button btn = new Button(this);
-                btn.setText(tmp.getAsString(DB.ACCOUNT.URL));
+                btn.setText(synchronizer.getUrl());
                 //TODO SDK 24 requires the file URI to be handled as FileProvider
                 //Something like OI File Manager is needed too
                 if (Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.NAME).equals(FileSynchronizer.NAME)) {
                     btn.setOnClickListener(urlButtonClick);
                 }
-                btn.setTag(tmp.getAsString(DB.ACCOUNT.URL));
+                btn.setTag(synchronizer.getUrl());
                 addRow(getResources().getString(R.string.Website) + ":", btn);
             }
 

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -137,7 +137,6 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
-                DB.ACCOUNT.ICON,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.AUTH_METHOD
         };
@@ -158,14 +157,14 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 ImageView im = (ImageView) findViewById(R.id.account_list_icon);
                 TextView tv = (TextView) findViewById(R.id.account_list_name);
                 tv.setText(tmp.getAsString(DB.ACCOUNT.NAME));
-                if (c.isNull(c.getColumnIndex(DB.ACCOUNT.ICON))) {
+                if (synchronizer.getIconId() == 0) {
                     im.setVisibility(View.GONE);
                     tv.setVisibility(View.VISIBLE);
                 } else {
                     im.setVisibility(View.VISIBLE);
                     tv.setVisibility(View.GONE);
-                    im.setBackgroundResource(tmp.getAsInteger(DB.ACCOUNT.ICON));
-                    synchronizerIcon = tmp.getAsInteger(DB.ACCOUNT.ICON);
+                    im.setBackgroundResource(synchronizer.getIconId());
+                    synchronizerIcon = synchronizer.getIconId();
                 }
             }
 

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -133,10 +133,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
         // Fields from the database (projection)
         // Must include the _id column for the adapter to work
         String[] from = new String[]{
-                "_id",
-                DB.ACCOUNT.NAME,
-                DB.ACCOUNT.FLAGS,
-                DB.ACCOUNT.AUTH_CONFIG
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.FLAGS, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FORMAT
         };
 
         String args[] = {

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -133,7 +133,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
         // Fields from the database (projection)
         // Must include the _id column for the adapter to work
         String[] from = new String[]{
-                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.FLAGS, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FORMAT
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.FLAGS, DB.ACCOUNT.AUTH_CONFIG
         };
 
         String args[] = {

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -49,6 +49,7 @@ import android.widget.TextView;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.db.DBHelper;
+import org.runnerup.export.FileSynchronizer;
 import org.runnerup.export.RunnerUpLiveSynchronizer;
 import org.runnerup.export.SyncManager;
 import org.runnerup.export.Synchronizer;
@@ -137,8 +138,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.FLAGS,
-                DB.ACCOUNT.AUTH_CONFIG,
-                DB.ACCOUNT.AUTH_METHOD
+                DB.ACCOUNT.AUTH_CONFIG
         };
 
         String args[] = {
@@ -173,9 +173,9 @@ public class AccountActivity extends AppCompatActivity implements Constants {
             if (tmp.containsKey(DB.ACCOUNT.URL)) {
                 Button btn = new Button(this);
                 btn.setText(tmp.getAsString(DB.ACCOUNT.URL));
-                //TODO SDK 24 requires the file URI to be handled as FileProvider, don't care yet
-                //For <= 24, something like OI File Manager is needed too
-                if(Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.AUTH_METHOD).contains("filepermission")) {
+                //TODO SDK 24 requires the file URI to be handled as FileProvider
+                //Something like OI File Manager is needed too
+                if(Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.NAME).equals(FileSynchronizer.NAME)) {
                     btn.setOnClickListener(urlButtonClick);
                 }
                 btn.setTag(tmp.getAsString(DB.ACCOUNT.URL));

--- a/app/src/org/runnerup/view/AccountActivity.java
+++ b/app/src/org/runnerup/view/AccountActivity.java
@@ -102,7 +102,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
 
         {
             Button btn = (Button) findViewById(R.id.account_download_button);
-            if (upd.checkSupport(Synchronizer.Feature.ACTIVITY_LIST) && upd.checkSupport(Synchronizer.Feature.GET_ACTIVITY)) {
+            if (upd != null && upd.checkSupport(Synchronizer.Feature.ACTIVITY_LIST) && upd.checkSupport(Synchronizer.Feature.GET_ACTIVITY)) {
                 btn.setOnClickListener(downloadButtonClick);
             } else {
                 btn.setVisibility(View.GONE);
@@ -131,7 +131,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
     void fillData() {
         // Fields from the database (projection)
         // Must include the _id column for the adapter to work
-        String[] from = new String[] {
+        String[] from = new String[]{
                 "_id",
                 DB.ACCOUNT.NAME,
                 DB.ACCOUNT.URL,
@@ -175,7 +175,7 @@ public class AccountActivity extends AppCompatActivity implements Constants {
                 btn.setText(tmp.getAsString(DB.ACCOUNT.URL));
                 //TODO SDK 24 requires the file URI to be handled as FileProvider
                 //Something like OI File Manager is needed too
-                if(Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.NAME).equals(FileSynchronizer.NAME)) {
+                if (Build.VERSION.SDK_INT < 24 || !tmp.getAsString(DB.ACCOUNT.NAME).equals(FileSynchronizer.NAME)) {
                     btn.setOnClickListener(urlButtonClick);
                 }
                 btn.setTag(tmp.getAsString(DB.ACCOUNT.URL));

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -115,11 +115,7 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
     @Override
     public Loader<Cursor> onCreateLoader(int arg0, Bundle arg1) {
         String[] from = new String[] {
-                "_id",
-                DB.ACCOUNT.NAME,
-                DB.ACCOUNT.ENABLED,
-                DB.ACCOUNT.AUTH_CONFIG,
-                DB.ACCOUNT.FLAGS
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS, DB.ACCOUNT.FORMAT
         };
         String showDisabled = null;
         if (!mShowDisabled) {

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -113,7 +113,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
-                DB.ACCOUNT.AUTH_NOTICE,
                 DB.ACCOUNT.FLAGS
         };
 

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -115,7 +115,7 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
     @Override
     public Loader<Cursor> onCreateLoader(int arg0, Bundle arg1) {
         String[] from = new String[] {
-                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS, DB.ACCOUNT.FORMAT
+                "_id", DB.ACCOUNT.NAME, DB.ACCOUNT.AUTH_CONFIG, DB.ACCOUNT.FLAGS
         };
         String showDisabled = null;
         if (!mShowDisabled) {

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -117,7 +117,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
         String[] from = new String[] {
                 "_id",
                 DB.ACCOUNT.NAME,
-                DB.ACCOUNT.URL,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.FLAGS

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -59,6 +59,7 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
     SQLiteDatabase mDB = null;
     SyncManager mSyncManager = null;
     boolean mTabFormat = false;
+    private boolean mShowDisabled = false;
     ListView mListView;
     CursorAdapter mCursorAdapter;
 
@@ -100,6 +101,11 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 item.setTitle(getString(R.string.Icon_list));
                 getSupportLoaderManager().restartLoader(0, null, this);
                 break;
+            case R.id.menu_show_disabled:
+                mShowDisabled = !mShowDisabled;
+                item.setChecked(mShowDisabled);
+                getSupportLoaderManager().restartLoader(0, null, this);
+                break;
         }
         return true;
     }
@@ -115,9 +121,13 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.FLAGS
         };
+        String showDisabled = null;
+        if (!mShowDisabled) {
+            showDisabled = DB.ACCOUNT.ENABLED + "==1";
+        }
 
-        return new SimpleCursorLoader(this, mDB, DB.ACCOUNT.TABLE, from, null, null,
-                DB.ACCOUNT.ENABLED + " desc, " + DB.ACCOUNT.AUTH_CONFIG + " is null, " + DB.ACCOUNT.NAME);
+        return new SimpleCursorLoader(this, mDB, DB.ACCOUNT.TABLE, from, showDisabled, null,
+                DB.ACCOUNT.AUTH_CONFIG + " is null, " + DB.ACCOUNT.ENABLED + " desc, " + DB.ACCOUNT.NAME);
     }
 
     @Override

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -118,7 +118,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 "_id",
                 DB.ACCOUNT.NAME,
                 DB.ACCOUNT.URL,
-                DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.FLAGS

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -112,7 +112,6 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
                 DB.ACCOUNT.URL,
                 DB.ACCOUNT.DESCRIPTION,
                 DB.ACCOUNT.ENABLED,
-                DB.ACCOUNT.ICON,
                 DB.ACCOUNT.AUTH_CONFIG,
                 DB.ACCOUNT.AUTH_NOTICE,
                 DB.ACCOUNT.FLAGS
@@ -175,15 +174,14 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
 
             boolean configured = mSyncManager.isConfigured(id);
             if (!mTabFormat) {
-                if (cursor.isNull(cursor.getColumnIndex(DB.ACCOUNT.ICON))) {
+                if (synchronizer.getIconId() == 0) {
                     accountIcon.setVisibility(View.GONE);
                     accountNameText.setVisibility(View.VISIBLE);
                     accountNameText.setText(tmp.getAsString(DB.ACCOUNT.NAME));
                 } else {
                     accountIcon.setVisibility(View.VISIBLE);
                     accountNameText.setVisibility(View.GONE);
-                    accountIcon.setBackgroundResource(tmp
-                            .getAsInteger(DB.ACCOUNT.ICON));
+                    accountIcon.setBackgroundResource(synchronizer.getIconId());
                 }
                 accountUploadBox.setVisibility(View.GONE);
                 accountFeedBox.setVisibility(View.GONE);

--- a/app/src/org/runnerup/view/AccountListActivity.java
+++ b/app/src/org/runnerup/view/AccountListActivity.java
@@ -35,6 +35,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -77,6 +78,7 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
         mListView.setDividerHeight(10);
         mCursorAdapter = new AccountListAdapter(this, null);
         mListView.setAdapter(mCursorAdapter);
+        mListView.setOnItemLongClickListener(itemLongClickListener);
         getSupportLoaderManager().initLoader(0, null, this);
     }
 
@@ -244,6 +246,21 @@ public class AccountListActivity extends AppCompatActivity implements Constants,
             } else {
                 mSyncManager.connect(callback, synchronizerName, false);
             }
+        }
+    };
+
+    final AdapterView.OnItemLongClickListener itemLongClickListener = new AdapterView.OnItemLongClickListener() {
+        public boolean onItemLongClick(AdapterView<?> arg0, View v,
+                                    int pos, long id) {
+            ContentValues tmp = DBHelper.get((Cursor)arg0.getItemAtPosition(pos));
+            final String synchronizerName = tmp.getAsString(DB.ACCOUNT.NAME);
+
+            //Toggle value for ENABLED
+            mDB.execSQL("update " + DB.ACCOUNT.TABLE + " set " + DB.ACCOUNT.ENABLED + " = 1 - " + DB.ACCOUNT.ENABLED +
+                    " where " + DB.ACCOUNT.NAME + " = \'" + synchronizerName + "\'");
+            getSupportLoaderManager().restartLoader(0, null, (AccountListActivity)v.getContext());
+
+            return true;
         }
     };
 

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -336,7 +336,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
-                    + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
+                    + ("  acc." + DB.ACCOUNT.FORMAT + ", ")
                     + ("  rep._id as repid, ")
                     + ("  rep." + DB.EXPORT.ACCOUNT + ", ")
                     + ("  rep." + DB.EXPORT.ACTIVITY + ", ")

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -334,7 +334,6 @@ public class DetailActivity extends AppCompatActivity implements Constants {
             String sql = "SELECT DISTINCT "
                     + "  acc._id, " // 0
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
-                    + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -600,7 +600,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
             }
 
             ContentValues tmp = reports.get(position);
-            String name = tmp.getAsString("name");
+            String name = tmp.getAsString(DB.ACCOUNT.NAME);
             viewHolder.cb.setChecked(false);
             viewHolder.cb.setEnabled(false);
             viewHolder.cb.setTag(name);

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -347,8 +347,8 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + (" ON ( acc._id = rep." + DB.EXPORT.ACCOUNT)
                     + ("     AND rep." + DB.EXPORT.ACTIVITY + " = "
                     + mID + " )")
-                    + (" WHERE acc." + DB.ACCOUNT.ENABLED + " != 0 ")
-                    + ("   AND acc." + DB.ACCOUNT.AUTH_CONFIG + " is not null");
+                    //Note: Show also accounts that are not enabled
+                    + (" WHERE acc." + DB.ACCOUNT.AUTH_CONFIG + " is not null");
 
             Cursor c = mDB.rawQuery(sql, null);
             alreadySynched.clear();

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -336,7 +336,6 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
-                    + ("  acc." + DB.ACCOUNT.AUTH_METHOD + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
                     + ("  rep._id as repid, ")

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -336,7 +336,6 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
-                    + ("  acc." + DB.ACCOUNT.FORMAT + ", ")
                     + ("  rep._id as repid, ")
                     + ("  rep." + DB.EXPORT.ACCOUNT + ", ")
                     + ("  rep." + DB.EXPORT.ACTIVITY + ", ")

--- a/app/src/org/runnerup/view/FeedActivity.java
+++ b/app/src/org/runnerup/view/FeedActivity.java
@@ -275,34 +275,6 @@ public class FeedActivity extends Activity implements Constants {
                     tv3.setVisibility(View.GONE);
                 }
 
-                // c.put(FEED.FEED_TYPE, FEED.FEED_TYPE_ACTIVITY);
-                // c.put(FEED.FEED_SUBTYPE,
-                // getTrainingType(o.getInt("TrainingTypeID"),
-                // o.getString("TrainingTypeName")));
-                // c.put(FEED.FEED_TYPE_STRING,
-                // o.getString("TrainingTypeName"));
-                // c.put(FEED.START_TIME,
-                // parseDateTime(o.getString("DateTime")));
-                // if (!o.isNull("Distance"))
-                // c.put(FEED.DISTANCE, 1000 * o.getDouble("Distance"));
-                // if (!o.isNull("Duration"))
-                // c.put(FEED.DURATION,
-                // getDuration(o.getJSONObject("Duration")));
-                // if (!o.isNull("PersonID"))
-                // c.put(FEED.USER_ID, o.getInt("PersonID"));
-                // if (!o.isNull("Firstname"))
-                // c.put(FEED.USER_FIRST_NAME, o.getString("Firstname"));
-                // if (!o.isNull("Lastname"))
-                // c.put(FEED.USER_LAST_NAME, o.getString("Lastname"));
-                // if (!o.isNull("PictureURL"))
-                // c.put(FEED.USER_IMAGE_URL,
-                // o.getString("PictureURL").replace("~/",
-                // "http://www.funbeat.se/"));
-                // if (!o.isNull("Description"))
-                // c.put(FEED.NOTES, o.getString("Description"));
-                // c.put(FEED.URL,
-                // "http://www.funbeat.se/training/show.aspx?TrainingID="
-                // + Long.toString(o.getLong("ID")));
                 return v;
             } else {
                 TextView tv = new TextView(context);

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -351,7 +351,6 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
                     + "  acc._id, " // 0
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
-                    + ("  acc." + DB.ACCOUNT.AUTH_METHOD + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + " ")

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -352,8 +352,7 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
-                    + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
-                    + ("  acc." + DB.ACCOUNT.FORMAT + " ")
+                    + ("  acc." + DB.ACCOUNT.FLAGS + " ")
                     + (" FROM " + DB.ACCOUNT.TABLE + " acc ");
 
             Cursor c = mDB.rawQuery(sql, null);

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -369,7 +369,9 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
 
         for (ContentValues tmp : allSynchronizers) {
             Synchronizer synchronizer = syncManager.add(tmp);
-            if (synchronizer != null && synchronizer.checkSupport(Synchronizer.Feature.WORKOUT_LIST)) {
+            //There is no option to show disabled providers, so check for enable or configured
+            if (synchronizer != null && synchronizer.checkSupport(Synchronizer.Feature.WORKOUT_LIST) &&
+                    (tmp.getAsInteger(DB.ACCOUNT.ENABLED) == 1 || tmp.getAsString(DB.ACCOUNT.AUTH_CONFIG) != null) ) {
                 providers.add(tmp);
 
                 workouts.remove(synchronizer.getName());

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -350,7 +350,6 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
             String sql = "SELECT DISTINCT "
                     + "  acc._id, " // 0
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
-                    + ("  acc." + DB.ACCOUNT.DESCRIPTION + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + " ")

--- a/app/src/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/org/runnerup/view/ManageWorkoutsActivity.java
@@ -352,7 +352,8 @@ public class ManageWorkoutsActivity extends Activity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
                     + ("  acc." + DB.ACCOUNT.ENABLED + ", ")
-                    + ("  acc." + DB.ACCOUNT.FLAGS + " ")
+                    + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
+                    + ("  acc." + DB.ACCOUNT.FORMAT + " ")
                     + (" FROM " + DB.ACCOUNT.TABLE + " acc ");
 
             Cursor c = mDB.rawQuery(sql, null);

--- a/common/src/main/java/org/runnerup/common/util/Constants.java
+++ b/common/src/main/java/org/runnerup/common/util/Constants.java
@@ -116,15 +116,12 @@ public interface Constants {
         public interface ACCOUNT {
             public static final String TABLE = "account";
             public static final String NAME = "name";
-            public static final String URL = "url";
-            public static final String DESCRIPTION = "description";
-            public static final String FORMAT = "format";
             public static final String FLAGS = "default_send";
             public static final String ENABLED = "enabled";
-            public static final String AUTH_METHOD = "auth_method";
             public static final String AUTH_CONFIG = "auth_config";
-            public static final String ICON = "icon";
-            public static final String AUTH_NOTICE = "auth_notice";
+
+            public static final String URL = "url";
+            public static final String FORMAT = "format";
 
             public static final int FLAG_UPLOAD = 0;
             public static final int FLAG_FEED = 1;

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -117,6 +117,7 @@
   <string name="synchronizing_feed">synkroniserar flöde…</string>
   <string name="OK">Ok</string>
   <string name="Table_format">Tabellformat</string>
+  <string name="Show_disabled_accounts">Visa inaktiverade konton</string>
   <string name="Clear_uploads">Rensa uppladdningar</string>
   <string name="Upload_missing_workouts">Ladda upp (saknade) träningspass</string>
   <string name="Disconnect_account">Koppla ifrån konto</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
   <string name="synchronizing_feed">synchronizing feed…</string>
   <string name="OK">OK</string>
   <string name="Table_format">Table format</string>
+  <string name="Show_disabled_accounts">Show disabled accounts</string>
   <string name="Clear_uploads">Clear uploads</string>
   <string name="Upload_missing_workouts">Upload (missing) workouts</string>
   <string name="Disconnect_account">Disconnect account</string>


### PR DESCRIPTION
The ACCOUNT table contains several columns that are no longer used
These are confusing (the FileSynchronizer was unnecessary complicated due to this).
All "account specific data" is now in AUTH_CONFIG.

Most preparations done in #593 (with preparations in #589 #590 ).
The actual database change has been kept minimal (to simplify moving back and forward between branches).