### PR TITLE
Apply path simplification on each "segment" of the path individually

### DIFF
--- a/app/src/main/org/runnerup/content/ActivityProvider.java
+++ b/app/src/main/org/runnerup/content/ActivityProvider.java
@@ -161,7 +161,7 @@ public class ActivityProvider extends ContentProvider {
                         //The data must exist if log, use the log option as a possibility to "deactivate" too
                         boolean extraData = prefs.getBoolean(this.getContext().getString(org.runnerup.R.string.pref_log_gpx_accuracy), false);
                         PathSimplifier simplifier = PathSimplifier.isEnabledForExportGpx(getContext()) ?
-                                new PathSimplifier(getContext(), true) :
+                                new PathSimplifier(getContext()) :
                                 null;
                         GPX gpx = new GPX(mDB, true, extraData, simplifier);
                         gpx.export(activityId, new OutputStreamWriter(out.second));

--- a/app/src/main/org/runnerup/export/DropboxSynchronizer.java
+++ b/app/src/main/org/runnerup/export/DropboxSynchronizer.java
@@ -68,7 +68,7 @@ public class DropboxSynchronizer extends DefaultSynchronizer implements OAuth2Se
             Log.w(NAME, "No client id configured in this build");
         }
         this.simplifier = PathSimplifier.isEnabledForExportGpx(context) ?
-                new PathSimplifier(context, true) :
+                new PathSimplifier(context) :
                 null;
     }
 

--- a/app/src/main/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/main/org/runnerup/export/FileSynchronizer.java
@@ -59,7 +59,7 @@ public class FileSynchronizer extends DefaultSynchronizer {
     FileSynchronizer(Context context) {
         this();
         this.simplifier = PathSimplifier.isEnabledForExportGpx(context) ?
-                new PathSimplifier(context, true) :
+                new PathSimplifier(context) :
                 null;
     }
 


### PR DESCRIPTION
Instead of simplifying globally on the whole path. This ensures original segments are not discarded/lost nor merged.
Simplification is only applied for segments of size > 2.
A segment is a set of locations terminated by a TYPE_PAUSE or TYPE_END location.

This class would deserve a cleanup to remove unused code/variables, but it is not done here to facilitate review.

On the left, path before simplification, on the right after simplification:
![image](https://user-images.githubusercontent.com/1472722/73874150-3fe9e500-4853-11ea-8b28-f5dca9e4a8bf.png)
For the recall before this patch the simplification resulted in:
![image](https://user-images.githubusercontent.com/1472722/73885393-f952b580-4867-11ea-8ed5-13cd1f7d629f.png)
