### PR TITLE
Feature/audio cue improvements

### DIFF
--- a/app/res/values-ar/cues.xml
+++ b/app/res/values-ar/cues.xml
@@ -61,19 +61,19 @@
     <item quantity="other">%d أخرى</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="zero">%d صفر</item>
-    <item quantity="one">%d كيلو متر واحد</item>
-    <item quantity="two">%d كيلومتران</item>
-    <item quantity="few">%d بضع كيلومترات</item>
-    <item quantity="many">%d كيلومترات كثيرة </item>
-    <item quantity="other">%d اخرى</item>
+    <item quantity="zero">%s صفر</item>
+    <item quantity="one">%s كيلو متر واحد</item>
+    <item quantity="two">%s كيلومتران</item>
+    <item quantity="few">%s بضع كيلومترات</item>
+    <item quantity="many">%s كيلومترات كثيرة </item>
+    <item quantity="other">%s اخرى</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="zero">صفر</item>
-    <item quantity="one">%d ميل واحد</item>
-    <item quantity="two">%d ميلان</item>
-    <item quantity="few">%d بضع أميال</item>
-    <item quantity="many">%d أميال كثيرة</item>
-    <item quantity="other">%d اخرى</item>
+    <item quantity="zero">%s صفر</item>
+    <item quantity="one">%s ميل واحد</item>
+    <item quantity="two">%s ميلان</item>
+    <item quantity="few">%s بضع أميال</item>
+    <item quantity="many">%s أميال كثيرة</item>
+    <item quantity="other">%s اخرى</item>
   </plurals>
 </resources>

--- a/app/res/values-bs/cues.xml
+++ b/app/res/values-bs/cues.xml
@@ -50,14 +50,14 @@
     <item quantity="other">%d metara</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometar</item>
-    <item quantity="few">%d kilometara</item>
-    <item quantity="other">%d kilometara</item>
+    <item quantity="one">%s kilometar</item>
+    <item quantity="few">%s kilometara</item>
+    <item quantity="other">%s kilometara</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d milja</item>
-    <item quantity="few">%d milja</item>
-    <item quantity="other">%d milja</item>
+    <item quantity="one">%s milja</item>
+    <item quantity="few">%s milja</item>
+    <item quantity="other">%s milja</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilometar po satu</item>

--- a/app/res/values-ca/cues.xml
+++ b/app/res/values-ca/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d metres</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilòmetre</item>
-    <item quantity="other">%d kilòmetres</item>
+    <item quantity="one">%s kilòmetre</item>
+    <item quantity="other">%s kilòmetres</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d milla</item>
-    <item quantity="other">%d milles</item>
+    <item quantity="one">%s milla</item>
+    <item quantity="other">%s milles</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s quilòmetre per hora</item>

--- a/app/res/values-de/cues.xml
+++ b/app/res/values-de/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d Meter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d Kilometer</item>
-    <item quantity="other">%d Kilometer</item>
+    <item quantity="one">%s Kilometer</item>
+    <item quantity="other">%s Kilometer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d Meile</item>
-    <item quantity="other">%d Meilen</item>
+    <item quantity="one">%s Meile</item>
+    <item quantity="other">%s Meilen</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s Kilometer pro Stunde</item>

--- a/app/res/values-es/cues.xml
+++ b/app/res/values-es/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d metros</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilómetro</item>
-    <item quantity="other">%d kilómetros</item>
+    <item quantity="one">%s kilómetro</item>
+    <item quantity="other">%s kilómetros</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d milla</item>
-    <item quantity="other">%d millas</item>
+    <item quantity="one">%s milla</item>
+    <item quantity="other">%s millas</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilómetro por hora</item>

--- a/app/res/values-fr/cues.xml
+++ b/app/res/values-fr/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d mètres</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilomètre</item>
-    <item quantity="other">%d kilomètres</item>
+    <item quantity="one">%s kilomètre</item>
+    <item quantity="other">%s kilomètres</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mile</item>
-    <item quantity="other">%d miles</item>
+    <item quantity="one">%s mile</item>
+    <item quantity="other">%s miles</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilomètre par heure</item>

