### PR TITLE
Material app bar for history items

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2012 - 2013 jonas.oreland@gmail.com
   ~
   ~  This program is free software: you can redistribute it and/or modify
@@ -17,145 +16,173 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.runnerup"
-	xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.runnerup">
 
-		<uses-feature
-  			android:glEsVersion="0x00020000"
-  			android:required="true"/>
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true" />
 
-		<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-		<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-		<uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
-		<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-		<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-		<uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
-		<uses-permission android:name="android.permission.WAKE_LOCK" />
-		<uses-permission android:name="android.permission.INTERNET" />
-		<permission android:name="org.runnerup.permission.MAPS_RECEIVE" android:protectionLevel="signature"/>
-        <uses-permission android:name="org.runnerup.permission.MAPS_RECEIVE"/>
-    	<uses-permission android:name="android.permission.BLUETOOTH" />
-    	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
-	<application
-	    android:icon="@drawable/ic_launcher"
-	    android:label="@string/app_name"
-		android:extractNativeLibs="false"
-		android:supportsRtl="true"
-		android:allowBackup="true"
-		android:theme="@style/MainLayoutTheme"
-		android:fullBackupContent="@xml/backup_descriptor"
-		android:appCategory="maps"
-		tools:ignore="UnusedAttribute">
+    <permission
+        android:name="org.runnerup.permission.MAPS_RECEIVE"
+        android:protectionLevel="signature" />
 
-		<activity
-			android:name=".view.MainLayout"
-			android:label="@string/app_name">
-			<intent-filter>
-				<action android:name="android.intent.action.MAIN" />
-				<category android:name="android.intent.category.LAUNCHER" />
-			</intent-filter>
+    <uses-permission android:name="org.runnerup.permission.MAPS_RECEIVE" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-				<category android:name="android.intent.category.BROWSABLE" />
-				<data android:mimeType="application/octet-stream"
-					android:scheme="http" />
-				<data android:host="*" />
-				<data android:pathPattern="runnerup.db.export" />
-			</intent-filter>
-  		</activity>
+    <application
+        android:allowBackup="true"
+        android:appCategory="maps"
+        android:extractNativeLibs="false"
+        android:fullBackupContent="@xml/backup_descriptor"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/MainLayoutTheme"
+        tools:ignore="UnusedAttribute">
 
-		<activity android:name=".view.StartActivity"/>
+        <activity
+            android:name=".view.MainLayout"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
 
-		<activity android:name="org.runnerup.view.FeedActivity"/>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
 
-		<activity android:name=".view.RunActivity"
-		    android:configChanges="keyboardHidden|orientation"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
-		<activity android:name=".view.SettingsActivity"/>
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:scheme="http" />
+                <data android:host="*" />
+                <data android:pathPattern="runnerup.db.export" />
+            </intent-filter>
+        </activity>
 
-		<activity android:name=".view.AudioCueSettingsActivity"
-			android:theme="@style/AppTheme" />
+        <activity android:name=".view.StartActivity" />
 
-		<activity android:name=".view.DetailActivity"
-			android:configChanges="orientation|screenSize|uiMode"
-		    android:theme="@style/AppTheme" />
+        <activity android:name="org.runnerup.view.FeedActivity" />
 
-		<activity android:name=".view.HistoryActivity"/>
+        <activity
+            android:name=".view.RunActivity"
+            android:configChanges="keyboardHidden|orientation" />
 
-		<activity android:name=".view.AccountListActivity"
-			android:theme="@style/AppTheme"
-			android:label="@string/Configure_accounts"
-			android:parentActivityName=".view.MainLayout">
-			<!-- Parent activity meta-data to support 4.0 and lower -->
-			<meta-data
-				android:name="android.support.PARENT_ACTIVITY"
-				android:value=".view.MainLayout" />
-		</activity>
+        <activity android:name=".view.SettingsActivity" />
 
