### PR TITLE
Fix NullPointerException by not passing null

### DIFF
--- a/app/src/main/org/runnerup/export/RunnerUpLiveSynchronizer.java
+++ b/app/src/main/org/runnerup/export/RunnerUpLiveSynchronizer.java
@@ -195,7 +195,7 @@ public class RunnerUpLiveSynchronizer extends DefaultSynchronizer implements Wor
                         Math.round(elapsedTimeMillis / 1000.0)))
                 .putExtra(
                 LiveService.PARAM_IN_PACE,
-                formatter.formatVelocityByPreferredUnit(Formatter.Format.TXT_SHORT, elapsedTimeMillis == 0 ? null :
+                formatter.formatVelocityByPreferredUnit(Formatter.Format.TXT_SHORT, elapsedTimeMillis == 0 ? 0 :
                         elapsedDistanceMeter * 1000.0 / elapsedTimeMillis))
                 .putExtra(LiveService.PARAM_IN_USERNAME, username)
                 .putExtra(LiveService.PARAM_IN_PASSWORD, password)


### PR DESCRIPTION
I saw a crash when using RunnerUpLive:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'double java.lang.Double.doubleValue()' on a null object reference
    at org.runnerup.util.Formatter.formatVelocityByPreferredUnit(SourceFile:5)
    at org.runnerup.export.RunnerUpLiveSynchronizer.workoutEvent(SourceFile:18)
    at org.runnerup.tracker.Tracker.liveLog(SourceFile:2)
    at org.runnerup.tracker.Tracker.onLocationChangedImpl(SourceFile:48)
    at org.runnerup.tracker.Tracker.internalOnLocationChanged(SourceFile:1)
    at org.runnerup.tracker.Tracker.resume(SourceFile:4)
    at org.runnerup.workout.Step.onResume(SourceFile:3)
    at org.runnerup.workout.Workout.onResume(SourceFile:3)
    at org.runnerup.view.RunActivity.lambda$new$2(SourceFile:3)
    at org.runnerup.view.RunActivity.lambda$new$2$RunActivity(Unknown Source:0)
    at org.runnerup.view.-$$Lambda$RunActivity$LAYXWNyyEflWVy5hBpwZeXI9O3w.onClick(Unknown Source:2)
    at android.view.View.performClick(View.java:6297)
    at android.view.View$PerformClick.run(View.java:24797)
    at android.os.Handler.handleCallback(Handler.java:790)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:164)
    at android.app.ActivityThread.main(ActivityThread.java:6626)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:811)
```

Passing null has been introduced here: https://github.com/jonasoreland/runnerup/commit/486223d684f233c1e27f5f473d0d6ac95afa0122#diff-2da782c174076e5cbf219eaa79f84615c97df0aa1c50b8ba3f66592f37af33c3R192

I think we should rather pass 0, when elapsedTimeMillis is 0.
