### PR TITLE
Added support for bonded Huami devices which broadcast HR on BLE (BIP and Mi Band)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
@@ -37,6 +37,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Connects to a Bluetooth Low Energy module for Android versions >= 4.3
@@ -228,6 +230,10 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
                     log("firmware => startHR()");
                     // triggered from DummyReadForSecLevelCheck
                     startHR();
+                } else if (huamiMatcherFound && charUuid.equals(HARDWARE_REVISON_UUID)) {
+                    // triggered from DummyReadForSecLevelCheck
+                    log("Huami hardware => startHR()");
+                    startHR();
                 } else if (charUuid.equals(BATTERY_LEVEL_CHARAC)) {
                     log("batterylevel: " + arg0);
                     batteryLevel = arg0.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0);
@@ -354,6 +360,13 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
             }
             BluetoothGattCharacteristic firmwareIdCharc = disService
                     .getCharacteristic(FIRMWARE_REVISON_UUID);
+            if (firmwareIdCharc == null) {
+                huamiMatcherFound = huamiPattern.matcher(btDevice.getName()).find();
+                if (huamiMatcherFound) {
+                    firmwareIdCharc = disService
+                            .getCharacteristic(HARDWARE_REVISON_UUID);
+                }
+            }
             if (firmwareIdCharc == null) {
                 reportConnectFailed("firmware revison charateristic not found!");
                 return;
@@ -513,8 +526,21 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
         if (AVOID_SCAN_WITH_UUID)
             // Android 4.3
             btAdapter.startLeScan(mLeScanCallback);
-        else
+        else {
+            for (BluetoothDevice btDeviceThis : btAdapter.getBondedDevices()) {
+                if (btDeviceThis.getType() != BluetoothDevice.DEVICE_TYPE_LE) {
+                    log("Non BLE device detected : " + btDeviceThis.getName());
+                    continue;
+                }
+                // Bonded device detected :Amazfit Bip S
+                huamiMatcherFound = huamiPattern.matcher(btDeviceThis.getName()).find();
+                if (huamiMatcherFound) {
+                    log("Bonded Huami device detected :" + btDeviceThis.getName());
+                    mLeScanCallback.onLeScan(btDeviceThis, 0, null);
+                }
+            }
             btAdapter.startLeScan(SCAN_UUIDS, mLeScanCallback);
+        }
     }
 
     @Override

--- a/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
@@ -69,6 +69,9 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
     private final static boolean AVOID_SCAN_WITH_UUID;
     private final static boolean CONNECT_IN_OWN_THREAD_FROM_ON_LE_SCAN;
 
+    static final UUID HARDWARE_REVISON_UUID = UUID
+            .fromString("00002a27-0000-1000-8000-00805f9b34fb");
+
     static {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             // 4.3
@@ -96,6 +99,9 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
     private boolean mIsConnected = false;
     private boolean mIsConnecting = false;
     private boolean mIsDisconnecting = false;
+
+    static final Pattern huamiPattern = Pattern.compile("(Amazfit +Bip|Mi +.*Band)");
+    static boolean huamiMatcherFound = false;
 
     public AndroidBLEHRProvider(Context ctx) {
         context = ctx;

--- a/hrdevice/src/org/runnerup/hr/BtHRBase.java
+++ b/hrdevice/src/org/runnerup/hr/BtHRBase.java
@@ -29,8 +29,6 @@ abstract class BtHRBase implements HRProvider {
             .fromString("0000180f-0000-1000-8000-00805f9b34fb");
     static final UUID FIRMWARE_REVISON_UUID = UUID
             .fromString("00002a26-0000-1000-8000-00805f9b34fb");
-    static final UUID HARDWARE_REVISON_UUID = UUID
-            .fromString("00002a27-0000-1000-8000-00805f9b34fb");
     static final UUID DIS_UUID = UUID
             .fromString("0000180a-0000-1000-8000-00805f9b34fb");
     static final UUID HEART_RATE_MEASUREMENT_CHARAC = UUID
@@ -39,9 +37,6 @@ abstract class BtHRBase implements HRProvider {
             .fromString("00002A19-0000-1000-8000-00805f9b34fb");
     static final UUID CCC = UUID
             .fromString("00002902-0000-1000-8000-00805f9b34fb");
-
-    static final Pattern huamiPattern = Pattern.compile("(Amazfit +Bip|Xiomi +Mi)");
-    static boolean huamiMatcherFound = false;
 
     HRProvider.HRClient hrClient;
     Handler hrClientHandler;

--- a/hrdevice/src/org/runnerup/hr/BtHRBase.java
+++ b/hrdevice/src/org/runnerup/hr/BtHRBase.java
@@ -20,7 +20,7 @@ import android.os.Handler;
 import android.os.Looper;
 
 import java.util.UUID;
-
+import java.util.regex.Pattern;
 
 abstract class BtHRBase implements HRProvider {
     static final UUID HRP_SERVICE = UUID
@@ -29,6 +29,8 @@ abstract class BtHRBase implements HRProvider {
             .fromString("0000180f-0000-1000-8000-00805f9b34fb");
     static final UUID FIRMWARE_REVISON_UUID = UUID
             .fromString("00002a26-0000-1000-8000-00805f9b34fb");
+    static final UUID HARDWARE_REVISON_UUID = UUID
+            .fromString("00002a27-0000-1000-8000-00805f9b34fb");
     static final UUID DIS_UUID = UUID
             .fromString("0000180a-0000-1000-8000-00805f9b34fb");
     static final UUID HEART_RATE_MEASUREMENT_CHARAC = UUID
@@ -37,6 +39,9 @@ abstract class BtHRBase implements HRProvider {
             .fromString("00002A19-0000-1000-8000-00805f9b34fb");
     static final UUID CCC = UUID
             .fromString("00002902-0000-1000-8000-00805f9b34fb");
+
+    static final Pattern huamiPattern = Pattern.compile("(Amazfit +Bip|Xiomi +Mi)");
+    static boolean huamiMatcherFound = false;
 
     HRProvider.HRClient hrClient;
     Handler hrClientHandler;


### PR DESCRIPTION
Address issue #975 
The changes are on the lines suggested by d3m3vilurr:

(a) Check for bonded devices in startScan(). Huami devices are usually bonded to the phone.
(b) Huami devices dont have a FIRMWARE_REVISON_UUID, so check for HARDWARE_REVISON_UUID for these devices (only)

The Huami devices are specifically checked through a regexp against getName(), and a boolean "huamiMatcherFound" is set accordingly.
