### PR TITLE
Bugfix/debug appid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
   - ANDROID_API=28
-  - ANDROID_BUILD_TOOLS=28.0.3
+  - ANDROID_BUILD_TOOLS=29.0.1
   - ADB_INSTALL_TIMEOUT=5
 language: android
 jdk:

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -109,12 +109,12 @@
         <activity
             android:name=".view.DetailActivity"
             android:configChanges="orientation|screenSize|uiMode"
-            android:parentActivityName=".view.MainLayout"
+            android:parentActivityName=".view.HistoryActivity"
             android:theme="@style/AppTheme.NoActionBar">
             <!-- Parent activity meta-data to support 4.0 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value=".view.MainLayout"/>
+                android:value=".view.HistoryActivity"/>
         </activity>
 
         <activity

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,6 @@ apply plugin: 'com.android.application'
 
 import java.util.regex.Pattern
 
-def doExtractStringFromManifest(name) {
-    def manifestFile = file(android.sourceSets.main.manifest.srcFile)
-    def pattern = Pattern.compile(name + "=\"(.*?)\"")
-    def matcher = pattern.matcher(manifestFile.getText())
-    matcher.find()
-    return matcher.group(1)
-}
-
 android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
@@ -77,7 +69,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = doExtractStringFromManifest("package")
+        applicationId = "org.runnerup"
         vectorDrawables.useSupportLibrary = true
         //By default all AppCompat translations are included, saves 350KB
         resConfigs "ar", "bs", "cs", "ca", "de", "en", "es", "fa", "fi", "fr", "hu", "id", "it", "ja", "lt", "nb", "nl", "pl", "pt", "ru", "sv", "tr"
@@ -91,13 +83,18 @@ android {
 
     buildTypes {
         debug {
+            // Set the applicationId separate for the debug build so it can be installed separately
+            // The applicationId is also used in some xml files (android:targetPackage)
+            // The packageId (in the manifest) is never changed
             applicationIdSuffix ".debug"
+            resValue "string", "applicationIdFull", "org.runnerup${applicationIdSuffix}"
         }
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.txt'
             signingConfig signingConfigs.release
+            resValue "string", "applicationIdFull", "org.runnerup"
         }
     }
 

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -41,7 +41,7 @@
             android:key="cue_configure_hr"
             android:title="@string/Heart_Rate_Monitor">
             <intent
-                android:targetPackage="org.runnerup"
+                android:targetPackage="@string/applicationIdFull"
                 android:targetClass="org.runnerup.view.HRSettingsActivity" />
         </Preference>
 
@@ -49,7 +49,7 @@
             android:key="@string/cue_configure_hrzones"
             android:title="@string/Heart_Rate_Zones">
             <intent
-                android:targetPackage="org.runnerup"
+                android:targetPackage="@string/applicationIdFull"
                 android:targetClass="org.runnerup.view.HRZonesActivity" />
         </Preference>
 
@@ -244,7 +244,7 @@
             android:title="@string/Accounts"
             android:summary="@string/Configure_accounts">
             <intent
-                android:targetPackage="org.runnerup"
+                android:targetPackage="@string/applicationIdFull"
                 android:targetClass="org.runnerup.view.AccountListActivity" />
     </Preference>
 
@@ -260,7 +260,7 @@
         android:title="@string/Audio_cues"
         android:summary="@string/Configure_audio_cues">
         <intent
-            android:targetPackage="org.runnerup"
+            android:targetPackage="@string/applicationIdFull"
             android:targetClass="org.runnerup.view.AudioCueSettingsActivity" />
     </Preference>
 
@@ -273,7 +273,7 @@
             android:title="@string/Manage_workouts"
             android:summary="@string/Downloadeditremove_workouts">
             <intent
-                android:targetPackage="org.runnerup"
+                android:targetPackage="@string/applicationIdFull"
                 android:targetClass="org.runnerup.view.ManageWorkoutsActivity" />
         </Preference>
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ project.ext {
     //Note that Android Studio does not know about the 'ext' module and will warn
     //Some settings may differ for 'froyo' release
     //minSdkVersion differs between modules
-    buildToolsVersion = '28.0.3' //Update Travis manually
+    buildToolsVersion = '29.0.1' //Update Travis manually
     compileSdkVersion = 28 //Update Travis manually
     targetSdkVersion = 28
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-android.enableD8.desugaring=false
 android.enableR8=false


### PR DESCRIPTION
Debug builds identifies as a separate application. Activities in settings could not be started as the applicationId had to be hardcoded there previously.

Updated build tools, to avoid warning