### PR TITLE
GPX/TCX file formats option for File and Dropbox Synchronizers

### DIFF
--- a/app/res/layout/filepermission.xml
+++ b/app/res/layout/filepermission.xml
@@ -55,24 +55,4 @@
 
     </TableRow>
 
-    <TableRow
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-
-        <CheckBox
-            android:id="@+id/tcxformat"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="8dp"
-            android:text="TCX"
-            tools:ignore="HardcodedText"/>
-
-        <CheckBox
-            android:id="@+id/gpxformat"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="GPX"
-            tools:ignore="HardcodedText"/>
-    </TableRow>
-
 </LinearLayout>

--- a/app/src/main/org/runnerup/db/DBHelper.java
+++ b/app/src/main/org/runnerup/db/DBHelper.java
@@ -17,7 +17,6 @@
 
 package org.runnerup.db;
 
-import android.annotation.TargetApi;
 import android.support.v7.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.ContentValues;
@@ -27,9 +26,10 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.util.Log;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.db.entities.DBEntity;
@@ -41,7 +41,6 @@ import org.runnerup.export.FileSynchronizer;
 import org.runnerup.export.FunBeatSynchronizer;
 import org.runnerup.export.GarminSynchronizer;
 import org.runnerup.export.GoogleFitSynchronizer;
-import org.runnerup.export.GooglePlusSynchronizer;
 import org.runnerup.export.JoggSESynchronizer;
 import org.runnerup.export.MapMyRunSynchronizer;
 import org.runnerup.export.NikePlusSynchronizer;
@@ -53,7 +52,9 @@ import org.runnerup.export.RunningFreeOnlineSynchronizer;
 import org.runnerup.export.RuntasticSynchronizer;
 import org.runnerup.export.StravaSynchronizer;
 import org.runnerup.util.FileUtil;
+import org.runnerup.workout.FileFormats;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -133,7 +134,7 @@ public class DBHelper extends SQLiteOpenHelper implements
             + (DB.ACCOUNT.NAME + " text not null, ")
             + (DB.ACCOUNT.DESCRIPTION + " text, ") //DBVERSION update: remove
             + (DB.ACCOUNT.URL + " text, ") //DBVERSION update: remove
-            + (DB.ACCOUNT.FORMAT + " text not null, ") //DBVERSION update: remove
+            + (DB.ACCOUNT.FORMAT + " text not null, ") // tcx/gpx, for file uploads
             + (DB.ACCOUNT.FLAGS + " integer not null default " + DB.ACCOUNT.DEFAULT_FLAGS + ", ") //Mostly not used but dynamic changes could be stored here
             + (DB.ACCOUNT.ENABLED + " integer not null default 1,") //Account is not hidden/disabled
             + (DB.ACCOUNT.AUTH_METHOD + " text not null, ") //DBVERSION update: remove
