### PR TITLE
Wip: Fix HR in DB. Max & avg were swapped

### DIFF
--- a/common/src/main/java/org/runnerup/common/util/Constants.java
+++ b/common/src/main/java/org/runnerup/common/util/Constants.java
@@ -41,8 +41,8 @@ public interface Constants {
             String NAME = "name";
             String COMMENT = "comment";
             String SPORT = "type";
-            String MAX_HR = "avg_hr";
-            String AVG_HR = "max_hr";
+            String MAX_HR = "max_hr";
+            String AVG_HR = "avg_hr";
             String AVG_CADENCE = "avg_cadence";
             String META_DATA = "meta_data";
             String DELETED = "deleted";


### PR DESCRIPTION
Stumbled upon the fact that max_hr and avg_hr were swapped while looking at the DB's activity