### PR TITLE
Disable RunKeeper Synchronizer

### DIFF
--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -453,7 +453,7 @@ public class DBHelper extends SQLiteOpenHelper implements
         //ENABLED, FLAGS need to be set if ever changed (like disabled or later enabled)
         //"Minor changes" like adding a new syncher can be handled with updating DB.DBINFO.ACCOUNT_VERSION
         insertAccount(arg0, GarminSynchronizer.NAME, 0);
-        insertAccount(arg0, RunKeeperSynchronizer.NAME, 1);
+        insertAccount(arg0, RunKeeperSynchronizer.NAME, RunKeeperSynchronizer.ENABLED);
         insertAccount(arg0, JoggSESynchronizer.NAME, 0);
         insertAccount(arg0, FunBeatSynchronizer.NAME, 0);
         insertAccount(arg0, MapMyRunSynchronizer.NAME, 0);

--- a/app/src/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/org/runnerup/export/RunKeeperSynchronizer.java
@@ -65,6 +65,7 @@ import java.util.concurrent.TimeUnit;
 public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchronizer, OAuth2Server {
 
     public static final String NAME = "RunKeeper";
+    public static final int ENABLED = 0;
     private static final String PUBLIC_URL = "https://runkeeper.com";
     private Context context = null;
     /**


### PR DESCRIPTION
RunKeeper has depreciated their HealthGraph API,
supposedly new users do not get access tokens.
Can still be added as "disabled" accounts if not configured

https://github.com/cpfair/tapiriik/issues/451