--- a/app/res/values-hu/cues.xml
+++ b/app/res/values-hu/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d méter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilométer</item>
-    <item quantity="other">%d kilométer</item>
+    <item quantity="one">%s kilométer</item>
+    <item quantity="other">%s kilométer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mérföld</item>
-    <item quantity="other">%d mérföld</item>
+    <item quantity="one">%s mérföld</item>
+    <item quantity="other">%s mérföld</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilométer per óra</item>

--- a/app/res/values-in/cues.xml
+++ b/app/res/values-in/cues.xml
@@ -30,25 +30,25 @@
   <string name="cue_speedup">lebih cepat</string>
   <string name="cue_slowdown">lebih lambat</string>
   <plurals name="cue_hour">
-    <item quantity="other">jam</item>
+    <item quantity="other">%d jam</item>
   </plurals>
   <plurals name="cue_minute">
-    <item quantity="other">menit</item>
+    <item quantity="other">%d menit</item>
   </plurals>
   <plurals name="cue_second">
-    <item quantity="other">detik</item>
+    <item quantity="other">%d detik</item>
   </plurals>
   <plurals name="cue_meter">
-    <item quantity="other">meter</item>
+    <item quantity="other">%d meter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="other">kilometer</item>
+    <item quantity="other">%s kilometer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="other">mil</item>
+    <item quantity="other">%s mil</item>
   </plurals>
   <plurals name="cue_bpm">
-    <item quantity="other">dpm</item>
+    <item quantity="other">%d dpm</item>
   </plurals>
   <string name="cue_activity_paused">aktivitas dijeda</string>
   <string name="cue_activity_resumed">aktivitas dilanjutkan</string>

--- a/app/res/values-it/cues.xml
+++ b/app/res/values-it/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d metri</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d chilometro</item>
-    <item quantity="other">%d chilometri</item>
+    <item quantity="one">%s chilometro</item>
+    <item quantity="other">%s chilometri</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d miglio</item>
-    <item quantity="other">%d miglia</item>
+    <item quantity="one">%s miglio</item>
+    <item quantity="other">%s miglia</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-ja/cues.xml
+++ b/app/res/values-ja/cues.xml
@@ -42,10 +42,10 @@
     <item quantity="other">%d メートル</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="other">%d キロメートル</item>
+    <item quantity="other">%s キロメートル</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="other">%d マイル</item>
+    <item quantity="other">%s マイル</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="other">%s キロメートル毎時</item>

--- a/app/res/values-lt/cues.xml
+++ b/app/res/values-lt/cues.xml
@@ -54,16 +54,16 @@
     <item quantity="other">%d metrai</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometras</item>
-    <item quantity="few">%d kilometrai</item>
-    <item quantity="many">%d kilometrai</item>
-    <item quantity="other">%d kilometrai</item>
+    <item quantity="one">%s kilometras</item>
+    <item quantity="few">%s kilometrai</item>
+    <item quantity="many">%s kilometrai</item>
+    <item quantity="other">%s kilometrai</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mylia</item>
-    <item quantity="few">%d mylios</item>
-    <item quantity="many">%d mylios</item>
-    <item quantity="other">%d mylios</item>
+    <item quantity="one">%s mylia</item>
+    <item quantity="few">%s mylios</item>
+    <item quantity="many">%s mylios</item>
+    <item quantity="other">%s mylios</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-nb-rNO/cues.xml
+++ b/app/res/values-nb-rNO/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometer</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mil</item>
-    <item quantity="other">%d mil</item>
+    <item quantity="one">%s mil</item>
+    <item quantity="other">%s mil</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilometer i timen</item>

