### PR TITLE
Remove Runnerup alpha

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -114,7 +114,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.MainLayout"/>
+                android:value=".view.MainLayout"/>
         </activity>
 
         <activity
@@ -130,7 +130,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.MainLayout"/>
+                android:value=".view.MainLayout"/>
         </activity>
 
         <activity
@@ -141,7 +141,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.MainLayout"/>
+                android:value=".view.MainLayout"/>
         </activity>
 
         <activity
@@ -151,7 +151,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.AccountListActivity"/>
+                android:value=".view.AccountListActivity"/>
         </activity>
 
         <activity android:name=".view.UploadActivity"/>
@@ -164,7 +164,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.MainLayout"/>
+                android:value=".view.MainLayout"/>
             <intent-filter tools:ignore="GoogleAppIndexingWarning,AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW"/>
                 <action android:name="android.intent.action.EDIT"/>
@@ -203,7 +203,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.AccountListActivity"/>
+                android:value=".view.AccountListActivity"/>
         </activity>
 
         <activity
@@ -214,7 +214,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.SettingsActivity"/>
+                android:value=".view.SettingsActivity"/>
         </activity>
 
         <activity
@@ -225,7 +225,7 @@
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.runnerup.view.SettingsActivity"/>
+                android:value=".view.SettingsActivity"/>
         </activity>
 
         <service android:name=".tracker.Tracker"/>

--- a/app/assets/changes.html
+++ b/app/assets/changes.html
@@ -5,6 +5,11 @@
 </head>
 <body>
 <h1>What's new</h1>
+<h2>v2.0.0.7</h2>
+<p>
+<ul>
+    <li>#799 Froyo startup fix</li>
+</ul>
 <h2>v2.0.0.6</h2>
 <p>
 <ul>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,6 @@ android {
     }
 
     defaultConfig {
-        applicationIdSuffix rootProject.ext.applicationIdSuffix
         applicationId = doExtractStringFromManifest("package")
         vectorDrawables.useSupportLibrary = true
         //By default all AppCompat translations are included, saves 350KB
@@ -91,6 +90,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             minifyEnabled true
             shrinkResources true

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -41,7 +41,7 @@
             android:key="cue_configure_hr"
             android:title="@string/Heart_Rate_Monitor">
             <intent
-                android:targetPackage="org.runnerup.alpha"
+                android:targetPackage="org.runnerup"
                 android:targetClass="org.runnerup.view.HRSettingsActivity" />
         </Preference>
 
@@ -49,7 +49,7 @@
             android:key="@string/cue_configure_hrzones"
             android:title="@string/Heart_Rate_Zones">
             <intent
-                android:targetPackage="org.runnerup.alpha"
+                android:targetPackage="org.runnerup"
                 android:targetClass="org.runnerup.view.HRZonesActivity" />
         </Preference>
 
@@ -244,7 +244,7 @@
             android:title="@string/Accounts"
             android:summary="@string/Configure_accounts">
             <intent
-                android:targetPackage="org.runnerup.alpha"
+                android:targetPackage="org.runnerup"
                 android:targetClass="org.runnerup.view.AccountListActivity" />
     </Preference>
 
@@ -260,7 +260,7 @@
         android:title="@string/Audio_cues"
         android:summary="@string/Configure_audio_cues">
         <intent
-            android:targetPackage="org.runnerup.alpha"
+            android:targetPackage="org.runnerup"
             android:targetClass="org.runnerup.view.AudioCueSettingsActivity" />
     </Preference>
 
@@ -273,7 +273,7 @@
             android:title="@string/Manage_workouts"
             android:summary="@string/Downloadeditremove_workouts">
             <intent
-                android:targetPackage="org.runnerup.alpha"
+                android:targetPackage="org.runnerup"
                 android:targetClass="org.runnerup.view.ManageWorkoutsActivity" />
         </Preference>
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,8 @@ project.ext {
     junitVersion = '4.12'
     mockitoVersion = '2.3.7'
 
-    versionName = '2.0.0.6'
+    versionName = '2.0.0.7'
     versionCode = 200
-    //Set a specific name to this app. Also need to be changed in settings.xml
-    applicationIdSuffix = ".alpha"
 
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -6,7 +6,6 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        applicationIdSuffix rootProject.ext.applicationIdSuffix
         minSdkVersion 23
         targetSdkVersion rootProject.ext.compileSdkVersion
         versionName rootProject.ext.versionName


### PR DESCRIPTION
In 2.0 development builds have been published as runnerup.alpha, so it could be
installed together with the Play version.
This had a few side effects, especially for the Froyo build,
where "Up" navigation in the navigation menu failed (Back is OK).

As a replacement, debug builds set a ".debug" suffix so it can be installed with
release builds.