### PR TITLE
Final: Catch back button to not exit RU accidentally

### DIFF
--- a/app/src/main/org/runnerup/view/FeedActivity.java
+++ b/app/src/main/org/runnerup/view/FeedActivity.java
@@ -145,6 +145,12 @@ public class FeedActivity extends AppCompatActivity implements Constants {
         feedAdapter.close();
     }
 
+    public void onBackPressed() {
+        Intent intent = new Intent(this, MainLayout.class);
+        startActivity(intent);
+        finish();
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/app/src/main/org/runnerup/view/HistoryActivity.java
+++ b/app/src/main/org/runnerup/view/HistoryActivity.java
@@ -99,6 +99,12 @@ public class HistoryActivity extends AppCompatActivity implements Constants, OnI
         getSupportLoaderManager().restartLoader(0, null, this);
     }
 
+    public void onBackPressed() {
+        Intent intent = new Intent(this, MainLayout.class);
+        startActivity(intent);
+        finish();
+    }
+
     @Override
     public void onDestroy() {
         super.onDestroy();

--- a/app/src/main/org/runnerup/view/SettingsActivity.java
+++ b/app/src/main/org/runnerup/view/SettingsActivity.java
@@ -19,6 +19,7 @@ package org.runnerup.view;
 
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Build;
@@ -128,4 +129,10 @@ public class SettingsActivity extends PreferenceActivity {
         DBHelper.purgeDeletedActivities(SettingsActivity.this, dialog, dialog::dismiss);
         return false;
     };
+
+    public void onBackPressed() {
+        Intent intent = new Intent(this, MainLayout.class);
+        startActivity(intent);
+        finish();
+    }
 }

--- a/app/src/main/org/runnerup/view/StartActivity.java
+++ b/app/src/main/org/runnerup/view/StartActivity.java
@@ -33,6 +33,7 @@ import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
@@ -53,6 +54,7 @@ import android.widget.TabHost;
 import android.widget.TabHost.OnTabChangeListener;
 import android.widget.TabHost.TabSpec;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -130,6 +132,7 @@ public class StartActivity extends AppCompatActivity
     private TextView wearOsMessage = null;
 
     boolean batteryLevelMessageShown = false;
+    private Boolean exit = false;
 
     TitleSpinner simpleTargetType = null;
     TitleSpinner simpleTargetPaceValue = null;
@@ -402,13 +405,21 @@ public class StartActivity extends AppCompatActivity
         super.onDestroy();
     }
 
-    @Override
     public void onBackPressed() {
         if (!getAutoStartGps() && mGpsStatus.isLogging()) {
             stopGps();
             updateView();
+        } else if (exit) {
+            super.onBackPressed(); // finish activity
         } else {
-            super.onBackPressed();
+            final Resources res = this.getResources();
+            Toast.makeText(getApplicationContext(), res.getString(R.string.Catch_backbuttonpress), Toast.LENGTH_SHORT).show();
+            exit = true;
+            new Handler().postDelayed(new Runnable() {
+                public void run() {
+                    exit = false;
+                }
+            }, 3 * 1000);
         }
     }
 
@@ -1246,6 +1257,5 @@ public class StartActivity extends AppCompatActivity
         public int preSetValue(int newValue) throws IllegalArgumentException {
             return newValue;
         }
-
     };
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -340,4 +340,5 @@
   <string name="File_need_one_format">You must specify at least one format</string>
   <string name="tts_not_available_title">Text to Speech is not available</string>
   <string name="tts_not_available">RunnerUp requires a working Text to Speech engine to play audio cues. Please ensure you have at least one working Text to Speech engine installed.</string>
+  <string name="Catch_backbuttonpress">Press Back again to exit</string>
 </resources>


### PR DESCRIPTION
This is the final version of #1053.

Oftenly, when navigating within RU, one hits back button once too often and exits RU accidentally.

With this PR, exiting RU is only possible from the first Tab (StartActivity) with a double back button press.
All other Tabs (History, Feed, Settings) jump back to first Tab instead.

Pls test and review