### PR TITLE
Play Services removed getOpenSourceSoftwareLicenseInfo()

### DIFF
--- a/app/latest/java/org/runnerup/widget/AboutPreference.java
+++ b/app/latest/java/org/runnerup/widget/AboutPreference.java
@@ -57,21 +57,14 @@ public class AboutPreference extends DialogPreference {
         return res;
     }
 
-    private boolean isPlayPref(Context ctx) {
-        Resources res = ctx.getResources();
-        return this.getKey() != null && this.getKey().contentEquals(res.getString(R.string.pref_googleplayserviceslegalnotices));
-    }
-
     @Override
     public void onClick(DialogInterface dialog, int which) {
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            if (!isPlayPref(this.getContext())) {
-                try {
-                    Uri uri = Uri.parse("market://details?id=" + this.getContext().getPackageName());
-                    this.getContext().startActivity(new Intent(Intent.ACTION_VIEW, uri));
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
+            try {
+                Uri uri = Uri.parse("market://details?id=" + this.getContext().getPackageName());
+                this.getContext().startActivity(new Intent(Intent.ACTION_VIEW, uri));
+            } catch (Exception ex) {
+                ex.printStackTrace();
             }
         }
     }
@@ -79,34 +72,24 @@ public class AboutPreference extends DialogPreference {
     @Override
     protected void onBindDialogView(View view) {
         super.onBindDialogView(view);
-        if (!isPlayPref(this.getContext())) {
-            WebView wv = (WebView) view.findViewById(R.id.web_view1);
-            wv.loadUrl("file:///android_asset/about.html");
-        }
+        WebView wv = (WebView) view.findViewById(R.id.web_view1);
+        wv.loadUrl("file:///android_asset/about.html");
     }
 
     private void init(Context context) {
-        if (isPlayPref(context)) {
-            setNegativeButtonText(null);
-            CharSequence msg = GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(context);
-            if (msg != null) {
-                this.setDialogMessage(msg);
-            }
-        } else {
-            try {
-                PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-                this.setDialogTitle(context.getString(R.string.About_RunnerUp)+" v" + pInfo.versionName);
-            } catch (NameNotFoundException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-            if (isGooglePlayServicesAvailable(context)) {
-                setNegativeButtonText(context.getString(R.string.OK));
-                setPositiveButtonText(context.getString(R.string.Rate_RunnerUp));
-            } else {
-                setNegativeButtonText(null);
-            }
-            setDialogLayoutResource(R.layout.whatsnew);
+        try {
+            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            this.setDialogTitle(context.getString(R.string.About_RunnerUp) + " v" + pInfo.versionName);
+        } catch (NameNotFoundException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
         }
+        if (isGooglePlayServicesAvailable(context)) {
+            setNegativeButtonText(context.getString(R.string.OK));
+            setPositiveButtonText(context.getString(R.string.Rate_RunnerUp));
+        } else {
+            setNegativeButtonText(null);
+        }
+        setDialogLayoutResource(R.layout.whatsnew);
     }
 }

--- a/app/res/values/pref_keys.xml
+++ b/app/res/values/pref_keys.xml
@@ -144,6 +144,4 @@
     <string name="pref_exportdb">pref_exportdb</string>
     <string name="pref_importdb">pref_importdb</string>
     <string name="pref_prunedb">pref_prunedb</string>
-    <string name="pref_aboutcategory">pref_aboutcategory</string>
-    <string name="pref_googleplayserviceslegalnotices">pref_googleplayserviceslegalnotices</string>
 </resources>

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -337,17 +337,7 @@
 
     </PreferenceScreen>
 
-    <PreferenceCategory
-        android:key="@string/pref_aboutcategory"
-        android:title="@string/About">
-
-        <org.runnerup.widget.AboutPreference
-            android:title="@string/About_RunnerUp" />
-
-        <org.runnerup.widget.AboutPreference
-            android:key="@string/pref_googleplayserviceslegalnotices"
-            android:title="@string/Google_Play_Services_Legal_Notices"
-            android:dialogMessage="@string/google_play_not_installed" />
-    </PreferenceCategory>
+    <org.runnerup.widget.AboutPreference
+        android:title="@string/About_RunnerUp" />
 
 </PreferenceScreen>

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -78,13 +78,6 @@ public class SettingsActivity extends PreferenceActivity
             getPreferenceManager().findPreference(res.getString(R.string.pref_experimental_features)).setEnabled(false);
         }
 
-        //remove google play notices from froyo since we do not use it
-        if (BuildConfig.FLAVOR.equals("froyo") || !AboutPreference.isGooglePlayServicesAvailable(this)) {
-            Preference pref = findPreference(res.getString(R.string.pref_googleplayserviceslegalnotices));
-            PreferenceCategory category = (PreferenceCategory)findPreference(res.getString(R.string.pref_aboutcategory));
-            category.removePreference(pref);
-        }
-
         //Geoid correction is not included in Froyo
         if (BuildConfig.FLAVOR.equals("froyo")) {
             getPreferenceManager().findPreference(res.getString(R.string.pref_altitude_adjust)).setEnabled(false);


### PR DESCRIPTION
getOpenSourceSoftwareLicenseInfo(context) is depreciated and removed in play services 11.3
This would show the open source licenses. In a way, this was a bug as it was very slow, the app seem to hang.