### PR TITLE
Target Android 11

### DIFF
--- a/app/assets/changes.html
+++ b/app/assets/changes.html
@@ -5,6 +5,12 @@
 </head>
 <body>
 <h1>What's new</h1>
+<h2>v2.4.2</h2>
+<p>
+<ul>
+    <li>#1064 A few crash preventions</li>
+    <li>#1055 Fix distancepicker</li>
+</ul>
 <h2>v2.4.1</h2>
 <p>
 <ul>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
     }
 }
 
@@ -30,8 +30,8 @@ project.ext {
     mockitoVersion = '3.11.2'
 
     //The Git tag for the release must be identical for F-Droid
-    versionName = '2.4.1.0'
-    versionCode = 307
+    versionName = '2.4.2.0'
+    versionCode = 308
     latestBaseVersionCode = 15000000
 
     travisBuild = System.getenv("TRAVIS") == "true"


### PR DESCRIPTION
A few crash preventions
Android 11 required after Nov 1. Should be working but requires some more steps to enable GPS scanning.