### PR TITLE
Enable Dropbox synchronizer by default

### DIFF
--- a/app/src/org/runnerup/export/DropboxSynchronizer.java
+++ b/app/src/org/runnerup/export/DropboxSynchronizer.java
@@ -50,8 +50,7 @@ public class DropboxSynchronizer extends DefaultSynchronizer implements OAuth2Se
 
     public static final String NAME = "Dropbox";
     private static final String PUBLIC_URL = "https://dropbox.com";
-    // TODO replace when production status: BuildConfig.DROPBOX_ENABLED;
-    public static int ENABLED = 0;
+    public static int ENABLED = BuildConfig.DROPBOX_ENABLED;
 
     private static final String UPLOAD_URL = "https://content.dropboxapi.com/2/files/upload";
     private static final String AUTH_URL = "https://www.dropbox.com/oauth2/authorize";


### PR DESCRIPTION
Fifty users are required for Dropbox to approve (and allow more than 50 users),
but as long as Dropbox is disabled by default, no one will test.