### PR TITLE
Add preference for custom MapBox API key for F-Droid users

### DIFF
--- a/app/res/values/pref_keys.xml
+++ b/app/res/values/pref_keys.xml
@@ -112,6 +112,7 @@
     <string name="pref_path_simplification_algorithm">pref_path_simplification_algorithm</string>
 
     <string name="pref_mapbox_default_style">pref_mapbox_default_style2</string>
+    <string name="pref_mapbox_custom_api_key">pref_mapbox_custom_api_key</string>
     <string name="pref_runneruplive_active">pref_runneruplive_active</string>
     <string name="pref_runneruplive_serveradress">pref_runneruplive_serveradress</string>
 

--- a/app/res/xml/settings.xml
+++ b/app/res/xml/settings.xml
@@ -373,6 +373,15 @@
             android:minHeight="48dp"
             android:persistent="true"
             android:title="@string/Mapbox_default_style" />
+
+        <org.runnerup.widget.TextPreference
+            android:defaultValue=""
+            android:inputType="text"
+            android:key="@string/pref_mapbox_custom_api_key"
+            android:minHeight="48dp"
+            android:persistent="true"
+            android:title="@string/custom_mapbox_api_key" />
+
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -21,11 +21,13 @@ import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -120,6 +122,16 @@ public class DetailActivity extends AppCompatActivity implements Constants {
 
     private long mStartTime = 0; // activity start time in unix timestamp
 
+    private boolean isMapboxEnabled() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        if (BuildConfig.MAPBOX_ENABLED > 0) {
+            return true;
+        } else if (prefs.getString(getResources().getString(R.string.pref_mapbox_custom_api_key), "").startsWith("pk")) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Called when the activity is first created.
      */
@@ -127,7 +139,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
+        if (isMapboxEnabled()) {
             MapWrapper.start(this);
             setContentView(R.layout.detail);
         } else {
@@ -169,7 +181,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         sport = findViewById(R.id.summary_sport);
         notes = findViewById(R.id.notes_text);
 
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
+        if (isMapboxEnabled()) {
             Object mapView = findViewById(R.id.mapview);
             mapWrapper = new MapWrapper(this, mDB, mID, formatter, mapView);
             mapWrapper.onCreate(savedInstanceState);
@@ -203,7 +215,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         tabSpec.setContent(R.id.tab_lap);
         th.addTab(tabSpec);
 
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
+        if (isMapboxEnabled()) {
             tabSpec = th.newTabSpec("map");
             tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Map)));
             tabSpec.setContent(R.id.tab_map);

--- a/app/src/main/org/runnerup/view/SettingsActivity.java
+++ b/app/src/main/org/runnerup/view/SettingsActivity.java
@@ -56,11 +56,13 @@ public class SettingsActivity extends PreferenceActivity {
             Preference btn = findPreference(res.getString(R.string.pref_prunedb));
             btn.setOnPreferenceClickListener(onPruneClick);
         }
-        
+
+        /*
         if (BuildConfig.MAPBOX_ENABLED == 0) {
             Preference pref = findPreference("map_preferencescreen");
             pref.setEnabled(false);
         }
+        */
 
         if (!hasHR(this)) {
             getPreferenceManager().findPreference(res.getString(R.string.cue_configure_hrzones)).setEnabled(false);

--- a/app/src/play/org/runnerup/util/MapWrapper.java
+++ b/app/src/play/org/runnerup/util/MapWrapper.java
@@ -81,8 +81,18 @@ public class MapWrapper implements Constants {
         this.mapView = (MapView)mapView;
     }
 
+    private static String getMapboxApiKey(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String customMapBoxApiKey = prefs.getString(context.getResources().getString(R.string.pref_mapbox_custom_api_key), "");
+        if ((customMapBoxApiKey != null) && customMapBoxApiKey.startsWith("pk")) {
+            return customMapBoxApiKey;
+        } else {
+            return BuildConfig.MAPBOX_ACCESS_TOKEN;
+        }
+    }
+
     public static void start(Context context) {
-        Mapbox.getInstance(context, BuildConfig.MAPBOX_ACCESS_TOKEN);
+        Mapbox.getInstance(context, getMapboxApiKey(context));
     }
 
     public void onCreate(Bundle savedInstanceState) {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
   <string name="Auto_start_GPS">Autostart GPS</string>
   <string name="Advanced_options">Advanced options</string>
   <string name="Mapbox_default_style">Mapbox style</string>
+  <string name="custom_mapbox_api_key">Custom MapBox API key</string>
   <string name="RunnerUp_live_address">RunnerUp Live address</string>
   <string name="Autopause_after_s">Autopause after (s)</string>
   <string name="Autopause_min_pace_minkm">Autopause minimum pace (min/km)</string>


### PR DESCRIPTION
Adding a text-preference for custom MapBox API keys.

This allows F-Droid users to use the mapbox widget by adding a custom API key.