### PR TITLE
Update Travis build host to Ubuntu Trusty (14.04) (was Precise, 12.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty #Force trusty for git-lfs (default from 2017-09)
+
 language: android
 
 jdk:


### PR DESCRIPTION
Also implies "sudo: false"
This will be the default from September (migration being done), then the setting can be removed
This speeds up builds and enables git-lfs by default