### PR TITLE
Lint: Two identical keys in HashMap

### DIFF
--- a/app/src/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/org/runnerup/export/MapMyRunSynchronizer.java
@@ -160,9 +160,9 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
     private String toHexString(byte messageDigest[]) {
         StringBuilder hexString = new StringBuilder();
         for (byte b : messageDigest) {
-            String h = Integer.toHexString(0xFF & b);
+            StringBuilder h = new StringBuilder(Integer.toHexString(0xFF & b));
             while (h.length() < 2)
-                h = "0" + h;
+                h.insert(0, "0");
             hexString.append(h);
         }
         return hexString.toString();

--- a/app/src/org/runnerup/tracker/Tracker.java
+++ b/app/src/org/runnerup/tracker/Tracker.java
@@ -401,7 +401,7 @@ public class Tracker extends android.app.Service implements
         bindValues.put(Workout.KEY_FORMATTER, new Formatter(ctx));
         bindValues.put(Workout.KEY_HRZONES, new HRZones(ctx));
         bindValues.put(Workout.KEY_MUTE, workout.getMute());
-        bindValues.put(DB.ACTIVITY.SPORT, workout.getSport());
+        bindValues.put(Workout.KEY_SPORT_TYPE, workout.getSport());
         bindValues.put(Workout.KEY_WORKOUT_TYPE, workout.getWorkoutType());
 
         components.onBind(bindValues);

--- a/app/src/org/runnerup/tracker/component/TrackerCadence.java
+++ b/app/src/org/runnerup/tracker/component/TrackerCadence.java
@@ -26,6 +26,7 @@ import android.preference.PreferenceManager;
 
 import org.runnerup.BuildConfig;
 import org.runnerup.common.util.Constants;
+import org.runnerup.workout.Workout;
 
 import java.util.HashMap;
 import java.util.Random;
@@ -179,7 +180,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
      *   to workout
      */
     public void onBind(HashMap<String, Object> bindValues) {
-        int sport = (int) bindValues.get(Constants.DB.ACTIVITY.SPORT);
+        int sport = (int) bindValues.get(Workout.KEY_SPORT_TYPE);
         if (sport == Constants.DB.ACTIVITY.SPORT_BIKING) {
             //Not used, disconnect sensor so nothing is returned
             isSportEnabled = false;

--- a/app/src/org/runnerup/workout/Workout.java
+++ b/app/src/org/runnerup/workout/Workout.java
@@ -106,7 +106,8 @@ public class Workout implements WorkoutComponent, WorkoutInfo {
     public static final String KEY_FORMATTER = "Formatter";
     public static final String KEY_HRZONES = "HrZones";
     public static final String KEY_MUTE = "mute";
-    public static final String KEY_WORKOUT_TYPE = "type";
+    public static final String KEY_WORKOUT_TYPE = "workout_type";
+    public static final String KEY_SPORT_TYPE = "sport";
 
     public Workout() {
     }


### PR DESCRIPTION
The consequence is that SportType was overwritten for trackers.
At least Cadence excluded step-cadence from Biking based on type (sport)

