### PR TITLE
Upload status was not set when uploading from accounts

### DIFF
--- a/app/src/org/runnerup/export/SyncManager.java
+++ b/app/src/org/runnerup/export/SyncManager.java
@@ -1115,6 +1115,7 @@ public class SyncManager {
         mSpinner.setProgress(syncActivitiesList.size());
         SyncActivityItem ai = syncActivitiesList.get(0);
         syncActivitiesList.remove(0);
+        mID = ai.getId();
         doSyncMulti(synchronizer, mode, ai);
     }
 


### PR DESCRIPTION
Discussed in #574
The activity id global mID was not set for bulk uploads started from UploadActivity
It seems like it worked like this for a long time, I looked hard for a regression