### PR TITLE
Cleanup for AntPlus, MapBox

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,11 @@ def doExtractStringFromManifest(name) {
 android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
@@ -126,9 +131,7 @@ dependencies {
     latestImplementation "com.android.support:cardview-v7:${rootProject.ext.supportLibrary}"
     latestImplementation "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesVersion}"
     latestImplementation 'com.getpebble:pebblekit:4.0.1'
-    latestImplementation ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.1@aar'){
-        transitive=true
-    }
+    latestImplementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:6.8.1'
     latestImplementation 'com.jjoe64:graphview:4.2.2'
     froyoImplementation 'com.jjoe64:graphview:4.2.1'
 

--- a/app/proguard.txt
+++ b/app/proguard.txt
@@ -12,9 +12,12 @@
 -dontnote com.google.protobuf.zz*
 -dontnote com.google.android.gms.dynamic.IObjectWrapper
 
-#AntPlus optional - created by reflection
+#AntPlus is optional - used by reflection
 -keep class org.runnerup.hr.AntPlus {
-  AntPlus(android.content.Context);
+  *;
+}
+-keepclassmembers class org.runnerup.hr.AntPlus {
+    *;
 }
 
 ############################

--- a/app/src/org/runnerup/db/DBHelper.java
+++ b/app/src/org/runnerup/db/DBHelper.java
@@ -602,20 +602,40 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     public static String getDbPath(Context ctx) {
-        return ctx.getFilesDir().getPath() + "/../databases/runnerup.db";
+        return ctx.getFilesDir().getPath() + "/../databases/" + DBNAME;
     }
 
     public static void importDatabase(Context ctx, String from) {
         AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
-        builder.setTitle("Import runnerup.db from " + from);
+        builder.setTitle("Import " + DBNAME + " from " + from);
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
             }
-
         };
         String to = getDbPath(ctx);
