### PR TITLE
Move simplify on save BEFORE exports

### DIFF
--- a/app/res/values/pref_keys.xml
+++ b/app/res/values/pref_keys.xml
@@ -106,8 +106,8 @@
     <string name="pref_pace_graph_smoothing">pref_pace_graph_smoothing</string>
     <string name="pref_pace_graph_smoothing_filters">pref_pace_graph_smoothing_filters</string>
 
-    <string name="pref_path_simplification_save">pref_path_simplification_save</string>
-    <string name="pref_path_simplification_export_gpx">pref_path_simplification_export_gpx</string>
+    <string name="pref_path_simplification_on_save">pref_path_simplification_on_save</string>
+    <string name="pref_path_simplification_on_export">pref_path_simplification_on_export</string>
     <string name="pref_path_simplification_tolerance">pref_path_simplification_tolerance</string>
     <string name="pref_path_simplification_algorithm">pref_path_simplification_algorithm</string>
 

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -169,18 +169,18 @@
                 android:summary="@string/path_simplification_info" />
 
             <CheckBoxPreference
-                android:key="@string/pref_path_simplification_save"
                 android:defaultValue="false"
+                android:key="@string/pref_path_simplification_on_save"
                 android:persistent="true"
-                android:title="@string/path_simplification_save"
-                android:summary="@string/path_simplification_save_info" />
+                android:title="@string/path_simplification_on_save"
+                android:disableDependentsState="true" />
 
             <CheckBoxPreference
-                android:key="@string/pref_path_simplification_export_gpx"
                 android:defaultValue="false"
+                android:key="@string/pref_path_simplification_on_export"
                 android:persistent="true"
-                android:title="@string/path_simplification_export_gpx"
-                android:summary="@string/path_simplification_export_gpx_info" />
+                android:title="@string/path_simplification_on_export"
+                android:dependency="@string/pref_path_simplification_on_save" />
 
             <org.runnerup.widget.TextPreference
                 android:key="@string/pref_path_simplification_tolerance"

--- a/app/src/main/org/runnerup/db/PathCursor.java
+++ b/app/src/main/org/runnerup/db/PathCursor.java
@@ -1,0 +1,86 @@
+package org.runnerup.db;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.runnerup.common.util.Constants;
+
+import java.util.ArrayList;
+
+public class PathCursor {
+
+    private Cursor cursor;
+    private ArrayList<Integer> ignoreIDs;
+    private int idxLocId;
+
+    public PathCursor(SQLiteDatabase mDB, long activityId, String[] columns, int idxLocId, PathSimplifier simplifier) {
+
+        if (simplifier != null) {
+            ignoreIDs = simplifier.getNoisyLocationIDs(mDB, activityId);
+            if (ignoreIDs.size() == 0) {
+                ignoreIDs = null;
+            }
+        }
+        this.idxLocId = idxLocId;
+
+        cursor = mDB.query(Constants.DB.LOCATION.TABLE, columns,
+                Constants.DB.LOCATION.ACTIVITY + " = " + activityId,
+                null, null, null,
+                null);
+    }
+
+    private boolean skipSimplified(boolean ok) {
+        if (ignoreIDs != null) {
+            while (ok && ignoreIDs.contains(cursor.getInt(idxLocId))) {
+                ok = cursor.moveToNext();
+            }
+        }
+        // useful?
+        if (!ok) {
+            cursor.close();
+        }
+        return ok;
+    }
+
+    /** Moves cursor to the first non-simplified location */
+    public boolean moveToFirst() {
+        return skipSimplified(cursor.moveToFirst());
+    }
+    /** Moves cursor to the next non-simplified location */
+    public boolean moveToNext() {
+        return skipSimplified(cursor.moveToNext());
+    }
+    /** Moves cursor to the non-simplified location after the 'skip' skipped locations  */
+    public boolean move(int skip) {
+        return skipSimplified(cursor.move(skip));
+    }
+
+    /** Simple wrapping of cursor methods */
+    public int getInt(int idx) {
+        return cursor.getInt(idx);
+    }
+    /** Simple wrapping of cursor methods */
+    public double getDouble(int idx) {
+        return cursor.getDouble(idx);
+    }
+    /** Simple wrapping of cursor methods */
+    public long getLong(int idx) {
+        return cursor.getLong(idx);
+    }
+    /** Simple wrapping of cursor methods */
+    public float getFloat(int idx) {
+        return cursor.getFloat(idx);
+    }
+    /** Simple wrapping of cursor methods */
+    public boolean isNull(int idx) {
+        return cursor.isNull(idx);
+    }
+
+    /** Simple wrapping of cursor methods */
+    public void close() {
+        if (!cursor.isClosed()) {
+            cursor.close();
+        }
+    }
+}

--- a/app/src/main/org/runnerup/export/DigifitSynchronizer.java
+++ b/app/src/main/org/runnerup/export/DigifitSynchronizer.java
@@ -34,6 +34,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.Part;
 import org.runnerup.export.util.StringWritable;
@@ -62,7 +63,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         String username = args[0];
         String password = args[1];
 
-        DigifitSynchronizer du = new DigifitSynchronizer();
+        DigifitSynchronizer du = new DigifitSynchronizer(null);
         du.init(username, password);
 
         Log.e("DigifitSynchronizer", du.connect().toString());
@@ -72,6 +73,11 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
     private boolean _loggedin;
     private String _password;
     private String _username;
+    private PathSimplifier simplifier;
+
+    public DigifitSynchronizer(PathSimplifier simplifier) {
+        this.simplifier = simplifier;
+    }
 
 // --Commented out by Inspection START (2017-08-11 13:14):
 //    private JSONObject buildRequest(String root, Map<String, String> requestParameters)