--- a/app/res/values-nl-rBE/cues.xml
+++ b/app/res/values-nl-rBE/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometer</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mijl</item>
-    <item quantity="other">%d mijl</item>
+    <item quantity="one">%s mijl</item>
+    <item quantity="other">%s mijl</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-nl-rNL/cues.xml
+++ b/app/res/values-nl-rNL/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meters</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometers</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometers</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mijl</item>
-    <item quantity="other">%d mijlen</item>
+    <item quantity="one">%s mijl</item>
+    <item quantity="other">%s mijlen</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-nl/cues.xml
+++ b/app/res/values-nl/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meters</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometers</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometers</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mijl</item>
-    <item quantity="other">%d mijlen</item>
+    <item quantity="one">%s mijl</item>
+    <item quantity="other">%s mijlen</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-pl/cues.xml
+++ b/app/res/values-pl/cues.xml
@@ -54,16 +54,16 @@
     <item quantity="other">%d metrów</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometr</item>
-    <item quantity="few">%d kilometry</item>
-    <item quantity="many">%d kilometrów</item>
-    <item quantity="other">%d kilometrów</item>
+    <item quantity="one">%s kilometr</item>
+    <item quantity="few">%s kilometry</item>
+    <item quantity="many">%s kilometrów</item>
+    <item quantity="other">%s kilometrów</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mila</item>
-    <item quantity="few">%d mile</item>
-    <item quantity="many">%d mil</item>
-    <item quantity="other">%d mil</item>
+    <item quantity="one">%s mila</item>
+    <item quantity="few">%s mile</item>
+    <item quantity="many">%s mil</item>
+    <item quantity="other">%s mil</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilometr na godzinę</item>

--- a/app/res/values-pt-rBR/cues.xml
+++ b/app/res/values-pt-rBR/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d metros</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d quilômetro</item>
-    <item quantity="other">%d quilômetros</item>
+    <item quantity="one">%s quilômetro</item>
+    <item quantity="other">%s quilômetros</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d milha</item>
-    <item quantity="other">%d milhas</item>
+    <item quantity="one">%s milha</item>
+    <item quantity="other">%s milhas</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s quilômetro por hora</item>

--- a/app/res/values-pt/cues.xml
+++ b/app/res/values-pt/cues.xml
@@ -45,12 +45,12 @@
     <item quantity="other">%d metros</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d quilómetros</item>
-    <item quantity="other">%d quilómetros</item>
+    <item quantity="one">%s quilómetros</item>
+    <item quantity="other">%s quilómetros</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d milhas</item>
-    <item quantity="other">%d milhas</item>
+    <item quantity="one">%s milhas</item>
+    <item quantity="other">%s milhas</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d bpm</item>

--- a/app/res/values-ru/cues.xml
+++ b/app/res/values-ru/cues.xml
@@ -54,16 +54,16 @@
     <item quantity="other">%d метров</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d километр</item>
-    <item quantity="few">%d километра</item>
-    <item quantity="many">%d километров</item>
-    <item quantity="other">%d километров</item>
+    <item quantity="one">%s километр</item>
+    <item quantity="few">%s километра</item>
+    <item quantity="many">%s километров</item>
+    <item quantity="other">%s километров</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d миля</item>
-    <item quantity="few">%d мили</item>
-    <item quantity="many">%d миль</item>
-    <item quantity="other">%d миль</item>
+    <item quantity="one">%s миля</item>
+    <item quantity="few">%s мили</item>
+    <item quantity="many">%s миль</item>
+    <item quantity="other">%s миль</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s километр в час</item>

--- a/app/res/values-sv/cues.xml
+++ b/app/res/values-sv/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meter</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometer</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometer</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mile</item>
-    <item quantity="other">%d miles</item>
+    <item quantity="one">%s mile</item>
+    <item quantity="other">%s miles</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilometer i timmen</item>