-		<activity android:name=".view.AccountActivity"
-			android:theme="@style/AppTheme" />
+        <activity
+            android:name=".view.AudioCueSettingsActivity"
+            android:theme="@style/AppTheme" />
 
-		<activity android:name=".view.UploadActivity"/>
+        <activity
+            android:name=".view.DetailActivity"
+            android:configChanges="orientation|screenSize|uiMode"
+            android:parentActivityName=".view.MainLayout"
+            android:theme="@style/MainLayoutTheme">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".view.MainLayout" />
+        </activity>
 
-		<activity android:name=".view.ManageWorkoutsActivity">
-			<intent-filter tools:ignore="GoogleAppIndexingWarning,AppLinkUrlError">
-				<action android:name="android.intent.action.VIEW" />
-  				<action android:name="android.intent.action.EDIT" />
-  				<category android:name="android.intent.category.DEFAULT" />
-  				<data android:mimeType="application/vnd.garmin.workout+json"/>
-			</intent-filter>
-<!-- Check for application/json too, see http://code.google.com/p/android/issues/detail?id=48594 -->
-			<intent-filter tools:ignore="GoogleAppIndexingWarning,AppLinkUrlError">
-				<action android:name="android.intent.action.VIEW" />
-  				<action android:name="android.intent.action.EDIT" />
-  				<category android:name="android.intent.category.DEFAULT" />
-  				<data android:mimeType="application/json"/>
-			</intent-filter>
-		</activity>
+        <activity android:name=".view.HistoryActivity" />
 
-        <provider android:name=".content.WorkoutFileProvider"
+        <activity
+            android:name=".view.AccountListActivity"
+            android:label="@string/Configure_accounts"
+            android:parentActivityName=".view.MainLayout"
+            android:theme="@style/AppTheme">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".view.MainLayout" />
+        </activity>
+
+        <activity
+            android:name=".view.AccountActivity"
+            android:theme="@style/AppTheme" />
+
+        <activity android:name=".view.UploadActivity" />
+
+        <activity android:name=".view.ManageWorkoutsActivity">
+            <intent-filter tools:ignore="GoogleAppIndexingWarning,AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/vnd.garmin.workout+json" />
+            </intent-filter>
+            <!-- Check for application/json too, see http://code.google.com/p/android/issues/detail?id=48594 -->
+            <intent-filter tools:ignore="GoogleAppIndexingWarning,AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/json" />
+            </intent-filter>
+        </activity>
+
+        <provider
+            android:name=".content.WorkoutFileProvider"
             android:authorities="org.runnerup.workout.file.provider"
             android:grantUriPermissions="true"
             tools:ignore="ExportedContentProvider" />
 
-        <provider android:name=".content.ActivityProvider"
+        <provider
+            android:name=".content.ActivityProvider"
             android:authorities="org.runnerup.activity.provider"
             android:grantUriPermissions="true"
             tools:ignore="ExportedContentProvider" />
 
-		<activity android:name=".export.oauth2client.OAuth2Activity"
-			android:theme="@style/AppTheme" />
+        <activity
+            android:name=".export.oauth2client.OAuth2Activity"
+            android:theme="@style/AppTheme" />
 
-		<activity android:name=".view.HRSettingsActivity"
-			android:theme="@style/AppTheme" />
+        <activity
+            android:name=".view.HRSettingsActivity"
+            android:theme="@style/AppTheme" />
 
-		<activity android:name=".view.HRZonesActivity"
-			android:theme="@style/AppTheme" />
+        <activity
+            android:name=".view.HRZonesActivity"
+            android:theme="@style/AppTheme" />
 
-		<service android:name=".tracker.Tracker" />
-		<service android:name=".export.RunnerUpLiveSynchronizer$LiveService" />
-
-		<receiver
-		    android:name=".tracker.component.HeadsetButtonReceiver"
-		    android:enabled="true" >
-		    <intent-filter>
-		        <action android:name="android.intent.action.MEDIA_BUTTON" android:priority="2147483647" />
-		    </intent-filter>
-		</receiver>
+        <service android:name=".tracker.Tracker" />
+        <service android:name=".export.RunnerUpLiveSynchronizer$LiveService" />
 
         <receiver