@@ -391,7 +392,7 @@ public class DBHelper extends SQLiteOpenHelper implements
     }
 
     private void migrateFileSynchronizerInfo(SQLiteDatabase arg0) {
-            //Migrate storage of parameters, FORMAT is removed
+        // Migrate storage of parameters
         String from[] = { "_id", DB.ACCOUNT.FORMAT, DB.ACCOUNT.AUTH_CONFIG };
         String args[] = { FileSynchronizer.NAME };
         Cursor c = arg0.query(DB.ACCOUNT.TABLE, from,
@@ -402,14 +403,31 @@ public class DBHelper extends SQLiteOpenHelper implements
         if (c.moveToFirst()) {
             ContentValues tmp = DBHelper.get(c);
             //URL was stored in AUTH_CONFIG previously, FORMAT migrated too
-            String oldUrl = tmp.getAsString(DB.ACCOUNT.AUTH_CONFIG);
+            String oldAuthConfig = tmp.getAsString(DB.ACCOUNT.AUTH_CONFIG);
             //DBVERSION update, not needed in onUpgrade()
-            if (oldUrl.startsWith("/")) {
-                tmp.put(DB.ACCOUNT.URL, oldUrl);
+            if (oldAuthConfig.startsWith("/")) {
+                tmp.put(DB.ACCOUNT.URL, oldAuthConfig);
                 String authConfig = FileSynchronizer.contentValuesToAuthConfig(tmp);
                 tmp = new ContentValues();
                 tmp.put(DB.ACCOUNT.AUTH_CONFIG, authConfig);
+                tmp.put(DB.ACCOUNT.FORMAT, FileFormats.DEFAULT_FORMATS.toString());
                 arg0.update(DB.ACCOUNT.TABLE, tmp, DB.ACCOUNT.NAME + " = ?", args);
+            } else {
+                try {
+                    // Check if AUTH_CONFIG contains deprecated FORMAT field
+                    JSONObject authcfg = new JSONObject(oldAuthConfig);
+                    String format = authcfg.optString(DB.ACCOUNT.FORMAT, null);
+                    if (format != null) {
+                        // Move deprecated FORMAT field in AUTH_CONFIG to ACCOUNT.FORMAT
+                        authcfg.put(DB.ACCOUNT.FORMAT, null);
+                        tmp = new ContentValues();
+                        tmp.put(DB.ACCOUNT.AUTH_CONFIG, authcfg.toString());
+                        tmp.put(DB.ACCOUNT.FORMAT, format);
+                        arg0.update(DB.ACCOUNT.TABLE, tmp, DB.ACCOUNT.NAME + " = ?", args);
+                    }
+                } catch (JSONException e) {
+                    Log.w("DBHelper", "Failed to parse File auth config", e);
+                }
             }
         }
         c.close();
@@ -486,8 +504,8 @@ public class DBHelper extends SQLiteOpenHelper implements
         if (flags >= 0) {
             arg1.put(DB.ACCOUNT.FLAGS, flags);
         }
+        arg1.put(DB.ACCOUNT.FORMAT, FileFormats.DEFAULT_FORMATS.toString());
         //DBVERSION update, must provide dummy data
-        arg1.put(DB.ACCOUNT.FORMAT, "tcx");
         arg1.put(DB.ACCOUNT.AUTH_METHOD, "dummy");
 
         //SQLite has no UPSERT command. Optimize for no change.

--- a/app/src/main/org/runnerup/export/SyncManager.java
+++ b/app/src/main/org/runnerup/export/SyncManager.java
@@ -216,7 +216,7 @@ public class SyncManager {
         } else if (synchronizerName.contentEquals(RunalyzeSynchronizer.NAME)) {
             synchronizer = new RunalyzeSynchronizer();
         } else if (synchronizerName.contentEquals(DropboxSynchronizer.NAME)) {
-            synchronizer = new DropboxSynchronizer();
+            synchronizer = new DropboxSynchronizer(mContext);
         } else {
             Log.e(getClass().getName(), "synchronizer does not exist: " + synchronizerName);;
         }
@@ -476,10 +476,6 @@ public class SyncManager {
         final TextView tv1 = (TextView) view.findViewById(R.id.fileuri);
         final TextView tvAuthNotice = (TextView) view.findViewById(R.id.textViewAuthNotice);
 
-        final CheckBox cbtcx = (CheckBox) view.findViewById(R.id.tcxformat);
-        final CheckBox cbgpx = (CheckBox) view.findViewById(R.id.gpxformat);
-        cbtcx.setChecked(true);
-
         String path;
         if (Build.VERSION.SDK_INT >= 19) {
             //noinspection InlinedApi
@@ -508,16 +504,8 @@ public class SyncManager {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         //Set default values
-                        String format = "";
-                        if (cbtcx.isChecked()) {
-                            format = "tcx,";
-                        }
-                        if (cbgpx.isChecked()) {
-                            format += "gpx,";
-                        }
 
                         ContentValues tmp = new ContentValues();
-                        tmp.put(DB.ACCOUNT.FORMAT, format);
                         tmp.put(DB.ACCOUNT.URL, tv1.getText().toString());
                         ContentValues config = new ContentValues();
                         config.put("_id", sync.getId());

--- a/app/src/main/org/runnerup/export/Synchronizer.java
+++ b/app/src/main/org/runnerup/export/Synchronizer.java
@@ -70,8 +70,8 @@ public interface Synchronizer {
         LIVE, // live feed of activity
         SKIP_MAP, // skip map in upload
         ACTIVITY_LIST, //list recorded activities
-        GET_ACTIVITY //download recorded activity
-
+        GET_ACTIVITY, //download recorded activity
+        FILE_FORMAT // upload as file in different possible formats
     }
 
     /**

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -414,6 +414,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                     + ("  acc." + DB.ACCOUNT.NAME + ", ")
                     + ("  acc." + DB.ACCOUNT.FLAGS + ", ")
                     + ("  acc." + DB.ACCOUNT.AUTH_CONFIG + ", ")
+                    + ("  acc." + DB.ACCOUNT.FORMAT + ", ")
                     + ("  rep._id as repid, ")
                     + ("  rep." + DB.EXPORT.ACCOUNT + ", ")
                     + ("  rep." + DB.EXPORT.ACTIVITY + ", ")

--- a/app/src/main/org/runnerup/workout/FileFormats.java
+++ b/app/src/main/org/runnerup/workout/FileFormats.java
@@ -1,0 +1,106 @@
+package org.runnerup.workout;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class FileFormats {
+
+    private final boolean readonly;
+    private String formats;
+
+    public static class Format {
+
+        final private String name;
+        final private String value;
+
+        Format(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public final static Format GPX = new Format("GPX", "gpx");
+    public final static Format TCX = new Format("TCX", "tcx");
+    public final static List<Format> ALL_FORMATS;
+    public final static FileFormats DEFAULT_FORMATS;
+
+    static {
+        List<Format> formatList = Arrays.asList(TCX, GPX);
+        ALL_FORMATS = Collections.unmodifiableList(formatList);
+        DEFAULT_FORMATS = new FileFormats(FileFormats.TCX.getValue(), true);
+    }
+
+    public FileFormats() {
+        this(null, false);
+    }
+
+    public FileFormats(String formats) {
+        this(formats, false);
+    }
+
+    private FileFormats(String formats, boolean readonly) {
+        this.readonly = readonly;
+        this.formats = formats == null ? "" : formats;
+    }
+
+    public boolean contains(Format format) {
+        if (format == null) {
+            throw new IllegalArgumentException();
+        }
+        // search for the format type between 2 word boundaries, anywhere in the string
+        return formats.matches(".*\\b" + format.getValue() + "\\b.*");
+    }
+
+    public boolean remove(Format format) {
+        if (format == null) {
+            throw new IllegalArgumentException();
+        }
+        if (readonly) {
+            throw new UnsupportedOperationException();
+        }
+        if (contains(format)) {
+            formats = formats.replaceAll(",?" + format.getValue() + "\\b", "");
+            // cleanup commas
+            formats = formats.replaceAll(",$", "");
+            formats = formats.replaceAll("^,", "");
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean add(Format format) {
+        if (format == null) {
+            throw new IllegalArgumentException();
+        }
+        if (readonly) {
+            throw new UnsupportedOperationException();
+        }
+        if (formats.length() == 0) {
+            formats = format.getValue();
+            return true;
+        } else {
+            if (contains(format)) {
+                return false;
+            } else {
+                formats += "," + format.getValue();
+                // cleanup commas
+                formats = formats.replaceAll(",,", ",");
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return formats;
+    }
+}

--- a/app/test/java/org/runnerup/workout/FileFormatsTest.java
+++ b/app/test/java/org/runnerup/workout/FileFormatsTest.java
@@ -1,0 +1,167 @@
+package org.runnerup.workout;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FileFormatsTest {
+
+    @Test
+    public void nullConstructor() {
+        FileFormats formats = new FileFormats();
+        assertNotNull(formats.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullContains() {
+        FileFormats formats = new FileFormats();
+        formats.contains(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullAdd() {
+        FileFormats formats = new FileFormats();
+        formats.add(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullRemove() {
+        FileFormats formats = new FileFormats();
+        formats.remove(null);
+    }
+
+    @Test
+    public void defaultNotEmpty() {
+        FileFormats formats = FileFormats.DEFAULT_FORMATS;
+        boolean notEmpty = false;
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            notEmpty = notEmpty || formats.contains(f);
+        }
+        assertTrue(notEmpty);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void defaultNoRemove() {
+        FileFormats formats = FileFormats.DEFAULT_FORMATS;
+        formats.remove(FileFormats.TCX);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void defaultNoAdd() {
+        FileFormats formats = FileFormats.DEFAULT_FORMATS;
+        formats.add(FileFormats.GPX);
+    }
+
+
+    @Test
+    public void addOnce() {
+        FileFormats formats;
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            formats = new FileFormats();
+            formats.add(f);
+            assertEquals(formats.toString(), f.getValue());
+        }
+    }
+
+    @Test
+    public void addAll() {
+        FileFormats formats = new FileFormats();
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertFalse(formats.contains(f));
+        }
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            formats.add(f);
+        }
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.contains(f));
+        }
+    }
+
+    @Test
+    public void addTwice() {
+        FileFormats formats = new FileFormats();
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.add(f));
+        }
+        String v1 = formats.toString();
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertFalse(formats.add(f));
+        }
+        String v2 = formats.toString();
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void removeOnce() {
+        FileFormats formats = new FileFormats();
+        String v1 = formats.toString();
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.add(f));
+        }
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.remove(f));
+        }
+        String v2 = formats.toString();
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void removeTwice() {
+        FileFormats formats = new FileFormats();
+        String v1 = formats.toString();
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.add(f));
+        }
+        for (FileFormats.Format f: FileFormats.ALL_FORMATS) {
+            assertTrue(formats.remove(f));
+            assertFalse(formats.remove(f));
+        }
+        String v2 = formats.toString();
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void legacyCompat() {
+        FileFormats formats;
+        // one format
+        formats = new FileFormats("gpx,");
+        assertTrue(formats.contains(FileFormats.GPX));
+        assertTrue(formats.add(FileFormats.TCX));
+        assertTrue(formats.remove(FileFormats.GPX));
+        assertFalse(formats.contains(FileFormats.GPX));
+        assertTrue(formats.contains(FileFormats.TCX));
+
+        // both formats
+        formats = new FileFormats("gpx,tcx,");
+        String v1 = formats.toString();
+        assertTrue(formats.contains(FileFormats.TCX));
+        assertFalse(formats.add(FileFormats.TCX));
+        String v2 = formats.toString();
+        assertEquals(v1, v2);
+        assertTrue(formats.remove(FileFormats.TCX));
+        assertFalse(formats.contains(FileFormats.TCX));
+        assertEquals(formats.toString(), FileFormats.GPX.getValue());
+    }
+
+    @Test
+    public void futureProof() {
+        // playing with longer list
+        FileFormats formats;
+        formats = new FileFormats("gpx,a,b,c,d,");
+        assertTrue(formats.contains(FileFormats.GPX));
+        assertTrue(formats.add(FileFormats.TCX));
+        assertTrue(formats.remove(FileFormats.GPX));
+        assertFalse(formats.contains(FileFormats.GPX));
+        assertTrue(formats.contains(FileFormats.TCX));
+        assertTrue(formats.add(FileFormats.GPX));
+        assertTrue(formats.contains(FileFormats.GPX));
+        assertTrue(formats.remove(FileFormats.TCX));
+        assertFalse(formats.contains(FileFormats.TCX));
+        assertTrue(formats.remove(FileFormats.GPX));
+        assertFalse(formats.contains(FileFormats.GPX));
+        assertEquals(formats.toString(), ("a,b,c,d"));
+    }
+}

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -350,4 +350,6 @@
   <string name="path_simplification_algorithm">Algorithme</string>
   <string name="path_simplification_algorithm_info">Choisissez entre rapidité et haute qualité de la simplification de la trace</string>
   <string name="path_simplification_menu">Simplifier la trace</string>
+  <string name="File_format">Fichier(s) au format:</string>
+  <string name="File_need_one_format">Sélectionnez au moins un format !</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -351,4 +351,6 @@
   <string name="path_simplification_algorithm">Algorithm</string>
   <string name="path_simplification_algorithm_info">Choose fast or high quality path simplification</string>
   <string name="path_simplification_menu">Simplify path</string>
+  <string name="File_format">Upload file(s) as:</string>
+  <string name="File_need_one_format">At least one format needed!</string>
 </resources>


### PR DESCRIPTION
Second try to address #874
This PR adds a configuration to File and Dropbox synchronizers to export in GPX or TCX formats :
![Screenshot_1579541737](https://user-images.githubusercontent.com/1472722/72747432-ec219f80-3bb4-11ea-951a-9a261093fd07.png)
![Screenshot_1579541752](https://user-images.githubusercontent.com/1472722/72747441-efb52680-3bb4-11ea-8af8-36de11277513.png)
Other synchronizers don't show these options:
![Screenshot_1579541936](https://user-images.githubusercontent.com/1472722/72747461-fba0e880-3bb4-11ea-8475-a18781b4dd15.png)

Today this option is only possible for File, and only when activating the File synchronizer. This PR makes it configurable at any time, by opening the synchronizer screen.

Duplicated FORMAT field present in File's AUTH_CONFIG is removed and DB from previous version is migrated. 