--- a/app/res/values-tr/cues.xml
+++ b/app/res/values-tr/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d metre</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometre</item>
-    <item quantity="other">%d kilometre</item>
+    <item quantity="one">%s kilometre</item>
+    <item quantity="other">%s kilometre</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mil</item>
-    <item quantity="other">%d mil</item>
+    <item quantity="one">%s mil</item>
+    <item quantity="other">%s mil</item>
   </plurals>
   <plurals name="cue_bpm">
     <item quantity="one">%d kalp atışı (dakikada)</item>

--- a/app/res/values/cues.xml
+++ b/app/res/values/cues.xml
@@ -46,12 +46,12 @@
     <item quantity="other">%d meters</item>
   </plurals>
   <plurals name="cue_kilometer">
-    <item quantity="one">%d kilometer</item>
-    <item quantity="other">%d kilometers</item>
+    <item quantity="one">%s kilometer</item>
+    <item quantity="other">%s kilometers</item>
   </plurals>
   <plurals name="cue_mile">
-    <item quantity="one">%d mile</item>
-    <item quantity="other">%d miles</item>
+    <item quantity="one">%s mile</item>
+    <item quantity="other">%s miles</item>
   </plurals>
   <plurals name="cue_kilometers_per_hour">
     <item quantity="one">%s kilometer per hour</item>
@@ -65,7 +65,7 @@
     <item quantity="one">%d bpm</item>
     <item quantity="other">%d bpm</item>
   </plurals>
-    <string name="cue_activity_paused">activity paused</string>
+  <string name="cue_activity_paused">activity paused</string>
   <string name="cue_activity_resumed">activity resumed</string>
   <string name="cue_activity_stopped">activity stopped</string>
   <string name="cue_lap_started">lap started</string>

--- a/app/res/values/cues.xml
+++ b/app/res/values/cues.xml
@@ -65,6 +65,10 @@
     <item quantity="one">%d bpm</item>
     <item quantity="other">%d bpm</item>
   </plurals>
+  <plurals name="cue_rpm">
+    <item quantity="one">%d rpm</item>
+    <item quantity="other">%d rpm</item>
+  </plurals>
   <string name="cue_activity_paused">activity paused</string>
   <string name="cue_activity_resumed">activity resumed</string>
   <string name="cue_activity_stopped">activity stopped</string>

--- a/app/res/values/pref_keys.xml
+++ b/app/res/values/pref_keys.xml
@@ -66,6 +66,7 @@
     <string name="cueinfo_current_hr">cueinfo_current_hr</string>
     <string name="cueinfo_current_hrz">cueinfo_current_hrz</string>
     <string name="cueinfo_current_pace">cueinfo_current_pace</string>
+    <string name="cueinfo_current_cad">cueinfo_current_cadence</string>
 
     <string name="cueinfo_target_coaching">cueinfo_target_coaching</string>
     <string name="cueinfo_skip_startstop">cueinfo_skip_startstop</string>

--- a/app/res/xml/audio_cue_settings.xml
+++ b/app/res/xml/audio_cue_settings.xml
@@ -174,24 +174,26 @@
 			android:persistent="true"
 			android:key="@string/cueinfo_current_pace"
 			android:title="@string/Current_pace" />
-
 		<CheckBoxPreference
 			android:defaultValue="false"
 			android:persistent="true"
 			android:key="@string/cueinfo_current_speed"
 			android:title="@string/Current_speed" />
-
 		<CheckBoxPreference
 			android:defaultValue="false"
 			android:persistent="true"
 			android:key="@string/cueinfo_current_hr"
 			android:title="@string/Current_heart_rate" />
-
 		<CheckBoxPreference
 			android:defaultValue="false"
 			android:persistent="true"
 			android:key="@string/cueinfo_current_hrz"
 			android:title="@string/Current_heart_rate_zone" />
+		<CheckBoxPreference
+			android:defaultValue="false"
+			android:persistent="true"
+			android:key="@string/cueinfo_current_cad"
+			android:title="@string/Current_cadence" />
 
 	</PreferenceCategory>
 	<PreferenceCategory android:title="@string/Misc_cues">

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -175,7 +175,7 @@
             android:title="@string/Poll_interval_ms" />
 
         <org.runnerup.widget.TextPreference