-            android:name=".view.StartActivityHeadsetButtonReceiver"
-            android:enabled="true" >
+            android:name=".tracker.component.HeadsetButtonReceiver"
+            android:enabled="true">
             <intent-filter>
-                <action android:name="android.intent.action.MEDIA_BUTTON" android:priority="2147483647" />
+                <action
+                    android:name="android.intent.action.MEDIA_BUTTON"
+                    android:priority="2147483647" />
             </intent-filter>
         </receiver>
 
-		<activity
-			android:name=".view.CreateAdvancedWorkout"/>
-	</application>
+        <receiver
+            android:name=".view.StartActivityHeadsetButtonReceiver"
+            android:enabled="true">
+            <intent-filter>
+                <action
+                    android:name="android.intent.action.MEDIA_BUTTON"
+                    android:priority="2147483647" />
+            </intent-filter>
+        </receiver>
+
+        <activity android:name=".view.CreateAdvancedWorkout" />
+    </application>
 </manifest>

--- a/app/res/layout/detail.xml
+++ b/app/res/layout/detail.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2012 - 2013 jonas.oreland@gmail.com
   ~
   ~  This program is free software: you can redistribute it and/or modify
@@ -22,70 +21,62 @@
     android:orientation="vertical">
 
     <LinearLayout
-        android:id="@+id/linear_layout0"
-        android:layout_width="fill_parent"
+        android:id="@+id/appbarlayout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:orientation="horizontal" >
+        android:background="@color/colorPrimary"
+        android:elevation="4dp"
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/total_time"
-            style="@style/RunHeader"
-            android:gravity="right"
-            android:text="@string/time" />
-
-        <TextView
-            android:id="@+id/total_distance"
-            style="@style/RunHeader"
-            android:gravity="right"
-            android:text="@string/distance" />
-
-        <TextView
-            android:id="@+id/total_pace"
-            style="@style/RunHeader"
-            android:layout_marginRight="3dp"
-            android:gravity="right"
-            android:text="@string/pace" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/total"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/linear_layout0"
-        android:background="@drawable/countdown_background"
-        android:orientation="vertical" >
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/actionbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
         <LinearLayout
-            android:id="@+id/header"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp" >
-
-            <TextView
-                android:id="@+id/text_view01"
-                style="@style/RunHeader"
-                android:text="@string/Total" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/linear_layout3"
+            android:id="@+id/stat_overview"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal" >
-
-            <TextView
-                android:id="@+id/activity_time"
-                style="@style/RunInfo" />
+            android:layout_height="48dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp">
 
             <TextView
                 android:id="@+id/activity_distance"
-                style="@style/RunInfo" />
+                style="@style/AppBarStatisticsText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAlignment="center" />
+
+            <View
+                android:layout_width="1dp"
+                android:layout_height="16dp"
+                android:background="@android:color/white" />
+
+            <TextView
+                android:id="@+id/activity_time"
+                style="@style/AppBarStatisticsText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAlignment="center" />
+
+            <View
+                android:id="@+id/activity_pace_separator"
+                android:layout_width="1dp"
+                android:layout_height="16dp"
+                android:background="@android:color/white" />
 
             <TextView
                 android:id="@+id/activity_pace"
-                style="@style/RunInfo"
-                android:layout_marginRight="3dp" />
+                style="@style/AppBarStatisticsText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAlignment="center" />
         </LinearLayout>
     </LinearLayout>
 
@@ -94,29 +85,28 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/buttons"
-        android:layout_below="@id/total" >
+        android:layout_below="@id/appbarlayout">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical" >
+            android:orientation="vertical">
 
             <TabWidget
                 android:id="@android:id/tabs"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" >
-            </TabWidget>
+                android:layout_height="wrap_content"></TabWidget>
 
             <FrameLayout
                 android:id="@android:id/tabcontent"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" >
