### PR TITLE
Disable TTS dialog on run start

### DIFF
--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -637,11 +637,15 @@ public class StartActivity extends AppCompatActivity
     private final OnClickListener startButtonClick = new OnClickListener() {
         public void onClick(View v) {
             if (mTracker.getState() == TrackerState.CONNECTED) {
+                /* FIXME: Triggers too often on the first run since app start even if TTS exists
                 if (!mTracker.isComponentConnected(new TrackerTTS().getName())) {
                     createNewNoTtsAvailableDialog();
                 } else {
                     startWorkout();
                 }
+                */
+                
+                startWorkout();
 
                 return;
             }


### PR DESCRIPTION
I've noticed this often triggers the first workout after app launch. Missed this during testing it seems. I recommend disabling this check for now as I will try to figure out a better way to fix this.