-            android:defaultValue="5"
+            android:defaultValue="0"
             android:inputType="number"
             android:key="@string/pref_pollDistance"
             android:persistent="true"

--- a/app/src/org/runnerup/tracker/component/TrackerCadence.java
+++ b/app/src/org/runnerup/tracker/component/TrackerCadence.java
@@ -55,6 +55,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
 
     public Float getValue() {
         if (isMockSensor) {
+            if (!isSportEnabled) { return null; }
             if (latestVal == null) {latestVal = 0.0f;}
             //if GPS update is every second, this is 0-120 rpm
             latestVal += (int)((new Random()).nextFloat() * 4);
@@ -166,7 +167,7 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
 
     @Override
     public boolean isConnected() {
-        return sensorManager != null;
+        return sensorManager != null || isMockSensor;
     }
 
     @Override
@@ -185,6 +186,8 @@ public class TrackerCadence extends DefaultTrackerComponent implements SensorEve
             //Not used, disconnect sensor so nothing is returned
             isSportEnabled = false;
             latestVal = null;
+            sensorManager = null;
+            isMockSensor = false;
         } else {
             isSportEnabled = true;
         }

--- a/app/src/org/runnerup/tracker/component/TrackerGPS.java
+++ b/app/src/org/runnerup/tracker/component/TrackerGPS.java
@@ -86,7 +86,7 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
                     R.string.pref_pollInterval), "2000"));
             if (!mWithoutGps) {
                 String frequency_meters = preferences.getString(context.getString(
-                        R.string.pref_pollDistance), "5");
+                        R.string.pref_pollDistance), "0");
                 lm.requestLocationUpdates(GPS_PROVIDER,
                         frequency_ms,
                         Integer.valueOf(frequency_meters),

--- a/app/src/org/runnerup/tracker/component/TrackerPressure.java
+++ b/app/src/org/runnerup/tracker/component/TrackerPressure.java
@@ -124,7 +124,7 @@ public class TrackerPressure extends DefaultTrackerComponent implements SensorEv
 
     @Override
     public boolean isConnected() {
-        return sensorManager != null;
+        return sensorManager != null || isMockSensor;
     }
 
     @Override

--- a/app/src/org/runnerup/tracker/component/TrackerTemperature.java
+++ b/app/src/org/runnerup/tracker/component/TrackerTemperature.java
@@ -127,7 +127,7 @@ public class TrackerTemperature extends DefaultTrackerComponent implements Senso
 
     @Override
     public boolean isConnected() {
-        return sensorManager != null;
+        return sensorManager != null || isMockSensor;
     }
 
     @Override

--- a/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
+++ b/app/src/org/runnerup/tracker/filter/PersistentGpsLoggerListener.java
@@ -109,9 +109,11 @@ public class PersistentGpsLoggerListener extends LocationListenerBase implements
                 values.put(DB.LOCATION.BEARING, arg0.getBearing());
             }
             //Most GPS chips also includes no of sats
