### PR TITLE
Implementing heart rate display on Pebble

### DIFF
--- a/app/latest/java/org/runnerup/tracker/component/TrackerPebble.java
+++ b/app/latest/java/org/runnerup/tracker/component/TrackerPebble.java
@@ -129,7 +129,7 @@ public class TrackerPebble extends DefaultTrackerComponent implements WorkoutObs
             data.addUint8(Constants.SPORTS_HR_BPM_KEY, (byte) workoutInfo.getHeartRate(Scope.CURRENT));
         }
         data.addString(Constants.SPORTS_CUSTOM_LABEL_KEY, "SPEED");
-        data.addString(Constants.SPORTS_CUSTOM_VALUE_KEY, formatter.format(Formatter.Format.TXT_SHORT, Dimension.SPEED, workoutInfo.getSpeed(Scope.ACTIVITY)));
+        data.addString(Constants.SPORTS_CUSTOM_VALUE_KEY, formatter.format(Formatter.Format.TXT_SHORT, Dimension.SPEED, workoutInfo.getSpeed(Scope.CURRENT)));
         data.addUint8(Constants.SPORTS_LABEL_KEY, (byte) Constants.SPORTS_DATA_PACE);
         data.addUint8(Constants.SPORTS_UNITS_KEY, isMetric ? (byte) Constants.SPORTS_UNITS_METRIC : (byte) Constants.SPORTS_UNITS_IMPERIAL);
 


### PR DESCRIPTION
Proposed implementation of heart rate display on Pebble as requested in #98.

The current heart rate appears as a scrollable field if a heart rate monitor is detected.

I initially tried to use Pebble's dedicated field `Constants.SPORTS_HR_BPM_KEY` as documented [here](https://developer.pebble.com/docs/pebblekit-android/com/getpebble/android/kit/Constants/#SPORTS_HR_BPM_KEY).  The display is sexier (it displays a small heart), but I couldn't get the correct value to be displayed.  Even a simple text such as "80" gets displayed as a different value!