### PR TITLE
Fix distancepicker

### DIFF
--- a/app/src/main/org/runnerup/widget/DistancePicker.java
+++ b/app/src/main/org/runnerup/widget/DistancePicker.java
@@ -49,6 +49,8 @@ public class DistancePicker extends LinearLayout {
         unitStringLayout.addView(unitString);
         meters = new NumberPicker(context, attrs);
 
+        unitMeters.setDigits(3);
+        unitMeters.setRange(0,999,true);
         unitMeters.setOrientation(VERTICAL);
         meters.setDigits(4);
         meters.setOrientation(VERTICAL);

--- a/app/src/main/org/runnerup/widget/NumberPicker.java
+++ b/app/src/main/org/runnerup/widget/NumberPicker.java
@@ -152,7 +152,7 @@ public class NumberPicker extends LinearLayout {
             } else {
                 return;
             }
-            long longSpeed = 300;
+            long longSpeed = 50;
             longHandler.postDelayed(this, longSpeed);
         }
     };


### PR DESCRIPTION
Setting distances was limited to 59 unitMeters.
There are sports that do more than 100km. So I set digits to 3 and maxValue to 999.

Together with this I speed up the long press. Was way too slow