### PR TITLE
Fix RunnerUpLive on Android Oreo

### DIFF
--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -161,6 +161,13 @@
             android:title="@string/log_extended_gps_title"
             android:summary="@string/log_extended_gps_summary" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_runneruplive_active"
+            android:persistent="true"
+            android:title="@string/Enable_RunnerUpLive"
+            android:summary="@string/Note_you_need_to_connect_to_the_account_too"/>
+
         <PreferenceCategory
             android:key="@string/path_simplification"
             android:title="@string/path_simplification">
@@ -376,13 +383,6 @@
                 android:title="@string/Smooth_pace_filters" />
         </PreferenceCategory>
     </PreferenceScreen>
-
-    <!--CheckBoxPreference
-        android:defaultValue="false"
-        android:key="@string/pref_runneruplive_active"
-        android:persistent="true"
-        android:title="@string/Enable_RunnerUpLive"
-        android:summary="@string/Note_you_need_to_connect_to_the_account_too" /-->
 
     <PreferenceScreen
         android:key="advanced_preferencescreen"

--- a/app/src/main/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -194,7 +194,7 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
                 .putExtra(LiveService.PARAM_IN_USERNAME, username)
                 .putExtra(LiveService.PARAM_IN_PASSWORD, password)
                 .putExtra(LiveService.PARAM_IN_SERVERADRESS, postUrl);
-        if (Build.VERSION.SDK_INT >= 26) {
+        if (Build.VERSION.SDK_INT >= 28) {
             context.startForegroundService(msgIntent);
         } else {
             context.startService(msgIntent);


### PR DESCRIPTION
RunnerUpLive did not work on my Android Oreo (8.1, API level 27):

-  it was not possible to activate live logging, because the config item pref_runneruplive_active was commented out. I re-activated it and moved it to a suitable submenu.
- `startForegroundService()` in LiveService crashed. Up to API level 25 `startService()` is used. Using `startService()` up to API level 27 works.

Crash log:
`ActivityManager: Bringing down service while still waiting for start foreground: ServiceRecord{bea663d u0 org.runnerup/.export.RunnerUpLiveSynchronizer$LiveService}`
`AndroidRuntime: Shutting down VM`
`AndroidRuntime: FATAL EXCEPTION: main`
`AndroidRuntime: Process: org.runnerup, PID: 8618`
`AndroidRuntime: android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground()`