@@ -438,7 +444,7 @@ public class DigifitSynchronizer extends DefaultSynchronizer {
         }
 
         Status errorStatus = Status.ERROR;
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         tcx.setAddGratuitousTrack(true);
 
         try {

--- a/app/src/main/org/runnerup/export/DropboxSynchronizer.java
+++ b/app/src/main/org/runnerup/export/DropboxSynchronizer.java
@@ -63,13 +63,11 @@ public class DropboxSynchronizer extends DefaultSynchronizer implements OAuth2Se
     private FileFormats mFormat;
     private PathSimplifier simplifier = null;
 
-    DropboxSynchronizer(Context context) {
+    DropboxSynchronizer(Context context, PathSimplifier simplifier) {
         if (ENABLED == 0) {
             Log.w(NAME, "No client id configured in this build");
         }
-        this.simplifier = PathSimplifier.isEnabledForExportGpx(context) ?
-                new PathSimplifier(context) :
-                null;
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -314,14 +312,15 @@ public class DropboxSynchronizer extends DefaultSynchronizer implements OAuth2Se
                 }
             }
 
-            StringWriter writer = new StringWriter();
             if (mFormat.contains(FileFormats.TCX)) {
-                TCX tcx = new TCX(db);
+                TCX tcx = new TCX(db, simplifier);
+                StringWriter writer = new StringWriter();
                 tcx.export(mID, writer);
                 s = uploadFile(db, mID, sport, writer, FileFormats.TCX.getValue());
             }
             if (s == Status.OK && mFormat.contains(FileFormats.GPX)) {
                 GPX gpx = new GPX(db, true, true, simplifier);
+                StringWriter writer = new StringWriter();
                 gpx.export(mID, writer);
                 s = uploadFile(db, mID, sport, writer, FileFormats.GPX.getValue());
             }

--- a/app/src/main/org/runnerup/export/EndomondoSynchronizer.java
+++ b/app/src/main/org/runnerup/export/EndomondoSynchronizer.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.EndomondoTrack;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.SyncHelper;
@@ -73,6 +74,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
     private String password = null;
     private String deviceId = null;
     private String authToken = null;
+    private PathSimplifier simplifier;
 
     private static final SparseArray<Sport> endomondo2sportMap = new SparseArray<>();
     public static final Map<Sport, Integer> sport2endomondoMap = new HashMap<>();
@@ -87,6 +89,10 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
         for (Sport s : sport2endomondoMap.keySet()) {
             endomondo2sportMap.put(sport2endomondoMap.get(s), s);
         }
+    }
+
+    public EndomondoSynchronizer(PathSimplifier simplifier) {
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -251,7 +257,7 @@ public class EndomondoSynchronizer extends DefaultSynchronizer {
             return s;
         }
 
-        EndomondoTrack tcx = new EndomondoTrack(db);
+        EndomondoTrack tcx = new EndomondoTrack(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/FacebookSynchronizer.java
+++ b/app/src/main/org/runnerup/export/FacebookSynchronizer.java
@@ -29,6 +29,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.FacebookCourse;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -77,8 +78,9 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
 
     private final SimpleDateFormat dateFormat = new SimpleDateFormat(
             "yyyy-MM-dd HH:mm:ss.SSSZ", Locale.getDefault());
+    private PathSimplifier simplifier;
 
-    FacebookSynchronizer(Context context, SyncManager syncManager) {
+    FacebookSynchronizer(Context context, SyncManager syncManager, PathSimplifier simplifier) {
         this.context = context;
         if (CLIENT_ID == null || CLIENT_SECRET == null) {
             try {
@@ -89,6 +91,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -248,7 +251,7 @@ public class FacebookSynchronizer extends DefaultSynchronizer implements OAuth2S
             return s;
         }
 
-        FacebookCourse courseFactory = new FacebookCourse(context, db);
+        FacebookCourse courseFactory = new FacebookCourse(context, db, simplifier);
         try {
             JSONObject runObj = new JSONObject();
             JSONObject course = courseFactory.export(mID, !skipMapInPost, runObj);

--- a/app/src/main/org/runnerup/export/FileSynchronizer.java
+++ b/app/src/main/org/runnerup/export/FileSynchronizer.java
@@ -52,15 +52,13 @@ public class FileSynchronizer extends DefaultSynchronizer {
     private long id = 0;
     private String mPath;
     private FileFormats mFormat;
-    private PathSimplifier simplifier = null;
+    private PathSimplifier simplifier;
 
     FileSynchronizer() {}
 
-    FileSynchronizer(Context context) {
+    FileSynchronizer(Context context, PathSimplifier simplifier) {
         this();
-        this.simplifier = PathSimplifier.isEnabledForExportGpx(context) ?
-                new PathSimplifier(context) :
-                null;
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -176,7 +174,7 @@ public class FileSynchronizer extends DefaultSynchronizer {
                     String.format(Locale.getDefault(), "RunnerUp_%04d_%s.", mID, sport.TapiriikType());
             
             if (mFormat.contains(FileFormats.TCX)) {
-                TCX tcx = new TCX(db);
+                TCX tcx = new TCX(db, simplifier);
                 File file = new File(fileBase + FileFormats.TCX.getValue());
                 OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
                 tcx.export(mID, new OutputStreamWriter(out));

--- a/app/src/main/org/runnerup/export/FunBeatSynchronizer.java
+++ b/app/src/main/org/runnerup/export/FunBeatSynchronizer.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.Part;
@@ -75,6 +76,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
     private String password = null;
     private String loginID = null;
     private String loginSecretHashed = null;
+    private PathSimplifier simplifier;
 
     private static final SparseArray<Sport> funbeat2sportMap = new SparseArray<>();
     //private static final Map<Sport, Integer> sport2funbeatMap = new HashMap<>();
@@ -93,7 +95,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
         //}
     }
 
-    FunBeatSynchronizer(SyncManager syncManager) {
+    FunBeatSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (APP_ID == null || APP_SECRET == null) {
             try {
                 final JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -103,6 +105,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -340,7 +343,7 @@ public class FunBeatSynchronizer extends DefaultSynchronizer {
             return s;
         }
 
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/GarminSynchronizer.java
+++ b/app/src/main/org/runnerup/export/GarminSynchronizer.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.Part;
@@ -81,6 +82,11 @@ public class GarminSynchronizer extends DefaultSynchronizer {
     private String username = null;
     private String password = null;
     private boolean isConnected = false;
+    private PathSimplifier simplifier;
+
+    public GarminSynchronizer(PathSimplifier simplifier) {
+        this.simplifier = simplifier;
+    }
 
     @Override
     public long getId() {
@@ -422,7 +428,7 @@ public class GarminSynchronizer extends DefaultSynchronizer {
             return s;
         }
 
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/JoggSESynchronizer.java
+++ b/app/src/main/org/runnerup/export/JoggSESynchronizer.java
@@ -26,6 +26,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.GPX;
 import org.runnerup.util.KXmlSerializer;
 import org.w3c.dom.DOMException;
@@ -67,8 +68,10 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
     private String username = null;
     private String password = null;
     private boolean isConnected = false;
+    private PathSimplifier simplifier;
 
-    JoggSESynchronizer(final SyncManager syncManager) {
+
+    JoggSESynchronizer(final SyncManager syncManager, PathSimplifier simplifier) {
         if (MASTER_USER == null || MASTER_KEY == null) {
             try {
                 final JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -78,6 +81,7 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -274,7 +278,7 @@ public class JoggSESynchronizer extends DefaultSynchronizer {
 
         Exception ex;
         HttpURLConnection conn = null;
-        final GPX gpx = new GPX(db);
+        final GPX gpx = new GPX(db, simplifier);
         try {
             final StringWriter gpxString = new StringWriter();
             gpx.export(mID, gpxString);

--- a/app/src/main/org/runnerup/export/MapMyRunSynchronizer.java
+++ b/app/src/main/org/runnerup/export/MapMyRunSynchronizer.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.SyncHelper;
@@ -61,6 +62,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
     private String md5pass = null;
     private String user_id = null;
     private String user_key = null;
+    private PathSimplifier simplifier;
 
     private static final SparseArray<Sport> mapmyrun2sportMap = new SparseArray<>();
     private static final Map<Sport, Integer> sport2mapmyrunMap = new HashMap<>();
@@ -75,7 +77,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
         }
     }
 
-    MapMyRunSynchronizer(SyncManager syncManager) {
+    MapMyRunSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (CONSUMER_KEY == null) {
             try {
                 JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -84,6 +86,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -241,7 +244,7 @@ public class MapMyRunSynchronizer extends DefaultSynchronizer {
             return s;
         }
 
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/NikePlusSynchronizer.java
+++ b/app/src/main/org/runnerup/export/NikePlusSynchronizer.java
@@ -27,6 +27,7 @@ import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.common.util.Constants.DB.FEED;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.GPX;
 import org.runnerup.export.format.NikeXML;
 import org.runnerup.export.util.FormValues;
@@ -80,8 +81,9 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
     private String password = null;
     private String access_token = null;
     private long expires_timeout = 0;
+    private PathSimplifier simplifier;
 
-    NikePlusSynchronizer(SyncManager syncManager) {
+    NikePlusSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (CLIENT_ID == null || CLIENT_SECRET == null || APP_ID == null) {
             try {
                 JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -92,6 +94,7 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -235,8 +238,8 @@ public class NikePlusSynchronizer extends DefaultSynchronizer {
             return s;
         }
 
-        NikeXML nikeXML = new NikeXML(db);
-        GPX nikeGPX = new GPX(db);
+        NikeXML nikeXML = new NikeXML(db, simplifier);
+        GPX nikeGPX = new GPX(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/RunKeeperSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunKeeperSynchronizer.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.db.entities.ActivityEntity;
 import org.runnerup.export.format.RunKeeper;
 import org.runnerup.export.oauth2client.OAuth2Activity;
@@ -85,6 +86,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
     private String access_token = null;
     private String fitnessActivitiesUrl = null;
     private String userName = null;
+    private PathSimplifier simplifier;
 
     public static final Map<String, Sport> runkeeper2sportMap = new HashMap<>();
     public static final Map<Sport, String> sport2runkeeperMap = new HashMap<>();
@@ -119,7 +121,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
         POINT_TYPE.put("manual", DB.LOCATION.TYPE_GPS);
     }
 
-    RunKeeperSynchronizer(SyncManager syncManager) {
+    RunKeeperSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (CLIENT_ID == null || CLIENT_SECRET == null) {
             try {
                 JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -130,6 +132,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
             }
         }
         context = syncManager.getContext();
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -402,7 +405,7 @@ public class RunKeeperSynchronizer extends DefaultSynchronizer implements Synchr
             conn.addRequestProperty("Authorization", "Bearer " + access_token);
             conn.addRequestProperty("Content-type",
                     "application/vnd.com.runkeeper.NewFitnessActivity+json");
-            RunKeeper rk = new RunKeeper(db);
+            RunKeeper rk = new RunKeeper(db, simplifier);
             BufferedWriter w = new BufferedWriter(new OutputStreamWriter(
                     conn.getOutputStream()));
             rk.export(mID, w);

--- a/app/src/main/org/runnerup/export/RunalyzeSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunalyzeSynchronizer.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 import org.runnerup.BuildConfig;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -64,11 +65,13 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer implements OAuth2S
     private String access_token = null;
     private String refresh_token = null;
     private long access_expire = -1;
+    private PathSimplifier simplifier;
 
-    RunalyzeSynchronizer() {
+    RunalyzeSynchronizer(PathSimplifier simplifier) {
         if (ENABLED == 0) {
             Log.w(NAME, "No client id configured in this build");
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -298,7 +301,7 @@ public class RunalyzeSynchronizer extends DefaultSynchronizer implements OAuth2S
         }
 
         String desc = getDesc(db, mID);
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         try {
             StringWriter writer = new StringWriter();
             tcx.export(mID, writer);

--- a/app/src/main/org/runnerup/export/RunningAHEADSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunningAHEADSynchronizer.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -63,8 +64,9 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
 
     private long id = 0;
     private String access_token = null;
+    private PathSimplifier simplifier;
 
-    RunningAHEADSynchronizer(SyncManager syncManager) {
+    RunningAHEADSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (CLIENT_ID == null || CLIENT_SECRET == null) {
             try {
                 JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -74,6 +76,7 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -203,7 +206,7 @@ public class RunningAHEADSynchronizer extends DefaultSynchronizer implements OAu
         }
 
         String URL = IMPORT_URL + "?access_token=" + access_token;
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
         HttpURLConnection conn;
         Exception ex;
         try {

--- a/app/src/main/org/runnerup/export/RunningFreeOnlineSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunningFreeOnlineSynchronizer.java
@@ -9,6 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.util.KXmlSerializer;
 import org.w3c.dom.Document;
@@ -51,6 +52,11 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
     private String username = null;
     private String secretKey  = null;
     private boolean isConnected = false;
+    private PathSimplifier simplifier;
+
+    public RunningFreeOnlineSynchronizer(PathSimplifier simplifier) {
+        this.simplifier = simplifier;
+    }
 
     public String getName() {
         return NAME;
@@ -204,7 +210,7 @@ public class RunningFreeOnlineSynchronizer extends DefaultSynchronizer {
         Exception exception = null;
         HttpURLConnection conn = null;
         try {
-            TCX tcx = new TCX(db);
+            TCX tcx = new TCX(db, simplifier);
             StringWriter writer = new StringWriter();
             tcx.exportWithSport(mID, writer);
             byte[] gzippedTcx = gzip(writer.toString());

--- a/app/src/main/org/runnerup/export/RuntasticSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RuntasticSynchronizer.java
@@ -28,6 +28,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.SyncHelper;
@@ -66,6 +67,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
 
     private Integer userId = null;
     private String authToken = null;
+    private PathSimplifier simplifier;
 
     private static final SparseArray<Sport> runtastic2sportMap = new SparseArray<>();
     private static final Map<Sport, Integer> sport2runtasticMap = new HashMap<>();
@@ -77,6 +79,9 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
         }
     }
 
+    public RuntasticSynchronizer(PathSimplifier simplifier) {
+        this.simplifier = simplifier;
+    }
 
     @Override
     public long getId() {
@@ -281,7 +286,7 @@ public class RuntasticSynchronizer extends DefaultSynchronizer {
         }
 
         StringWriter writer = new StringWriter();
-        TCX tcx = new TCX(db);
+        TCX tcx = new TCX(db, simplifier);
 
         HttpURLConnection conn = null;
         try {

--- a/app/src/main/org/runnerup/export/StravaSynchronizer.java
+++ b/app/src/main/org/runnerup/export/StravaSynchronizer.java
@@ -29,6 +29,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.format.TCX;
 import org.runnerup.export.oauth2client.OAuth2Activity;
 import org.runnerup.export.oauth2client.OAuth2Server;
@@ -73,8 +74,9 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
     private String access_token = null;
     private String refresh_token = null;
     private long access_expire = -1;
+    private PathSimplifier simplifier;
 
-    StravaSynchronizer(SyncManager syncManager) {
+    StravaSynchronizer(SyncManager syncManager, PathSimplifier simplifier) {
         if (CLIENT_ID == null || CLIENT_SECRET == null) {
             try {
                 JSONObject tmp = new JSONObject(syncManager.loadData(this));
@@ -84,6 +86,7 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
                 ex.printStackTrace();
             }
         }
+        this.simplifier = simplifier;
     }
 
     @Override
@@ -348,7 +351,7 @@ public class StravaSynchronizer extends DefaultSynchronizer implements OAuth2Ser
         }
 
         try {
-            TCX tcx = new TCX(db);
+            TCX tcx = new TCX(db, simplifier);
             StringWriter writer = new StringWriter();
             tcx.export(mID, writer);
             ActivityDbInfo dbInfo = getStravaType(db, mID);

--- a/app/src/main/org/runnerup/export/SyncManager.java
+++ b/app/src/main/org/runnerup/export/SyncManager.java
@@ -56,6 +56,7 @@ import org.runnerup.BuildConfig;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.db.DBHelper;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.Synchronizer.AuthMethod;
 import org.runnerup.export.Synchronizer.Status;
 import org.runnerup.feed.FeedList;
@@ -90,6 +91,7 @@ public class SyncManager {
     private Context mContext = null;
     private final Map<String, Synchronizer> synchronizers = new HashMap<>();
     private final LongSparseArray<Synchronizer> synchronizersById = new LongSparseArray<>();
+    PathSimplifier simplifier;
 
     private ProgressDialog mSpinner = null;
 
@@ -118,6 +120,7 @@ public class SyncManager {
         mDB = DBHelper.getWritableDatabase(context);
         mSpinner = spinner;
         mSpinner.setCancelable(false);
+        simplifier = PathSimplifier.getPathSimplifierForExport(context);
     }
     public SyncManager(Activity activity) {
         init(activity, activity, new ProgressDialog(activity));
@@ -178,45 +181,46 @@ public class SyncManager {
         if (synchronizers.containsKey(synchronizerName)) {
             return synchronizers.get(synchronizerName);
         }
+
         Synchronizer synchronizer = null;
         if (synchronizerName.contentEquals(RunKeeperSynchronizer.NAME)) {
-            synchronizer = new RunKeeperSynchronizer(this);
+            synchronizer = new RunKeeperSynchronizer(this,simplifier);
         } else if (synchronizerName.contentEquals(GarminSynchronizer.NAME)) {
-            synchronizer = new GarminSynchronizer();
+            synchronizer = new GarminSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(FunBeatSynchronizer.NAME)) {
-            synchronizer = new FunBeatSynchronizer(this);
+            synchronizer = new FunBeatSynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(MapMyRunSynchronizer.NAME)) {
-            synchronizer = new MapMyRunSynchronizer(this);
+            synchronizer = new MapMyRunSynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(NikePlusSynchronizer.NAME)) {
-            synchronizer = new NikePlusSynchronizer(this);
+            synchronizer = new NikePlusSynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(JoggSESynchronizer.NAME)) {
-            synchronizer = new JoggSESynchronizer(this);
+            synchronizer = new JoggSESynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(EndomondoSynchronizer.NAME)) {
-            synchronizer = new EndomondoSynchronizer();
+            synchronizer = new EndomondoSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(RunningAHEADSynchronizer.NAME)) {
-            synchronizer = new RunningAHEADSynchronizer(this);
+            synchronizer = new RunningAHEADSynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(RunnerUpLiveSynchronizer.NAME)) {
             synchronizer = new RunnerUpLiveSynchronizer(mContext);
         } else if (synchronizerName.contentEquals(DigifitSynchronizer.NAME)) {
-            synchronizer = new DigifitSynchronizer();
+            synchronizer = new DigifitSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(StravaSynchronizer.NAME)) {
-            synchronizer = new StravaSynchronizer(this);
+            synchronizer = new StravaSynchronizer(this, simplifier);
         } else if (synchronizerName.contentEquals(FacebookSynchronizer.NAME)) {
-            synchronizer = new FacebookSynchronizer(mContext, this);
+            synchronizer = new FacebookSynchronizer(mContext, this, simplifier);
         } else if (synchronizerName.contentEquals(GooglePlusSynchronizer.NAME)) {
             synchronizer = new GooglePlusSynchronizer(this);
         } else if (synchronizerName.contentEquals(RuntasticSynchronizer.NAME)) {
-            synchronizer = new RuntasticSynchronizer();
+            synchronizer = new RuntasticSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(GoogleFitSynchronizer.NAME)) {
             synchronizer = new GoogleFitSynchronizer(mContext, this);
         } else if (synchronizerName.contentEquals(RunningFreeOnlineSynchronizer.NAME)) {
-            synchronizer = new RunningFreeOnlineSynchronizer();
+            synchronizer = new RunningFreeOnlineSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(FileSynchronizer.NAME)) {
-            synchronizer = new FileSynchronizer(mContext);
+            synchronizer = new FileSynchronizer(mContext, simplifier);
         } else if (synchronizerName.contentEquals(RunalyzeSynchronizer.NAME)) {
-            synchronizer = new RunalyzeSynchronizer();
+            synchronizer = new RunalyzeSynchronizer(simplifier);
         } else if (synchronizerName.contentEquals(DropboxSynchronizer.NAME)) {
-            synchronizer = new DropboxSynchronizer(mContext);
+            synchronizer = new DropboxSynchronizer(mContext, simplifier);
         } else {
             Log.e(getClass().getName(), "synchronizer does not exist: " + synchronizerName);;
         }

--- a/app/src/main/org/runnerup/export/format/EndomondoTrack.java
+++ b/app/src/main/org/runnerup/export/format/EndomondoTrack.java
@@ -22,6 +22,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
 
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.export.EndomondoSynchronizer;
 import org.runnerup.workout.Sport;
 
@@ -41,12 +43,14 @@ public class EndomondoTrack {
 
     private SQLiteDatabase mDB = null;
     private SimpleDateFormat simpleDateFormat = null;
+    private PathSimplifier simplifier;
 
-    public EndomondoTrack(final SQLiteDatabase db) {
+    public EndomondoTrack(final SQLiteDatabase db, PathSimplifier simplifier) {
         mDB = db;
         simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss 'UTC'",
                 Locale.US);
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        this.simplifier = simplifier;
     }
 
     public static class Summary {
@@ -97,11 +101,11 @@ public class EndomondoTrack {
                 DB.LOCATION.HR, // 6
                 DB.LOCATION.DISTANCE, // 7
                 DB.LOCATION.SPEED, // 8
-                DB.LOCATION.CADENCE // 9
+                DB.LOCATION.CADENCE, // 9
+                DB.PRIMARY_KEY // 10
         };
 
-        final Cursor c = mDB.query(DB.LOCATION.TABLE, pColumns, DB.LOCATION.ACTIVITY
-                + " = " + activityId, null, null, null, null);
+        PathCursor c = new PathCursor(mDB, activityId, pColumns, 10, simplifier);
 
         double distance = 0;
         Location lastLoc = null;

--- a/app/src/main/org/runnerup/export/format/FacebookCourse.java
+++ b/app/src/main/org/runnerup/export/format/FacebookCourse.java
@@ -26,6 +26,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.util.Formatter;
 
 import java.text.SimpleDateFormat;
@@ -43,10 +45,12 @@ public class FacebookCourse {
     private Formatter formatter = null;
     private final SimpleDateFormat dateFormat = new SimpleDateFormat(
             "yyyy-MM-dd HH:mm:ss.SSSZ", Locale.getDefault());
+    private PathSimplifier simplifier;
 
-    public FacebookCourse(Context ctx, SQLiteDatabase db) {
+    public FacebookCourse(Context ctx, SQLiteDatabase db, PathSimplifier simplifier) {
         mDB = db;
         formatter = new Formatter(ctx);
+        this.simplifier = simplifier;
     }
 
     private String formatTime(long time) {
@@ -123,10 +127,10 @@ public class FacebookCourse {
     private JSONArray trail(long activityId) throws JSONException {
         final String cols[] = {
                 DB.LOCATION.TYPE, DB.LOCATION.LATITUDE,
-                DB.LOCATION.LONGITUDE, DB.LOCATION.TIME, DB.LOCATION.SPEED
+                DB.LOCATION.LONGITUDE, DB.LOCATION.TIME, DB.LOCATION.SPEED,
+                DB.PRIMARY_KEY // 5
         };
-        Cursor c = mDB.query(DB.LOCATION.TABLE, cols, DB.LOCATION.ACTIVITY
-                + " = " + activityId, null, null, null, null);
+        PathCursor c = new PathCursor(mDB, activityId, cols, 5, simplifier);
         if (c.moveToFirst()) {
             Location prev = null, last = null;
             double sumDist = 0;

--- a/app/src/main/org/runnerup/export/format/GPX.java
+++ b/app/src/main/org/runnerup/export/format/GPX.java
@@ -21,6 +21,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
 import org.runnerup.db.PathSimplifier;
 import org.runnerup.util.KXmlSerializer;
 import org.runnerup.workout.Sport;
@@ -43,9 +44,10 @@ public class GPX {
     private final boolean mAccuracyExtensions;
     private PathSimplifier simplifier;
 
-    public GPX(SQLiteDatabase mDB) {
-        this(mDB, true, false, null);
+    public GPX(SQLiteDatabase mDB, PathSimplifier simplifier) {
+        this(mDB, true, false, simplifier);
     }
+
 
     public GPX(SQLiteDatabase mDB, boolean garminExt, boolean accuracyExtensions, PathSimplifier simplifier) {
         this.mDB = mDB;
@@ -55,10 +57,6 @@ public class GPX {
         this.mGarminExt = garminExt;
         this.mAccuracyExtensions = accuracyExtensions;
         this.simplifier = simplifier;
-    }
-
-    public GPX(SQLiteDatabase mDB, boolean garminExt, boolean accuracyExtensions) {
-        this(mDB, garminExt, accuracyExtensions, null);
     }
 
     private String formatTime(long time) {
@@ -165,9 +163,7 @@ public class GPX {
                 DB.LOCATION.SATELLITES, DB.LOCATION.GPS_ALTITUDE,
                 DB.PRIMARY_KEY
         };
-        Cursor cLocation = mDB.query(DB.LOCATION.TABLE, pColumns,
-                DB.LOCATION.ACTIVITY + " = " + activityId, null, null, null,
-                null);
+        PathCursor cLocation = new PathCursor(mDB, activityId, pColumns, 15, simplifier);
         boolean lok = cLap.moveToFirst();
         boolean pok = cLocation.moveToFirst();
 

--- a/app/src/main/org/runnerup/export/format/NikeXML.java
+++ b/app/src/main/org/runnerup/export/format/NikeXML.java
@@ -22,6 +22,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
 
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.util.Formatter;
 import org.runnerup.util.KXmlSerializer;
 
@@ -44,9 +46,11 @@ public class NikeXML {
     private SQLiteDatabase mDB = null;
     private KXmlSerializer mXML = null;
     private SimpleDateFormat simpleDateFormat = null;
+    private PathSimplifier simplifier;
 
-    public NikeXML(final SQLiteDatabase db) {
+    public NikeXML(final SQLiteDatabase db, PathSimplifier simplifier) {
         mDB = db;
+        this.simplifier = simplifier;
         simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ",
                 Locale.US);
     }
@@ -446,11 +450,11 @@ public class NikeXML {
                 DB.LOCATION.LONGITUDE,// 3
                 DB.LOCATION.ALTITUDE, // 4
                 DB.LOCATION.TYPE, // 5
-                DB.LOCATION.HR
+                DB.LOCATION.HR, // 6
+                DB.PRIMARY_KEY // 7
         }; // 6
 
-        final Cursor c = mDB.query(DB.LOCATION.TABLE, pColumns, DB.LOCATION.ACTIVITY
-                + " = " + activityId, null, null, null, null);
+        PathCursor c = new PathCursor(mDB, activityId, pColumns, 7, simplifier);
 
         try {
             final Pos p = new Pos();

--- a/app/src/main/org/runnerup/export/format/RunKeeper.java
+++ b/app/src/main/org/runnerup/export/format/RunKeeper.java
@@ -26,6 +26,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.runnerup.common.util.Constants;
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.db.entities.ActivityEntity;
 import org.runnerup.db.entities.LapEntity;
 import org.runnerup.db.entities.LocationEntity;
@@ -58,9 +60,11 @@ import java.util.concurrent.TimeUnit;
 public class RunKeeper {
 
     private SQLiteDatabase mDB = null;
+    private PathSimplifier simplifier;
 
-    public RunKeeper(SQLiteDatabase db) {
+    public RunKeeper(SQLiteDatabase db, PathSimplifier simplifier) {
         mDB = db;
+        this.simplifier = simplifier;
     }
 
     private static String formatTime(long time) {
@@ -134,11 +138,10 @@ public class RunKeeper {
             throws IOException {
         String[] pColumns = {
                 DB.LOCATION.TIME, DB.LOCATION.LATITUDE,
-                DB.LOCATION.LONGITUDE, DB.LOCATION.ALTITUDE, DB.LOCATION.TYPE
+                DB.LOCATION.LONGITUDE, DB.LOCATION.ALTITUDE, DB.LOCATION.TYPE,
+                DB.PRIMARY_KEY
         };
-        Cursor cursor = mDB.query(DB.LOCATION.TABLE, pColumns,
-                DB.LOCATION.ACTIVITY + " = " + activityId, null, null, null,
-                null);
+        PathCursor cursor = new PathCursor(mDB, activityId, pColumns, 5, simplifier);
         if (cursor.moveToFirst()) {
             w.name(name);
             w.beginArray();

--- a/app/src/main/org/runnerup/export/format/TCX.java
+++ b/app/src/main/org/runnerup/export/format/TCX.java
@@ -23,6 +23,8 @@ import android.location.Location;
 import android.util.Pair;
 
 import org.runnerup.common.util.Constants.DB;
+import org.runnerup.db.PathCursor;
+import org.runnerup.db.PathSimplifier;
 import org.runnerup.util.KXmlSerializer;
 import org.runnerup.workout.Sport;
 
@@ -50,11 +52,13 @@ public class TCX {
     private String notes = null;
     private SimpleDateFormat simpleDateFormat = null;
     private Sport sport = null;
+    private PathSimplifier simplifier;
 
     private boolean addGratuitousTrack = false;
 
-    public TCX(SQLiteDatabase mDB) {
+    public TCX(SQLiteDatabase mDB, PathSimplifier simplifier) {
         this.mDB = mDB;
+        this.simplifier = simplifier;
         simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
@@ -165,11 +169,9 @@ public class TCX {
                 DB.LOCATION.LAP, DB.LOCATION.TYPE,
                 DB.LOCATION.TIME, DB.LOCATION.DISTANCE,
                 DB.LOCATION.LATITUDE, DB.LOCATION.LONGITUDE, DB.LOCATION.ALTITUDE,
-                DB.LOCATION.HR, DB.LOCATION.CADENCE //, DB.LOCATION.TEMPERATURE, DB.LOCATION.PRESSURE
+                DB.LOCATION.HR, DB.LOCATION.CADENCE, DB.PRIMARY_KEY //, DB.LOCATION.TEMPERATURE, DB.LOCATION.PRESSURE
         };
-        Cursor cLocation = mDB.query(DB.LOCATION.TABLE, pColumns,
-                DB.LOCATION.ACTIVITY + " = " + activityId, null, null, null,
-                null);
+        PathCursor cLocation = new PathCursor(mDB, activityId, pColumns, 9, simplifier);
         boolean lok = cLap.moveToFirst();
         boolean pok = cLocation.moveToFirst();
 

--- a/app/src/main/org/runnerup/tracker/Tracker.java
+++ b/app/src/main/org/runnerup/tracker/Tracker.java
@@ -564,18 +564,6 @@ public class Tracker extends android.app.Service implements
         if (save) {
             saveActivity();
             liveLog(DB.LOCATION.TYPE_END);
-
-            // path simplification (reduce resolution of location entries in database)
-            try {
-                if (PathSimplifier.isEnabledForSave(this)) {
-                    PathSimplifier simplifier = new PathSimplifier(this);
-                    ArrayList<String> ids = simplifier.getNoisyLocationIDsAsStrings(mDB, mActivityId);
-                    ActivityCleaner.deleteLocations(mDB, ids);
-                    (new ActivityCleaner()).recompute(mDB, mActivityId);
-                }
-            } catch (Exception e) {
-                Log.e(getClass().getName(), "Failed to simplify path: " + e.getMessage());
-            }
         } else {
             ContentValues tmp = new ContentValues();
             tmp.put("deleted", 1);

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -32,6 +32,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -732,6 +733,18 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                 Long.toString(mID)
         };
         mDB.update(DB.ACTIVITY.TABLE, tmp, "_id = ?", whereArgs);
+
+        // path simplification (reduce resolution of location entries in database)
+        try {
+            PathSimplifier simplifier = PathSimplifier.getPathSimplifierForSave(this);
+            if (simplifier != null) {
+                ArrayList<String> ids = simplifier.getNoisyLocationIDsAsStrings(mDB, mID);
+                ActivityCleaner.deleteLocations(mDB, ids);
+                (new ActivityCleaner()).recompute(mDB, mID);
+            }
+        } catch (Exception e) {
+            Log.e(getClass().getName(), "Failed to simplify path: " + e.getMessage());
+        }
     }
 
     private final OnLongClickListener clearUploadClick = new OnLongClickListener() {

--- a/app/src/main/org/runnerup/view/SettingsActivity.java
+++ b/app/src/main/org/runnerup/view/SettingsActivity.java
@@ -29,6 +29,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
@@ -98,6 +99,19 @@ public class SettingsActivity extends PreferenceActivity
             Preference pref = findPreference(this.getString(R.string.pref_use_pressure_sensor));
             pref.setEnabled(false);
         }
+        CheckBoxPreference simplifyOnSave = (CheckBoxPreference) findPreference("pref_path_simplification_on_save");
+        CheckBoxPreference simplifyOnExport = (CheckBoxPreference) findPreference("pref_path_simplification_on_export");
+        if (simplifyOnSave.isChecked()) {
+            simplifyOnExport.setChecked(true);
+        }
+        simplifyOnSave.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue){
+                if ((Boolean) newValue) {
+                    simplifyOnExport.setChecked(true);
+                };
+                return true;
+            }
+        });
     }
 
     public static boolean hasHR(Context ctx) {

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -342,10 +342,6 @@
   <string name="Speed_unit_preference">Unité de vitesse</string>
   <string name="path_simplification">Simplification des traces GPS</string>
   <string name="path_simplification_info">Réduit la résolution des traces GPS (enregistrement des positions au fil du temps). Lisse la trace et réduit le poids d\'une activité dans la base de données ou dans un fichier exporté.</string>
-  <string name="path_simplification_save">Simplifier lors de l\'enregistrement de l\'activité</string>
-  <string name="path_simplification_save_info">Simplifie la trace GPS lors de son enregistrement en base de données</string>
-  <string name="path_simplification_export_gpx">Simplifier lors de l\'export GPX</string>
-  <string name="path_simplification_export_gpx_info">Simplifie la trace GPS lors de l\'export en fichier GPX</string>
   <string name="path_simplification_tolerance">Tolérance en mètres</string>
   <string name="path_simplification_algorithm">Algorithme</string>
   <string name="path_simplification_algorithm_info">Choisissez entre rapidité et haute qualité de la simplification de la trace</string>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -342,11 +342,7 @@
   <string name="Speed_unit_preference">スピード単位</string>
   <string name="path_simplification">経路の単純化</string>
   <string name="path_simplification_info">GPS経路の解像度を下げます (時間の経過とともに記録された場所)。 経路を滑らかにして、データベースやエクスポートされたファイル内のアクティビティのサイズを小さくします。</string>
-  <string name="path_simplification_save">アクティビティの保存時に単純化</string>
-  <string name="path_simplification_save_info">保存時にデータベース内のGPS経路を単純化します</string>
-  <string name="path_simplification_export_gpx">GPXのエクスポート時に単純化</string>
-  <string name="path_simplification_export_gpx_info">GPXへのエクスポート時にGPS経路を単純化します</string>
-  <string name="path_simplification_tolerance">公差（m）</string>
+    <string name="path_simplification_tolerance">公差（m）</string>
   <string name="path_simplification_algorithm">アルゴリズム</string>
   <string name="path_simplification_algorithm_info">高速または高品質の経路簡素化を選択</string>
   <string name="path_simplification_menu">経路を単純化する</string>

--- a/common/src/main/res/values-sv/array.xml
+++ b/common/src/main/res/values-sv/array.xml
@@ -43,5 +43,4 @@
     <item>Kvinna</item>
   </string-array>
   <!--Note: keep in same order as DB-->
-  <string-array name="path_simplification_algorithm_titles"/>
 </resources>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -342,11 +342,7 @@
   <string name="Speed_unit_preference">Hastighetsenhet</string>
   <string name="path_simplification">GPS-spår förenkling</string>
   <string name="path_simplification_info">Reducera upplösning för GPS-spår (antalet punkter). Jämnar ut GPS-spår och minskar storleken för aktiviteten i databasen eller i export.</string>
-  <string name="path_simplification_save">Förenkla då aktivitet sparas</string>
-  <string name="path_simplification_save_info">Förenkla GPS-spår i databas då aktivitet sparas</string>
-  <string name="path_simplification_export_gpx">Förenkla vid GPX export</string>
-  <string name="path_simplification_export_gpx_info">Förenkla GPS-spår vid GPX export</string>
-  <string name="path_simplification_tolerance">Tolerans (m)</string>
+    <string name="path_simplification_tolerance">Tolerans (m)</string>
   <string name="path_simplification_algorithm">Algoritm</string>
   <string name="path_simplification_algorithm_info">Välj snabb eller hög kvalitet GPS-spår förenkling</string>
   <string name="path_simplification_menu">Förenkla GPS-spår</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -343,10 +343,8 @@
   <string name="Speed_unit_preference">Speed unit</string>
   <string name="path_simplification">Path simplification</string>
   <string name="path_simplification_info">Reduce the resolution of the GPS path (logged locations over time). Smooths the path and decreases the size of an activity in the database or an exported file.</string>
-  <string name="path_simplification_save">Simplify at activity save</string>
-  <string name="path_simplification_save_info">Simplify GPS path in the database when saving</string>
-  <string name="path_simplification_export_gpx">Simplify at GPX export</string>
-  <string name="path_simplification_export_gpx_info">Simplify GPS path when exporting to GPX</string>
+  <string name="path_simplification_on_save">Simplify when saving activity</string>
+  <string name="path_simplification_on_export">Simplify when uploading to accounts</string>
   <string name="path_simplification_tolerance">Tolerance (m)</string>
   <string name="path_simplification_algorithm">Algorithm</string>
   <string name="path_simplification_algorithm_info">Choose fast or high quality path simplification</string>


### PR DESCRIPTION
Today if "simplify at activity save" is checked it is only applied after exports. So only GPX exports are simplified if "simplify on GPX export" is selected. And users do not know which exports use GPX or TCX (apart from file ones). 
This PR applies the simplification before exports, so that all exports (GPX, TCX, etc.) benefit from the simplification if "simplify at activity save" is selected. 
Then I don't think it makes sense to have a second checkbox to "simplify at GPX export", as the activity may already be simplified.
It could be 2 alternative options: either simplify at DB saving, or simplify only at export (and then would need to be added to TCX in addition to GPX). Could be represented as a radio button, instead of check boxes which allow to activate both. However I don't see why you would simplify at export and not in DB... Furthermore if preference is changed after saving, and export is triggered again it may end up in 2 simplification passes, which may oversimplify. 
I would therefore suggest to remove the "simplify on export" option, and only leave the "simplify on save". It would make things simpler to understand for users, and avoid duplicate simplifications.
Unless I missed a good reason to only simplify on export, or only in DB?
@dratasich, can you please help to understand the motivation of the initial design?