+                android:layout_height="match_parent">
 
                 <LinearLayout
                     android:id="@+id/tab_main"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:orientation="vertical" >
+                    android:orientation="vertical">
 
                     <org.runnerup.widget.TitleSpinner
                         android:id="@+id/summary_sport"
@@ -132,52 +122,51 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:gravity="top|left"
+                        android:hint="@string/Notes_about_your_workout"
                         android:inputType="textCapSentences|textMultiLine"
                         android:minLines="4"
-                        android:hint="@string/Notes_about_your_workout"
                         android:singleLine="false" />
 
                     <LinearLayout
                         android:id="@+id/hrzonesBarLayout"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
+                        android:background="@color/black"
                         android:orientation="vertical"
-                        android:visibility="gone"
-                        android:background="@color/black">
+                        android:visibility="gone">
+
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="@string/Heartrate_zones_distribution"
-                            android:textColor="@android:color/white"
                             android:layout_gravity="center"
-                            android:textAlignment="center"/>
+                            android:text="@string/Heartrate_zones_distribution"
+                            android:textAlignment="center"
+                            android:textColor="@android:color/white" />
                     </LinearLayout>
                 </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/tab_lap"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
+                    android:layout_height="match_parent">
 
                     <ListView
                         android:id="@+id/laplist"
                         android:layout_width="0dip"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1" >
-                    </ListView>
+                        android:layout_weight="1"></ListView>
                 </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/tab_upload"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" >
+                    android:layout_height="match_parent">
 
                     <ListView
                         android:id="@+id/report_list"
                         android:layout_width="0dip"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1" >
-                    </ListView>
+                        android:layout_weight="1"></ListView>
                 </LinearLayout>
 
                 <LinearLayout
@@ -185,14 +174,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:weightSum="1">
-                </LinearLayout>
+                    android:weightSum="1"></LinearLayout>
 
                 <include
                     android:id="@+id/tab_map"
                     layout="@layout/map_area"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"/>
+                    android:layout_height="match_parent" />
             </FrameLayout>
         </LinearLayout>
     </TabHost>
@@ -202,7 +190,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:orientation="vertical" >
+        android:orientation="vertical">
 
         <Button
             android:id="@+id/resume_button"
@@ -211,19 +199,19 @@
             android:layout_height="wrap_content"
             android:layout_above="@+id/save_button"
             android:background="@drawable/btn_blue"
-            android:text="@string/Resume"
+            android:drawablePadding="-32dp"
             android:drawableRight="@drawable/ic_av_play_arrow"
-            android:drawablePadding="-32dp" />
+            android:text="@string/Resume" />
 
         <Button
-            style="@style/ButtonText"
             android:id="@+id/upload_button"
+            style="@style/ButtonText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_above="@+id/save_button"
             android:background="@drawable/btn_blue"
-            android:text="@string/Upload_activity"
-            android:singleLine="false" />
+            android:singleLine="false"
+            android:text="@string/Upload_activity" />
 
         <Button
             android:id="@+id/save_button"

--- a/app/res/layout/detail.xml
+++ b/app/res/layout/detail.xml
@@ -49,6 +49,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:gravity="center"
                 android:textAlignment="center" />
 
             <View
@@ -62,12 +63,14 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:gravity="center"
                 android:textAlignment="center" />
 
             <View
                 android:id="@+id/activity_pace_separator"
                 android:layout_width="1dp"
                 android:layout_height="16dp"
+                android:gravity="center"
                 android:background="@android:color/white" />
 
             <TextView
@@ -76,6 +79,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:gravity="center"
                 android:textAlignment="center" />
         </LinearLayout>
     </LinearLayout>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -14,7 +14,7 @@
   ~  You should have received a copy of the GNU General Public License
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="AppTheme" parent="Theme.AppCompat">
         <item name="colorPrimary">@color/colorPrimary</item>
@@ -88,8 +88,14 @@
         <item name="android:textSize">18sp</item>
     </style>
 
