### PR TITLE
Use HR Mock sensor setting to control other emulations

### DIFF
--- a/app/src/org/runnerup/tracker/component/TrackerCadence.java
+++ b/app/src/org/runnerup/tracker/component/TrackerCadence.java
@@ -24,7 +24,6 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 
-import org.runnerup.BuildConfig;
 import org.runnerup.common.util.Constants;
 
 import java.util.HashMap;
@@ -42,8 +41,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
     private SensorManager sensorManager = null;
 
     //For debug builds, use random if sensor is unavailable
-    private final static boolean testMode = BuildConfig.DEBUG;
-    private static boolean isEmulating = false;
+    private static boolean isMockSensor = false;
 
     private boolean isSportEnabled = true;
     //The sensor fires continuously, use the last available values (no smoothing)
@@ -55,7 +53,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
     private Float currentCadence = null;
 
     public Float getValue() {
-        if (isEmulating) {
+        if (isMockSensor) {
             if (latestVal == null) {latestVal = 0.0f;}
             //if GPS update is every second, this is 0-120 rpm
             latestVal += (int)((new Random()).nextFloat() * 4);
@@ -111,7 +109,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
      * Sensor is available
      */
     public static boolean isAvailable(final Context context) {
-        return ((new TrackerCadence()).getSensor(context) != null) || testMode;
+        return ((new TrackerCadence()).getSensor(context) != null) || isMockSensor;
     }
 
     private Sensor getSensor(final Context context) {
@@ -126,10 +124,12 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
                 sensorManager = null;
             }
         }
-        if (testMode && sensor == null) {
-            //No real sensor, emulate
-            isEmulating = true;
+
+        if (sensor == null) {
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            isMockSensor = prefs.getBoolean(context.getString(org.runnerup.R.string.pref_bt_mock), false);
         }
+
         return sensor;
     }
 
@@ -154,7 +154,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
             if (sensor != null) {
                 sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_FASTEST);
                 res = ResultCode.RESULT_OK;
-            } else if (isEmulating) {
+            } else if (isMockSensor) {
                 res = ResultCode.RESULT_OK;
             } else {
                 res = ResultCode.RESULT_NOT_SUPPORTED;
@@ -229,7 +229,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
         isStarted = false;
         if (sensorManager != null) { sensorManager.unregisterListener(this); }
         sensorManager = null;
-        isEmulating = false;
+        isMockSensor = false;
         return ResultCode.RESULT_OK;
     }
 }

--- a/app/src/org/runnerup/tracker/component/TrackerPressure.java
+++ b/app/src/org/runnerup/tracker/component/TrackerPressure.java
@@ -22,8 +22,6 @@ import android.content.SharedPreferences;
 import android.hardware.*;
 import android.preference.PreferenceManager;
 
-import org.runnerup.BuildConfig;
-
 import java.util.HashMap;
 import java.util.Random;
 
@@ -38,9 +36,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
 
     private SensorManager sensorManager = null;
 
-    //For debug builds, use random if sensor is unavailable
-    private final static boolean testMode = BuildConfig.DEBUG;
-    private static boolean isEmulating = false;
+    private static boolean isMockSensor = false;
 
     //The sensor fires continuously, use the last available values (no smoothing)
     @SuppressWarnings("unused")
@@ -48,7 +44,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
     private Float latestVal = null;
 
     public Float getValue() {
-        if (isEmulating) {
+        if (isMockSensor) {
             latestVal = (new Random()).nextFloat() * 0.2f + 1013.25f/*SensorManager.PRESSURE_STANDARD_ATMOSPHERE*/;
             //latestTime = SystemClock.elapsedRealtime()*1000000;
         }
@@ -76,7 +72,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
      * Sensor is available
      */
     public static boolean isAvailable(final Context context) {
-        return ((new TrackerPressure()).getSensor(context) != null) || testMode;
+        return ((new TrackerPressure()).getSensor(context) != null) || isMockSensor;
     }
 
     private Sensor getSensor(final Context context) {
@@ -89,9 +85,9 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
             sensorManager = null;
         }
 
-        if (testMode && sensor == null) {
-            //No real sensor, emulate
-            isEmulating = true;
+        if (sensor == null) {
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            isMockSensor = prefs.getBoolean(context.getString(org.runnerup.R.string.pref_bt_mock), false);
         }
 
         return sensor;
@@ -116,7 +112,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
             if (sensor != null) {
                 sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_FASTEST);
                 res = ResultCode.RESULT_OK;
-            } else if (isEmulating) {
+            } else if (isMockSensor) {
                 res = ResultCode.RESULT_OK;
             } else {
                 res = ResultCode.RESULT_NOT_SUPPORTED;
@@ -185,7 +181,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
         isStarted = false;
         if (sensorManager != null) { sensorManager.unregisterListener(this); }
         sensorManager = null;
-        isEmulating = false;
+        isMockSensor = false;
         return ResultCode.RESULT_OK;
     }
 }


### PR DESCRIPTION
Previously, Debug builds were used to emulate debug, this will
not enable by default and make it possible to test sensors in release builds