+        try {
+            int cnt = FileUtil.copyFile(to, from);
+            builder.setMessage("Copied " + cnt + " bytes");
+            builder.setPositiveButton(ctx.getString(R.string.Great), listener);
+        } catch (IOException e) {
+            builder.setMessage("Exception: " + e.toString());
+            builder.setNegativeButton(ctx.getString(R.string.Darn), listener);
+        }
+        builder.show();
+    }
+
+    public static void exportDatabase(Context ctx, String to) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
+        builder.setTitle("Export " + DBNAME + " to " + to);
+        DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        };
+        String from = getDbPath(ctx);
         try {
             int cnt = FileUtil.copyFile(to, from);
             builder.setMessage("Copied " + cnt + " bytes");

--- a/app/src/org/runnerup/view/MainLayout.java
+++ b/app/src/org/runnerup/view/MainLayout.java
@@ -37,7 +37,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
@@ -171,18 +173,23 @@ public class MainLayout extends TabActivity
         handleBundled(getApplicationContext().getAssets(), "bundled", getFilesDir().getPath() + "/..");
 
         // if we were called from an intent-filter because user opened "runnerup.db.export", load it
+        final String filePath;
         final Uri data = getIntent().getData();
         if (data != null) {
-            if (SettingsActivity.requestReadStoragePermissions(MainLayout.this)) {
-                String filePath;
-                if ("content".equals(data.getScheme())) {
-                    Cursor cursor = this.getContentResolver().query(data, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
-                    cursor.moveToFirst();
-                    filePath = cursor.getString(0);
-                    cursor.close();
-                } else {
-                    filePath = data.getPath();
-                }
+            if ("content".equals(data.getScheme())) {
+                Cursor cursor = this.getContentResolver().query(data, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
+                cursor.moveToFirst();
+                filePath = cursor.getString(0);
+                cursor.close();
+            } else {
+                filePath = data.getPath();
+            }
+        } else {
+            filePath = null;
+        }
+
+        if (filePath != null) {
+            if (requestReadStoragePermissions(MainLayout.this)) {
                 Log.i(getClass().getSimpleName(), "Importing database from " + filePath);
                 DBHelper.importDatabase(MainLayout.this, filePath);
             } else {
@@ -351,16 +358,52 @@ public class MainLayout extends TabActivity
         }
     }
 
+    private static boolean requestReadStoragePermissions(final Activity activity) {
+        boolean ret = true;
+        if (Build.VERSION.SDK_INT >= 16 &&
+                ContextCompat.checkSelfPermission(activity,
+                        Manifest.permission.READ_EXTERNAL_STORAGE)
+                        != PackageManager.PERMISSION_GRANTED) {
+            ret = false;
+
+            //Request permission (not using shouldShowRequestPermissionRationale())
+            ActivityCompat.requestPermissions(activity,
+                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                    REQUEST_READ_EXTERNAL_STORAGE);
+            String s = "Requesting read permission";
+            Log.i(activity.getClass().getSimpleName(), s);
+        }
+        return ret;
+    }
+
     /**
      * Id to identify a permission request.
      */
     private static final int REQUEST_LOCATION = 1000;
+    private static final int REQUEST_READ_EXTERNAL_STORAGE = 2000;
+    private static final int REQUEST_WRITE_EXTERNAL_STORAGE = 2001;
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
 
-        if (requestCode == REQUEST_LOCATION) {
+        if (requestCode == REQUEST_READ_EXTERNAL_STORAGE || requestCode == REQUEST_WRITE_EXTERNAL_STORAGE) {
+            // Check if the only required permission has been granted (could react on the response)
+            //noinspection StatementWithEmptyBody
+            if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                //OK, could redo request here
+            } else {
+                String s = (requestCode == REQUEST_READ_EXTERNAL_STORAGE ? "READ" : "WRITE")
+                        + " permission was NOT granted";
+                if (grantResults.length >= 1) {
+                    s += grantResults[0];
+                }
+
+                Log.i(getClass().getSimpleName(), s);
+                //Toast.makeText(SettingsActivity.this, s, Toast.LENGTH_SHORT).show();
+            }
+
+        } else if (requestCode == REQUEST_LOCATION) {
             // Check if the only required permission has been granted (could react on the response)
             if (grantResults.length >= 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 String s = "Permission response OK: " + grantResults.length;

--- a/app/src/org/runnerup/view/SettingsActivity.java
+++ b/app/src/org/runnerup/view/SettingsActivity.java
@@ -119,18 +119,12 @@ public class SettingsActivity extends PreferenceActivity
                 != PackageManager.PERMISSION_GRANTED) {
             ret = false;
 
-            //noinspection StatementWithEmptyBody
-            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
-                    Manifest.permission.READ_EXTERNAL_STORAGE)) {
-                //The caller informs the user, no toast or SnackBar
-            } else {
-                //Request permission - not working from Settings.Activity
-                //ActivityCompat.requestPermissions(activity,
-                //        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
-                //        REQUEST_READ_EXTERNAL_STORAGE);
-                String s = "Read permission is NOT granted";
-                Log.i(activity.getClass().getSimpleName(), s);
-            }
+            //Request permission - not working from Settings.Activity
+            ActivityCompat.requestPermissions(activity,
+                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                    REQUEST_READ_EXTERNAL_STORAGE);
+            String s = "Requesting read permission";
+            Log.i(activity.getClass().getSimpleName(), s);
         }
         return ret;
     }
@@ -142,18 +136,13 @@ public class SettingsActivity extends PreferenceActivity
                 != PackageManager.PERMISSION_GRANTED) {
             ret = false;
 
-            //noinspection StatementWithEmptyBody
-            if (ActivityCompat.shouldShowRequestPermissionRationale(activity,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                //The caller informs the user, no toast or SnackBar
-            } else {
-                 //Request permission - not working from Settings.Activity
-                 //ActivityCompat.requestPermissions(activity,
-                 //        new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                 //        REQUEST_WRITE_EXTERNAL_STORAGE);
-                String s = "Write permission is NOT granted";
-                Log.i(activity.getClass().getSimpleName(), s);
-            }
+            //Request permission (not using shouldShowRequestPermissionRationale())
+            // not working from Settings.Activity
+            ActivityCompat.requestPermissions(activity,
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    REQUEST_WRITE_EXTERNAL_STORAGE);
+            String s = "Requesting write permission";
+            Log.i(activity.getClass().getSimpleName(), s);
         }
         return ret;
     }
@@ -192,32 +181,25 @@ public class SettingsActivity extends PreferenceActivity
 
         @Override
         public boolean onPreferenceClick(Preference preference) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this);