+    <style name="AppBarStatisticsText">
+        <item name="android:fontFamily" tools:ignore="NewApi">@string/fontFamily_medium</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textColor">@android:color/white</item>
+    </style>
+
     <style name="ListCategoryHeading">
-        <!-- item name="android:fontFamily">@string/fontFamily_medium</item -->
+        <item name="android:fontFamily" tools:ignore="NewApi">@string/fontFamily_medium</item>
         <item name="android:textColor">@color/colorAccent</item>
         <item name="android:textSize">14sp</item>
     </style>

--- a/app/src/org/runnerup/view/DetailActivity.java
+++ b/app/src/org/runnerup/view/DetailActivity.java
@@ -28,8 +28,10 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.NavUtils;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -102,6 +104,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     private Button resumeButton = null;
     private TextView activityTime = null;
     private TextView activityPace = null;
+    private View activityPaceSeparator = null;
     private TextView activityDistance = null;
 
     private TitleSpinner sport = null;
@@ -121,6 +124,11 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         super.onCreate(savedInstanceState);
         MapWrapper.start(this);
         setContentView(R.layout.detail);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.actionbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
         WidgetUtil.addLegacyOverflowButton(getWindow());
 
         Intent intent = getIntent();
@@ -148,6 +156,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         activityTime = (TextView) findViewById(R.id.activity_time);
         activityDistance = (TextView) findViewById(R.id.activity_distance);
         activityPace = (TextView) findViewById(R.id.activity_pace);
+        activityPaceSeparator = findViewById(R.id.activity_pace_separator);
         sport = (TitleSpinner) findViewById(R.id.summary_sport);
         notes = (EditText) findViewById(R.id.notes_text);
 
@@ -220,7 +229,10 @@ public class DetailActivity extends AppCompatActivity implements Constants {
 
     private void setEdit(boolean value) {
         edit = value;
-        saveButton.setEnabled(value);
+        if (value)
+            saveButton.setVisibility(View.VISIBLE);
+        else
+            saveButton.setVisibility(View.GONE);
         WidgetUtil.setEditable(notes, value);
         sport.setEnabled(value);
         if (recomputeMenuItem != null)
@@ -247,6 +259,9 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case android.R.id.home:
+                NavUtils.navigateUpFromSameTask(this);
+                break;
             case R.id.menu_delete_activity:
                 deleteButtonClick.onClick(null);
                 break;
@@ -415,7 +430,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
 
         if (tmp.containsKey(DB.ACTIVITY.START_TIME)) {
             long st = tmp.getAsLong(DB.ACTIVITY.START_TIME);
-            setTitle("RunnerUp - " + formatter.formatDateTime(st));
+            setTitle(formatter.formatDateTime(st));
         }
         float d = 0;
         if (tmp.containsKey(DB.ACTIVITY.DISTANCE)) {
@@ -434,9 +449,12 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         }
 
         if (d != 0 && t != 0) {
+            activityPace.setVisibility(View.VISIBLE);
+            activityPaceSeparator.setVisibility(View.VISIBLE);
             activityPace.setText(formatter.formatPace(Formatter.Format.TXT_LONG, t / d));
         } else {
-            activityPace.setText("");
+            activityPace.setVisibility(View.GONE);
+            activityPaceSeparator.setVisibility(View.GONE);
         }
 
         if (tmp.containsKey(DB.ACTIVITY.COMMENT)) {


### PR DESCRIPTION
Another iterative change to RunnerUp's look. Here's what it looks like in Froyo:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/7361228/42112394-f3fb8ff6-7be7-11e8-825d-4769099583b2.png">

The long-term goal is to get something like this:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/7361228/42112455-21044bd2-7be8-11e8-8e29-4c4e4cf0ac19.png">

However, as listening for sport changes may be tricky and as swipeable tabs are a big task (that would call for using a ViewPager and putting individual tab contents into fragments), I'm leaving those for pull requests sometime down the line.