### PR TITLE
Prevent errors in case numeric settings are empty

### DIFF
--- a/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
+++ b/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
@@ -24,6 +24,7 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.text.TextUtils;
 
 import androidx.core.content.ContextCompat;
 
@@ -73,6 +74,17 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
         return ResultCode.RESULT_OK;
     }
 
+    private Integer parseAndFixInteger(int resId, String def, Context context) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        String s = preferences.getString(context.getString(resId), def);
+        if (TextUtils.isEmpty(s)) {
+            SharedPreferences.Editor prefedit = preferences.edit();
+            prefedit.putString(context.getString(resId), def);
+            prefedit.apply();
+            return Integer.parseInt(def);
+        }
+        return Integer.parseInt(s);
+    }
     @Override
     public ResultCode onConnecting(final Callback callback, Context context) {
         if (ContextCompat.checkSelfPermission(this.tracker,
@@ -83,14 +95,12 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
         try {
             LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
             SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-            frequency_ms = Integer.parseInt(preferences.getString(context.getString(
-                    R.string.pref_pollInterval), "1000"));
+            frequency_ms = parseAndFixInteger(R.string.pref_pollInterval, "1000", context);
             if (!mWithoutGps) {
-                String frequency_meters = preferences.getString(context.getString(
-                        R.string.pref_pollDistance), "0");
+                Integer frequency_meters = parseAndFixInteger(R.string.pref_pollDistance, "0", context);
                 lm.requestLocationUpdates(GPS_PROVIDER,
                         frequency_ms,
-                        Integer.parseInt(frequency_meters),
+                        frequency_meters,
                         tracker);
                 mGpsStatus = new GpsStatus(context);
                 mGpsStatus.start(this);

--- a/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
+++ b/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
@@ -74,14 +74,14 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
         return ResultCode.RESULT_OK;
     }
 
-    private Integer parseAndFixInteger(int resId, String def, Context context) {
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    private Integer parseAndFixInteger(SharedPreferences preferences, int resId, String def, Context context) {
         String s = preferences.getString(context.getString(resId), def);
         if (TextUtils.isEmpty(s)) {
+            // Update the settings
             SharedPreferences.Editor prefedit = preferences.edit();
             prefedit.putString(context.getString(resId), def);
             prefedit.apply();
-            return Integer.parseInt(def);
+            s = def;
         }
         return Integer.parseInt(s);
     }
@@ -95,9 +95,9 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
         try {
             LocationManager lm = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
             SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-            frequency_ms = parseAndFixInteger(R.string.pref_pollInterval, "1000", context);
+            frequency_ms = parseAndFixInteger(preferences, R.string.pref_pollInterval, "1000", context);
             if (!mWithoutGps) {
-                Integer frequency_meters = parseAndFixInteger(R.string.pref_pollDistance, "0", context);
+                Integer frequency_meters = parseAndFixInteger(preferences, R.string.pref_pollDistance, "0", context);
                 lm.requestLocationUpdates(GPS_PROVIDER,
                         frequency_ms,
                         frequency_meters,


### PR DESCRIPTION
Even though some of the settings like pollDistance and pollInterval are
set to be numeric and (at least as I tested) cannot be negative or
contain anything else than numbers, they can be an empty string. Parsing
that empty string to parseInt() is causing trouble.

This patch looks for empty strings and in that case uses the default
value instead. In addition, it resets the preference value to that
default to make the usage of that default clear to the user.

This should close #1100.

Note that this only happens here when those values are used: when an
activity starts. Ideally, this should be prevented by Android itself,
but barring that, it should be checked right after the setting is
changed in the settings dialog. However, this is beyond my current
Android-Voodoo.

Also note, that this code (like the original version) duplicates the
default values from the file settings.xml. Ideally, that default should
be obtained and used instead - alas I do not know how that can be done.