### PR TITLE
Update Formatter.java to fix month display on some languages

### DIFF
--- a/app/src/main/org/runnerup/util/Formatter.java
+++ b/app/src/main/org/runnerup/util/Formatter.java
@@ -79,7 +79,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
 
         dateFormat = android.text.format.DateFormat.getDateFormat(ctx);
         timeFormat = android.text.format.DateFormat.getTimeFormat(ctx);
-        monthFormat = new SimpleDateFormat("MMM yyyy", cueResources.defaultLocale);
+        monthFormat = new SimpleDateFormat("LLL yyyy", cueResources.defaultLocale);
         dayOfMonthFormat = new SimpleDateFormat("E d", cueResources.defaultLocale);
         unitCue = sharedPreferences.getBoolean(cueResources.getString(R.string.cueinfo_units), true);
         //hrZones = new HRZones(context);


### PR DESCRIPTION
Hi, there's an issue in the ICU notation format that makes some languages to look bad in the history screen of runner up, for example in catalan the history appears as "de gen. 2022" (there's an extra article) instead of "gen. 2022" that would be the proper text in this case.
Using LLL instead of MMM fixes this for the affected languages (Belarusian, Catalan, Croatian, Finnish, Greek, Lithuanian, Polish, Russian,
Slovak, Ukrainian and several more...) without touching the rest. (see the explanation in here https://developer.android.com/reference/android/icu/text/SimpleDateFormat)

![image](https://user-images.githubusercontent.com/555542/153302781-83d2b41d-2adc-4ddc-8b5a-0313e53f3fb2.png)
