### PR TITLE
12h manual offset

### DIFF
--- a/app/src/org/runnerup/view/HistoryActivity.java
+++ b/app/src/org/runnerup/view/HistoryActivity.java
@@ -184,7 +184,7 @@ public class HistoryActivity extends AppCompatActivity implements Constants, OnI
             }
 
             TextView dateText = view.findViewById(R.id.history_list_date);
-            dateText.setText(formatter.formatDayOfMonth(curDate));
+            dateText.setText(formatter.formatDateTime(ae.getStartTime()));
 
             // distance
             Double d = ae.getDistance();

--- a/app/src/org/runnerup/view/ManualActivity.java
+++ b/app/src/org/runnerup/view/ManualActivity.java
@@ -41,6 +41,7 @@ import org.runnerup.widget.SpinnerInterface.OnSetValueListener;
 
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.util.Calendar;
 import java.util.Date;
 
 @TargetApi(Build.VERSION_CODES.FROYO)
@@ -196,7 +197,11 @@ public class ManualActivity extends AppCompatActivity {
             DateFormat df = android.text.format.DateFormat.getTimeFormat(ManualActivity.this);
             try {
                 Date d = df.parse(time.toString());
-                start_time += d.getTime() / 1000;
+                // date has no timezine/dst info, must compensate
+                Calendar c = Calendar.getInstance();
+                c.setTime(d);
+                c.add(Calendar.MILLISECOND, c.getTimeZone().getOffset((new Date()).getTime()));
+                start_time += c.getTime().getTime() / 1000;
             } catch (ParseException e) {
             }
         }

--- a/app/src/org/runnerup/widget/SpinnerPresenter.java
+++ b/app/src/org/runnerup/widget/SpinnerPresenter.java
@@ -301,9 +301,8 @@ public class SpinnerPresenter {
 
                     private String getValue(TimePicker dp) {
                         Calendar c = Calendar.getInstance();
-                        c.set(Calendar.HOUR, dp.getCurrentHour());
-                        c.set(Calendar.MINUTE, dp.getCurrentMinute());
-                        DateFormat df = android.text.format.DateFormat.getTimeFormat(context);
+                        c.set(2000,01,01, dp.getCurrentHour(), dp.getCurrentMinute());
+                        DateFormat df = android.text.format.DateFormat.getTimeFormat(mContext);
                         return df.format(c.getTime());
                     }
                 });
@@ -532,10 +531,11 @@ public class SpinnerPresenter {
             mCurrValue = 0;
         } else if (mType == Type.TS_DURATIONPICKER) {
             mCurrValue = SafeParse.parseSeconds(value, 0);
-        } else {
+        } else if (mType != Type.TS_TIMEPICKER) {
             mCurrValue = (long) SafeParse.parseDouble(value, 0);
         }
         if (mType == Type.TS_DISTANCEPICKER && !TextUtils.isEmpty(value)) {
+            // Should be replaced with Formatter
             mSpin.setViewText(String.format("%s %s", value, mContext.getResources().getString(R.string.metrics_distance_m)));
         } else {
             mSpin.setViewText(value);


### PR DESCRIPTION
* Include time of day in History overview
@12people This changes the layout some, year/month is included twice but I want to see the start time in the history
* Manual Activity: Adjust selected time for timezone/dst offset
Old bug
* TimePicker: No 12h offset
Closes #732, also in 1.x