### PR TITLE
Ensure HR value is 0 when HR is disconnected.

### DIFF
--- a/app/src/main/org/runnerup/tracker/Tracker.java
+++ b/app/src/main/org/runnerup/tracker/Tracker.java
@@ -892,7 +892,7 @@ public class Tracker extends android.app.Service implements
         }
 
         HRProvider hrProvider = trackerHRM.getHrProvider();
-        if (hrProvider == null)
+        if ((hrProvider == null) || !hrProvider.isConnected())
             return null;
 
         // now is elapsed nanosec, no sensor adjust needed
@@ -904,7 +904,7 @@ public class Tracker extends android.app.Service implements
 
     private Integer getCurrentHRValue(long now, long maxAge) {
         HRProvider hrProvider = trackerHRM.getHrProvider();
-        if (hrProvider == null)
+        if ((hrProvider == null) || !hrProvider.isConnected())
             return null;
 
         if (now > hrProvider.getHRValueTimestamp() + maxAge)


### PR DESCRIPTION
HR value is used in HRMStateChangeFeedback to choose between connection_lost and conection_restored. On my mobile with BLE HR band, the HR value after disconnection is the latest collected value, which leads to conection_restored message on both disconnection and reconnection events. This change should fix this issue.