### PR TITLE
Add current battery level to HR connection status

### DIFF
--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -1009,6 +1009,8 @@ public class StartActivity extends AppCompatActivity
             Integer hrVal = mTracker.getCurrentHRValue();
             if (hrVal != null)
                 str.append(" ").append(hrVal);
+                Integer batteryLevel = mTracker.getCurrentBatteryLevel();
+                str.append(" ").append(batteryLevel).append("%");
         }
         return str.toString();
     }


### PR DESCRIPTION
The battery level of HR sensors is only shown in a popup (when it is low) and while setting up the HR device.
Having it in the connection status line (displayed before starting the run) helps keeping track of remaining battery life.