### PR TITLE
Disable Media button control in Lollipop and later

### DIFF
--- a/app/src/main/org/runnerup/view/SettingsActivity.java
+++ b/app/src/main/org/runnerup/view/SettingsActivity.java
@@ -82,6 +82,10 @@ public class SettingsActivity extends PreferenceActivity
             //pref.setSummary(null);
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Preference pref = findPreference(this.getString(R.string.pref_keystartstop_active));
+            pref.setEnabled(false);
+        }
         if (!TrackerCadence.isAvailable(this)) {
             Preference pref = findPreference(this.getString(R.string.pref_use_cadence_step_sensor));
             pref.setEnabled(false);

--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -28,6 +28,7 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
@@ -439,7 +440,8 @@ public class StartActivity extends AppCompatActivity implements TickListener, Gp
         intentFilter.addAction(Constants.Intents.START_WORKOUT);
         registerReceiver(startEventBroadcastReceiver, intentFilter);
 
-        if (StartActivityHeadsetButtonReceiver.getAllowStartStopFromHeadsetKey(this)) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP &&
+                StartActivityHeadsetButtonReceiver.getAllowStartStopFromHeadsetKey(this)) {
             headsetRegistered = true;
             StartActivityHeadsetButtonReceiver.registerHeadsetListener(this);
         }


### PR DESCRIPTION
Not working in Lollipop (even earlier?), need a rewrite using MediaStream, not really usable

Will be kind of replaced with notification buttons and maybe Assistant Actions