### PR TITLE
Fix bugs #991 in HRZones

### DIFF
--- a/app/src/main/org/runnerup/view/HRZonesActivity.java
+++ b/app/src/main/org/runnerup/view/HRZonesActivity.java
@@ -111,8 +111,6 @@ public class HRZonesActivity extends AppCompatActivity implements Constants {
                     int zoneCount = hrZoneCalculator.getZoneCount();
                     int zoneDiff = zoneCount - loZone;
 
-                    System.err.println("loZone="+loZone);
-
                     // each zone should have at least one HR beat
                     if (loHR > maxHR - zoneDiff) {
                         loHR = maxHR - zoneDiff;

--- a/app/src/main/org/runnerup/view/HRZonesActivity.java
+++ b/app/src/main/org/runnerup/view/HRZonesActivity.java
@@ -63,10 +63,41 @@ public class HRZonesActivity extends AppCompatActivity implements Constants {
         TextView tv = row.findViewById(R.id.zonetext);
         EditText lo = row.findViewById(R.id.zonelo);
         EditText hi = row.findViewById(R.id.zonehi);
+        // disable setting the hi value
+        hi.setKeyListener(null);
+        hi.setEnabled(false);
         Pair<Integer, Integer> lim = hrZoneCalculator.getZoneLimits(zone);
         tv.setText(String.format(Locale.getDefault(), "%s %d %d%% - %d%%", getString(R.string.Zone), zone, lim.first, lim.second));
         lo.setTag("zone" + zone + "lo");
         hi.setTag("zone" + zone + "hi");
+
+        lo.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            int loZone = zone;
+
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                // When focus is lost, check that the text field has valid values.
+                if (!hasFocus) {
+                    // Validate
+                    int prevZoneRow = loZone - 2;
+                    int loHR = Integer.parseInt(lo.getText().toString());
+
+                    if (prevZoneRow >= 0) {
+                        //Check that the lo's are in increasing order
+                        int prevLoHR = Integer.parseInt(zones.get(2 * prevZoneRow).getText().toString());
+                        if (loHR <= prevLoHR) {
+                            // lo's are out of order, use some default
+                            loHR = prevLoHR +1;
+                            lo.setText(String.format(Locale.getDefault(), "%d", loHR));
+                        }
+                        // update the previous row's hi to the current row's lo
+                        zones.get(2 * prevZoneRow + 1).setText(String.format(Locale.getDefault(), "%d", loHR));
+                    }
+
+                }
+            }
+        });
+
         zones.add(lo);
         zones.add(hi);
 

--- a/app/src/main/org/runnerup/view/StepButton.java
+++ b/app/src/main/org/runnerup/view/StepButton.java
@@ -300,10 +300,11 @@ public class StepButton extends LinearLayout {
                         targetHrz.setEnabled(true);
                         targetHrz.setVisibility(View.VISIBLE);
                         if (target != null) {
-                            int matchedZone=hrZonesAdapter.hrZones.match(target.minValue,
-                                    target.maxValue)-2;
-                            if (matchedZone<0)
-                                matchedZone=0;
+                            int matchedZone = hrZonesAdapter.hrZones.match(target.minValue,
+                                    target.maxValue) - 2;
+                            if (matchedZone < 0) {
+                                matchedZone = 0;
+                            }
                             targetHrz.setValue(matchedZone);
                         } else {
                             targetHrz.setValue(0);
@@ -311,8 +312,7 @@ public class StepButton extends LinearLayout {
                         break;
                     default:
                         targetPaceLo.setEnabled(false);
-                        targetPaceHi
-                                .setEnabled(false);
+                        targetPaceHi.setEnabled(false);
                         targetHrz.setEnabled(false);
                         break;
                 }

--- a/app/src/main/org/runnerup/view/StepButton.java
+++ b/app/src/main/org/runnerup/view/StepButton.java
@@ -300,8 +300,11 @@ public class StepButton extends LinearLayout {
                         targetHrz.setEnabled(true);
                         targetHrz.setVisibility(View.VISIBLE);
                         if (target != null) {
-                            targetHrz.setValue(hrZonesAdapter.hrZones.match(target.minValue,
-                                    target.maxValue));
+                            int matchedZone=hrZonesAdapter.hrZones.match(target.minValue,
+                                    target.maxValue)-2;
+                            if (matchedZone<0)
+                                matchedZone=0;
+                            targetHrz.setValue(matchedZone);
                         } else {
                             targetHrz.setValue(0);
                         }


### PR DESCRIPTION
These changes address bug/issue #991 . 

Part 1 addresses "The UI should not allow changing the upper limit."

1. HRZonesActivity.java: 
  Make the high range of HR Zones uneditable.
   Map the low end of a zone to the high end of the previous zone on-the-fly
   A first attempt to make sure the zones are ordered (increasing)

Part 2  fixes a bug in zones: "saved HR zone is +2 to the selected. If I choose zone 1, after closing and reopening it becomes zone 3. And zones 4 and 5 become empty.". This behavior seems to derive from different zero- versus one-based numbering: 1 for the zones (for users) and 0 programmatically. This results in changes of 2 in HR zones when editing zones as targets of intervals.

2. StepButton.java:
   When HR is the target in an interval, the zone changes by +2 each time it is re-edited.
   This is fixed by subtracting 2 from the results of the match of hrZones from its adapter
   This is probably not the best way to write the solution, but it prevents app crashes as well.