### PR TITLE
apk abi split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ before_cache:
 
 android:
     components:
-        - tools #latest for "builtin" sdk (24.4.1 in Android-24)
+        - tools #latest for "builtin" sdk tools (24.4.1 in Android-25)
         #To update SDK Tools to latest, another update is required
         #- tools #latest, 25.2.4 as of 2016-12-16
         - platform-tools #latest, 25.0.3 as of 2016-12-17
-        - build-tools-25.0.2
+        - build-tools-26.0.1
         - android-25
         - extra-android-m2repository
         - extra-google-m2repository

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -40,7 +40,7 @@
 	<application
 	    android:icon="@drawable/ic_launcher"
 	    android:label="@string/app_name"
-		android:extractNativeLibs="true"
+		android:extractNativeLibs="false"
 		android:theme="@style/AppTheme">
 
 		<activity

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,7 @@ dependencies {
 
     latestCompile "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesVersion}"
     latestCompile 'com.getpebble:pebblekit:4.0.1'
-    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar'){
+    latestCompile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.1@aar'){
         transitive=true
     }
     compile 'com.jjoe64:graphview:4.2.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,9 @@ android {
 }
 
 repositories {
+    maven {
+        url "https://maven.google.com"
+    }
     //jcenter and mavenCentral normally have the same packages but there may be a delay after updating the primary
     jcenter()
     mavenCentral() //MapBox GraphView

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,14 +49,23 @@ android {
             minSdkVersion 15
             targetSdkVersion rootProject.ext.compileSdkVersion
             versionName rootProject.ext.versionName
-            versionCode rootProject.ext.versionCode
+            versionCode 14000000 + rootProject.ext.versionCode
         }
         froyo {
             dimension "all"
             minSdkVersion 8
             targetSdkVersion rootProject.ext.targetSdkVersion
             versionName rootProject.ext.versionName
-            versionCode rootProject.ext.froyoVersionCode
+            versionCode 8000000 + rootProject.ext.versionCode
+        }
+    }
+
+    splits {
+        abi {
+            //We would have preferred to not create split for Froyo, so explicitly enabling split
+            //.\gradlew --project-prop splitApk assembleLatestRelease
+            enable project.hasProperty('splitApk')
+            universalApk true
         }
     }
 
@@ -173,6 +182,28 @@ android.applicationVariants.all { variant ->
             content = content.replaceAll(/mapboxMapID.*/, "mapboxMapID\">" + props.mapboxid + "</string>")
             content = content.replaceAll(/mapboxAccessToken.*/, "mapboxAccessToken\">" + props.mapboxAccessToken + "</string>")
             valuesFile.write(content, 'UTF-8')
+        }
+    }
+}
+
+//Based on an example from https://developer.android.com/studio/build/configure-apk-splits.html
+//Most comments from there removed
+
+// Map for the version code that gives each ABI a value.
+ext.abiCodes = ['arm64-v8a': 1, 'armeabi':2, 'armeabi-v7a':3, 'mips':4, 'mips64':5, 'x86':6, 'x86_64':7]
+
+import com.android.build.OutputFile
+
+// For each APK output variant, override versionCode with a combination of
+// ext.abiCodes * 10000 + variant.versionCode. (universal gets no offset)
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def baseAbiVersionCode =
+                project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+
+        if (baseAbiVersionCode != null) {
+            output.versionCodeOverride =
+                    baseAbiVersionCode * 10000 + variant.versionCode
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,14 +42,17 @@ android {
         test.setRoot('test')
     }
 
+    flavorDimensions "all"
     productFlavors {
         latest {
+            dimension "all"
             minSdkVersion 15
             targetSdkVersion rootProject.ext.compileSdkVersion
             versionName rootProject.ext.versionName
             versionCode rootProject.ext.versionCode
         }
         froyo {
+            dimension "all"
             minSdkVersion 8
             targetSdkVersion rootProject.ext.targetSdkVersion
             versionName rootProject.ext.versionName
@@ -109,7 +112,7 @@ android {
 
 repositories {
     //jcenter and mavenCentral normally have the same packages but there may be a delay after updating the primary
-    jcenter() //Google
+    jcenter()
     mavenCentral() //MapBox GraphView
     maven { url "https://oss.sonatype.org/content/groups/public/" } //pebblekit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
+}
 
+repositories {
+    maven {
+        url "https://maven.google.com"
+    }
 }
 
 project.ext {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ project.ext {
     //Note that Android Studio does not know about the 'ext' module and will warn
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
-    buildToolsVersion = '25.0.2' //Update Travis manually
+    buildToolsVersion = '26.0.1' //Update Travis manually
     compileSdkVersion = 25 //Update Travis manually
     targetSdkVersion = 25
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,7 @@ project.ext {
     mockitoVersion = '2.3.7'
 
     versionName = '1.57'
-    versionCode = 14000057
-    froyoVersionCode = 8000057
+    versionCode = 57
 
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,9 @@ project.ext {
     compileSdkVersion = 25 //Update Travis manually
     targetSdkVersion = 25
 
-    supportLibrary = '25.2.0'
-    //googlePlayServicesVersion = '9.6.0'
-    googlePlayServicesVersion = '10.2.0'
-    googleWearVersion = '2.0.0'
+    supportLibrary = '25.3.1'
+    googlePlayServicesVersion = '11.0.4'
+    googleWearVersion = '2.0.4'
 
     junitVersion = '4.12'
     mockitoVersion = '2.3.7'

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -52,6 +52,12 @@ android {
     }
 }
 
+repositories {
+    maven {
+        url "https://maven.google.com"
+    }
+}
+
 dependencies {
     compile project(':common')
 


### PR DESCRIPTION
Enable apk split per ABI, #588

Minimize the .apk size, unpacked(compressed) from 41(17)MB to 11(7)MB
Libraries are no longer stored compressed in the .apk, so the universal apk size increses

Unfortunately, there is no way to avoid for Froyo or Debug:
https://stackoverflow.com/questions/27964484/android-gradle-is-use-splits-only-for-release-possible

The functionality is not enabled by default as Froyo (that should not have splits) cannot be excluded as well as builds are slower.
Set variable splitApk from commandline
.\gradlew --project-prop splitApk assembleLatestRelease

Note: When uploading to Play (and F-Droid?) the universal apk for Latest should not be included, as all abi are already included (there were at least errors reported about this)

To only enable for a few targets (and have "fat" or universal for others) set in the splits.abi closure:

      reset()
      include 'x86', 'armeabi-v7a', 'armeabi-v8a'


Based on #572