-            int sats = arg0.getExtras().getInt("satellites", -1);
-            if (sats >= 0) {
-                values.put(DB.LOCATION.SATELLITES, sats);
+            if (arg0.getExtras() != null) {
+                int sats = arg0.getExtras().getInt("satellites", -1);
+                if (sats >= 0) {
+                    values.put(DB.LOCATION.SATELLITES, sats);
+                }
             }
             //Not accuracy related but unused by exporters
             if (pressureValue != null) {

--- a/app/src/org/runnerup/util/Formatter.java
+++ b/app/src/org/runnerup/util/Formatter.java
@@ -374,14 +374,16 @@ public class Formatter implements OnSharedPreferenceChangeListener {
      * @return
      */
     public String formatCadence(Format target, double val) {
+        int val2 = (int) Math.round(val);
         switch (target) {
             case CUE:
             case CUE_SHORT:
             case CUE_LONG:
+                return cueResources.getQuantityString(R.plurals.cue_rpm, val2, val2);
             case TXT:
             case TXT_SHORT:
             case TXT_LONG:
-                return Integer.toString((int) Math.round(val));
+                return Integer.toString((int) val2);
         }
         return "";
     }

--- a/app/src/org/runnerup/workout/Workout.java
+++ b/app/src/org/runnerup/workout/Workout.java
@@ -430,7 +430,7 @@ public class Workout implements WorkoutComponent, WorkoutInfo {
             case CURRENT: {
                 Float val = tracker.getCurrentCadence();
                 if (val == null)
-                    return -1; //TODO should not be used
+                    return 0; //TODO should not be used
                 return val;
             }
             case LAP:
@@ -662,6 +662,10 @@ public class Workout implements WorkoutComponent, WorkoutInfo {
 
         public double getHeartRate(Scope scope) {
             return 150 + 25 * Math.random();
+        }
+
+        public double getCadence(Scope scope) {
+            return 50 + 25 * Math.random();
         }
     }
 

--- a/app/src/org/runnerup/workout/WorkoutBuilder.java
+++ b/app/src/org/runnerup/workout/WorkoutBuilder.java
@@ -679,6 +679,7 @@ public class WorkoutBuilder {
     public static void addFeedbackFromPreferences(SharedPreferences prefs,
             Resources res, ArrayList<Feedback> feedback) {
 
+        int feedbackStart = feedback.size();
         /* TOTAL */
         if (prefs.getBoolean(res.getString(R.string.cueinfo_total_distance), false)) {
             feedback.add(new AudioFeedback(Scope.ACTIVITY, Dimension.DISTANCE));
@@ -759,5 +760,18 @@ public class WorkoutBuilder {
             feedback.add(new AudioFeedback(Scope.CURRENT, Dimension.CAD));
         }
 
+        // Insert Scope
+        for (int i=feedbackStart; i<feedback.size(); i++)
+        {
+            if (feedback.get(i) instanceof AudioFeedback &&
+                    (i == 0 ||
+                            feedback.get(i-1) == null ||
+                            !(feedback.get(i-1) instanceof AudioFeedback) ||
+                            ((AudioFeedback) feedback.get(i-1)).getScope() == null ||
+                            ((AudioFeedback) feedback.get(i-1)).getScope() != ((AudioFeedback) feedback.get(i)).getScope())) {
+                feedback.add(i, new AudioFeedback(((AudioFeedback)feedback.get(i)).getScope()));
+                i++;
+            }
+        }
     }
 }

--- a/app/src/org/runnerup/workout/WorkoutBuilder.java
+++ b/app/src/org/runnerup/workout/WorkoutBuilder.java
@@ -755,6 +755,9 @@ public class WorkoutBuilder {
         if (prefs.getBoolean(res.getString(R.string.cueinfo_current_hrz), false)) {
             feedback.add(new AudioFeedback(Scope.CURRENT, Dimension.HRZ));
         }
+        if (prefs.getBoolean(res.getString(R.string.cueinfo_current_cad), false)) {
+            feedback.add(new AudioFeedback(Scope.CURRENT, Dimension.CAD));
+        }
 
     }
 }

--- a/app/src/org/runnerup/workout/feedback/AudioFeedback.java
+++ b/app/src/org/runnerup/workout/feedback/AudioFeedback.java
@@ -44,13 +44,14 @@ public class AudioFeedback extends Feedback {
 
     public AudioFeedback(int msgId) {
         super();
+        this.scope = null;
         this.msgId = msgId;
     }
 
-    public AudioFeedback(Scope scope, Event event) {
+    public AudioFeedback(Scope scope) {
         super();
         this.scope = scope;
-        this.event = event;
+        this.event = null;
         this.dimension = null;
     }
 
@@ -59,14 +60,6 @@ public class AudioFeedback extends Feedback {
         this.scope = scope;
         this.event = null;
         this.dimension = dimension;
-    }
-
-    public AudioFeedback(Intensity intensity, Event event) {
-        super();
-        this.scope = null;
-        this.dimension = null;
-        this.intensity = intensity;
-        this.event = event;
     }
 
     @Override
@@ -93,21 +86,28 @@ public class AudioFeedback extends Feedback {
         return this.dimension == other.dimension;
     }
 
-    String getCue(Workout w, Context ctx) {
+    public Scope getScope() { return scope; }
+
+    private String getCue(Workout w, Context ctx) {
         String msg = null;
         if (msgId != 0) {
             if (msgTxt == null) {
                 msgTxt = formatter.getCueString(msgId);
             }
             msg = msgTxt;
-        } else if (event != null && scope != null) {
-            msg = formatter.getCueString(scope.getCueId()) + " " + formatter.getCueString(event.getCueId());
-        } else if (event != null && intensity != null) {
-            msg = formatter.getCueString(intensity.getCueId()) + " " + formatter.getCueString(event.getCueId());
-        } else if (dimension != null && scope != null && w.isEnabled(dimension, scope)) {
-            double val = w.get(scope, dimension); // SI
-            msg = formatter.getCueString(scope.getCueId()) + " "
-                    + formatter.format(Formatter.Format.CUE_LONG, dimension, val);
+        } else {
+            if (event != null && scope != null) {
+                msg = formatter.getCueString(event.getCueId());
+            } else if (event != null && intensity != null) {
+                msg = formatter.getCueString(intensity.getCueId()) + " " + formatter.getCueString(event.getCueId());
+            } else if (dimension != null && scope != null) {
+                if (w.isEnabled(dimension, scope)) {
+                    double val = w.get(scope, dimension); // SI
+                    msg = formatter.format(Formatter.Format.CUE_LONG, dimension, val);
+                }
+            } else if (scope != null) {
+                msg = formatter.getCueString(scope.getCueId());
+            }
         }
         return msg;
     }

--- a/app/src/org/runnerup/workout/feedback/CoachFeedback.java
+++ b/app/src/org/runnerup/workout/feedback/CoachFeedback.java
@@ -41,20 +41,8 @@ public class CoachFeedback extends AudioFeedback {
         this.range = range;
         this.trigger = trigger;
 
-        switch (dimension) {
-            case PACE:
+        if (dimension == Dimension.PACE) {
                 sign = -1; // pace is "inverse"
-                break;
-            case DISTANCE:
-            case HR:
-            case HRZ:
-            case CAD:
-            case TEMPERATURE:
-            case PRESSURE:
-            case SPEED:
-            case TIME:
-            default:
-                break;
         }
     }
 

--- a/app/src/org/runnerup/workout/feedback/RUTextToSpeech.java
+++ b/app/src/org/runnerup/workout/feedback/RUTextToSpeech.java
@@ -95,6 +95,7 @@ public class RUTextToSpeech {
 
         final boolean trace = true;
         if (queueMode == TextToSpeech.QUEUE_FLUSH) {
+            //Unused in RU
             //noinspection ConstantConditions
             if (trace) {
                 Log.e(getClass().getName(), "speak (mute: " + mute + "): " + text);

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
   <string name="Current_speed">Current speed</string>
   <string name="Current_heart_rate">Current heart rate</string>
   <string name="Current_heart_rate_zone">Current heart rate zone</string>
+  <string name="Current_cadence">Current cadence</string>
   <string name="Misc_cues">Misc cues</string>
   <string name="Target_coaching">Target coaching</string>
   <string name="Skip_event_audio_cues">Skip event audio cues</string>


### PR DESCRIPTION
Various improvements to audio cues

* GPS update also with less than 5m update in default settings. Reverts part of #573 
* Incorrect audio cues for distance (also updates all Transifex files)
* Cue for current cadence
* Skip "lap started" for autolaps
* Group cues, so skip the second lap in "lap 1.01 km lap 5:02"
* Some cleanups
