### PR TITLE
Remove commented out code

### DIFF
--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -637,14 +637,6 @@ public class StartActivity extends AppCompatActivity
     private final OnClickListener startButtonClick = new OnClickListener() {
         public void onClick(View v) {
             if (mTracker.getState() == TrackerState.CONNECTED) {
-                /* FIXME: Triggers too often on the first run since app start even if TTS exists
-                if (!mTracker.isComponentConnected(new TrackerTTS().getName())) {
-                    createNewNoTtsAvailableDialog();
-                } else {
-                    startWorkout();
-                }
-                */
-                
                 startWorkout();
 
                 return;

--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -604,19 +604,6 @@ public class StartActivity extends AppCompatActivity
         return w;
     }
 
-    private void createNewNoTtsAvailableDialog() {
-        new AlertDialog.Builder(this)
-                .setTitle(R.string.tts_not_available_title)
-                .setMessage(R.string.tts_not_available)
-                .setPositiveButton(R.string.OK, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        startWorkout();
-                    }
-                })
-                .show();
-    }
-
     private void startWorkout() {
         mGpsStatus.stop(StartActivity.this);
 


### PR DESCRIPTION
I know I said in #970 that I was planning to create a more permanent fix, and I was planning on looking into this this weekend. Life has been quite busy in the mean time.

Sadly, the /e/OS update I got for my phone just today adds a TTS engine by default. As a system app and without root access, I can no longer remove the TTS and thus sadly can no longer test the no-TTS situation.

I apologize for making a promise I ended up not being able to keep, but I really hadn't expected this to happen. So I'm at least making this small PR to remove the obsolete code.

Again, my apologies.