### PR TITLE
Few fixes/enhancements on path simplification preferences:

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -17,4 +17,5 @@
   <string name="mm31kz513sg5" translatable="false">mm(31);kz(5,13);sg(5)</string>
   <string name="_sign_plus" translatable="false">+</string>
   <string name="_sign_minus" translatable="false">-</string>
+  <string name="path_simplification_default_tolerance" translatable="false">3</string>
 </resources>

--- a/app/src/main/org/runnerup/db/PathSimplifier.java
+++ b/app/src/main/org/runnerup/db/PathSimplifier.java
@@ -79,13 +79,13 @@ public class PathSimplifier {
 
         // get user settings
 
-        // tolerance in meters (default to 3)
+        // tolerance in meters (default to R.string.path_simplification_default_tolerance)
         double tolerance;
         try {
             tolerance = Double.parseDouble(prefs.getString(
-                    res.getString(R.string.pref_path_simplification_tolerance), "3"));
+                    res.getString(R.string.pref_path_simplification_tolerance), res.getString(R.string.path_simplification_default_tolerance)));
         } catch (Exception ex) {
-            tolerance = 3;
+            tolerance = Double.parseDouble(res.getString(R.string.path_simplification_default_tolerance));
         }
         // squared tolerance in meters has to be transformed to tolerance in degrees
         this.toleranceDeg = tolerance / ONE_DEGREE;

--- a/app/src/main/org/runnerup/view/SettingsActivity.java
+++ b/app/src/main/org/runnerup/view/SettingsActivity.java
@@ -40,15 +40,11 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 
-import org.runnerup.BuildConfig;
 import org.runnerup.R;
 import org.runnerup.db.DBHelper;
 import org.runnerup.tracker.component.TrackerCadence;
 import org.runnerup.tracker.component.TrackerPressure;
 import org.runnerup.tracker.component.TrackerTemperature;
-import org.runnerup.util.FileUtil;
-
-import java.io.IOException;
 
 
 public class SettingsActivity extends PreferenceActivity
@@ -99,8 +95,8 @@ public class SettingsActivity extends PreferenceActivity
             Preference pref = findPreference(this.getString(R.string.pref_use_pressure_sensor));
             pref.setEnabled(false);
         }
-        CheckBoxPreference simplifyOnSave = (CheckBoxPreference) findPreference("pref_path_simplification_on_save");
-        CheckBoxPreference simplifyOnExport = (CheckBoxPreference) findPreference("pref_path_simplification_on_export");
+        CheckBoxPreference simplifyOnSave = (CheckBoxPreference) findPreference(getString(R.string.pref_path_simplification_on_save));
+        CheckBoxPreference simplifyOnExport = (CheckBoxPreference) findPreference(getString(R.string.pref_path_simplification_on_export));
         if (simplifyOnSave.isChecked()) {
             simplifyOnExport.setChecked(true);
         }

--- a/app/src/main/org/runnerup/widget/TextPreference.java
+++ b/app/src/main/org/runnerup/widget/TextPreference.java
@@ -65,6 +65,9 @@ public class TextPreference extends android.preference.EditTextPreference {
                 if (this.getKey().equals(res.getString(R.string.pref_mapbox_default_style))) {
                     val = res.getString(R.string.mapboxDefaultStyle);
                     super.setText(val);
+                } else if (this.getKey().equals(res.getString(R.string.pref_path_simplification_tolerance))) {
+                    val = res.getString(R.string.path_simplification_default_tolerance);
+                    super.setText(val);
                 }
             }
             super.setSummary(val);


### PR DESCRIPTION
- use string resource constants instead literals for preferences
- set default tolerance in a shared string resource, instead of duplicated hardcoded values
- reset this default when preference input is empty