### PR TITLE
Increse Wear mimimum version to 23

### DIFF
--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationIdSuffix rootProject.ext.applicationIdSuffix
-        minSdkVersion 20
+        minSdkVersion 23
         targetSdkVersion rootProject.ext.compileSdkVersion
         versionName rootProject.ext.versionName
         versionCode rootProject.ext.versionCode


### PR DESCRIPTION
Only Marshmallow and above supported
Resolves #628 
Decreases the support, all devices should have been updated to Android 6.0
(Some were stuck there like Sony SmartWatch 3, the only one I have had a remote interest in).