-            String dstdir = Environment.getExternalStorageDirectory().getPath();
-            builder.setTitle("Export runnerup.db to " + dstdir);
-            DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    dialog.dismiss();
-                }
-
-            };
-            if(requestWriteStoragePermissions(SettingsActivity.this)) {
-                String from = DBHelper.getDbPath(getApplicationContext());
+            if (requestWriteStoragePermissions(SettingsActivity.this)) {
+                String dstdir = Environment.getExternalStorageDirectory().getPath();
                 String to = dstdir + "/runnerup.db.export";
-                try {
-                    int cnt = FileUtil.copyFile(to, from);
-                    builder.setMessage("Copied " + cnt + " bytes");
-                    builder.setPositiveButton(getString(R.string.Great), listener);
-                } catch (IOException e) {
-                    builder.setMessage("Exception: " + e.toString());
-                    builder.setNegativeButton(getString(R.string.Darn), listener);
-                }
+                DBHelper.exportDatabase(SettingsActivity.this, to);
+
             } else {
+                AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this);
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+
+                };
+                builder.setTitle("Export runnerup.db");
                 builder.setMessage("Storage permission not granted in Android settings");
                 builder.setNegativeButton(getString(R.string.Darn), listener);
+                builder.show();
             }
-            builder.show();
             return false;
         }
     };

--- a/hrdevice/src/org/runnerup/hr/AntPlus.java
+++ b/hrdevice/src/org/runnerup/hr/AntPlus.java
@@ -28,6 +28,7 @@ import com.dsi.ant.plugins.antplus.pcc.AntPlusHeartRatePcc.IHeartRateDataReceive
 import com.dsi.ant.plugins.antplus.pcc.defines.DeviceState;
 import com.dsi.ant.plugins.antplus.pcc.defines.EventFlag;
 import com.dsi.ant.plugins.antplus.pcc.defines.RequestAccessResult;
+import com.dsi.ant.plugins.antplus.pccbase.AntPluginPcc;
 import com.dsi.ant.plugins.antplus.pccbase.AntPluginPcc.IDeviceStateChangeReceiver;
 import com.dsi.ant.plugins.antplus.pccbase.AntPluginPcc.IPluginAccessResultReceiver;
 import com.dsi.ant.plugins.antplus.pccbase.AsyncScanController;
@@ -47,7 +48,7 @@ import java.util.HashSet;
 
 public class AntPlus extends BtHRBase {
 
-    static final String NAME = "AntPlus";
+    private static final String NAME = "AntPlus";
     private static final String DISPLAY_NAME = "ANT+";
 
     private final Context context;
@@ -57,7 +58,6 @@ public class AntPlus extends BtHRBase {
 
     private HRDeviceRef connectRef = null;
 
-    AntPlusHeartRatePcc hrPcc = null;
     private AsyncScanController<AntPlusHeartRatePcc> hrScanCtrl = null;
 
     private boolean mIsScanning = false;
@@ -96,6 +96,20 @@ public class AntPlus extends BtHRBase {
         if (client != null) {
             client.onCloseResult(true);
         }
+    }
+
+    public static boolean checkLibrary(Context ctx) {
+        try {
+            // A few required libs
+            Class.forName("com.dsi.ant.plugins.antplus.pcc.AntPlusHeartRatePcc");
+            Class.forName("com.dsi.ant.plugins.antplus.pcc.defines.DeviceState");
+            Class.forName("com.dsi.ant.plugins.antplus.pcc.defines.RequestAccessResult");
+            Class.forName("com.dsi.ant.plugins.antplus.pccbase.AsyncScanController");
+
+            // The system libraries must be installed
+            return AntPluginPcc.getInstalledPluginsVersionNumber(ctx) >= 0;
+        } catch(Exception e){}
+        return false;
     }
 
     @Override
@@ -416,7 +430,7 @@ public class AntPlus extends BtHRBase {
         return -1;
     }
 
-    /** it seems ANT+ requires Bluetooth too */
+    // ANT+ requires Bluetooth too, as well as that system libs are loaded
 
     @Override
     public boolean isEnabled() {


### PR DESCRIPTION
AntPlus: Only show if the ant+ libraries are installed

Update mapbox to 6.8.1
7.3 is latest version, but will require rewrite of the mapwrapper to avoid removal (depreciated in 6.x)

Cleanup for requesting read/write permissions 