### PR TITLE
Set a "debug" suffix for debug build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".${applicationIdSuffix}.debug"
+        }
         release {
             minifyEnabled true
             shrinkResources true


### PR DESCRIPTION
This allows installation of debug builds together with
the release builds.
There are some limitations with intents, hardcoded refs in
settings.xml