### PR TITLE
Added support for Osmdroid in the F-Droid version of RunnerUp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,8 @@ dependencies {
         latestImplementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.2'
         latestImplementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
         latestImplementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-v8:0.2.0'
+    } else {
+        implementation 'org.osmdroid:osmdroid-android:6.1.11'
     }
     latestImplementation 'com.jjoe64:graphview:4.2.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,6 +192,12 @@ android.applicationVariants.all {
         buildConfigField 'String', 'MAPBOX_ACCESS_TOKEN', '""'
     }
 
+    if (rootProject.ext.allowNonFree) {
+        buildConfigField 'boolean', 'USING_OSMDROID', "false"
+    } else {
+        buildConfigField 'boolean', 'USING_OSMDROID', "true"
+    }
+
     if (rootProject.file("runalyze.properties").exists()) {
         // Contact Runalyze team at https://forum.runalyze.com/
         props.load(new FileInputStream(rootProject.file("runalyze.properties")))

--- a/app/res/layout/map_area.xml
+++ b/app/res/layout/map_area.xml
@@ -3,7 +3,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android">
-<com.mapbox.mapboxsdk.maps.MapView
+<org.runnerup.util.MapViewWrapper
     android:id="@+id/mapview"
     android:layout_width="match_parent"
     android:layout_height="match_parent"    />

--- a/app/src/free/org/runnerup/util/MapViewWrapper.java
+++ b/app/src/free/org/runnerup/util/MapViewWrapper.java
@@ -1,0 +1,39 @@
+package org.runnerup.util;
+
+import android.content.Context;
+import android.os.Handler;
+import android.util.AttributeSet;
+
+import org.osmdroid.tileprovider.MapTileProviderBase;
+
+
+public class MapViewWrapper extends org.osmdroid.views.MapView {
+    public MapViewWrapper(Context context, MapTileProviderBase tileProvider, Handler tileRequestCompleteHandler, AttributeSet attrs) {
+        super(context, tileProvider, tileRequestCompleteHandler, attrs);
+    }
+
+    public MapViewWrapper(final Context context,
+                   MapTileProviderBase tileProvider,
+                   final Handler tileRequestCompleteHandler, final AttributeSet attrs, boolean hardwareAccelerated) {
+        super(context, tileProvider, tileRequestCompleteHandler, attrs, hardwareAccelerated);
+    }
+
+    public MapViewWrapper(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MapViewWrapper(final Context context) {
+        super(context);
+    }
+
+    public MapViewWrapper(final Context context,
+                   final MapTileProviderBase aTileProvider) {
+        super(context, aTileProvider);
+    }
+
+    public MapViewWrapper(final Context context,
+                   final MapTileProviderBase aTileProvider,
+                   final Handler tileRequestCompleteHandler) {
+        super(context, aTileProvider, tileRequestCompleteHandler);
+    }
+}

--- a/app/src/free/org/runnerup/util/MapWrapper.java
+++ b/app/src/free/org/runnerup/util/MapWrapper.java
@@ -24,7 +24,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 
 import org.osmdroid.api.IMapController;
-import org.osmdroid.api.IMapView;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
@@ -32,6 +31,7 @@ import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Polyline;
+import org.runnerup.R;
 import org.runnerup.common.util.Constants;
 import org.runnerup.db.entities.LocationEntity;
 
@@ -39,6 +39,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class MapWrapper implements Constants {
+
+    public static final boolean USING_OSMDROID = true;
 
     private final Context context;
     private final SQLiteDatabase mDB;
@@ -97,6 +99,7 @@ public class MapWrapper implements Constants {
             long mID = params[0].mID;
             IMapController iMapController = params[0].iMapController;
             Polyline route = new Polyline(mapView, true);
+            route.setInfoWindow(null);
             route.getOutlinePaint().setStrokeWidth(10.f);
             LocationEntity.LocationList<LocationEntity> ll = new LocationEntity.LocationList<>(mDB, mID);
             List<GeoPoint> points = new LinkedList<>();
@@ -107,12 +110,17 @@ public class MapWrapper implements Constants {
             ll.close();
             route.setPoints(points);
             Marker markerStart = new Marker(mapView);
+            markerStart.setInfoWindow(null);
             Marker markerEnd = new Marker(mapView);
+            markerEnd.setInfoWindow(null);
             if (points.size() > 0) {
                 iMapController.setCenter(points.get(0));
 
                 markerStart.setPosition(points.get(0));
                 markerEnd.setPosition(points.get(points.size() - 1));
+
+                markerStart.setTextIcon(context.getString(R.string.Start));
+                markerEnd.setTextIcon(context.getString(R.string.Finished));
 
                 markerStart.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
                 markerEnd.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);

--- a/app/src/free/org/runnerup/util/MapWrapper.java
+++ b/app/src/free/org/runnerup/util/MapWrapper.java
@@ -17,23 +17,117 @@
 
 package org.runnerup.util;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.AsyncTask;
 import android.os.Bundle;
 
+import org.osmdroid.api.IMapController;
+import org.osmdroid.api.IMapView;
+import org.osmdroid.config.Configuration;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.CustomZoomButtonsController;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.Polyline;
 import org.runnerup.common.util.Constants;
-import org.runnerup.util.Formatter;
+import org.runnerup.db.entities.LocationEntity;
 
+import java.util.LinkedList;
+import java.util.List;
 
 public class MapWrapper implements Constants {
 
+    private final Context context;
+    private final SQLiteDatabase mDB;
+    private final long mID;
+    private final Formatter formatter;
+    private final MapView mapView;
+
+    private static final String OSMDROID_USER_AGENT = "org.runnerup.free";
+
     public MapWrapper(Context context, SQLiteDatabase mDB, long mID, Formatter formatter, Object mapView) {
+        this.context = context;
+        this.mDB = mDB;
+        this.mID = mID;
+        this.formatter = formatter;
+        this.mapView = (MapView)mapView;
     }
 
     public static void start(Context context) {
     }
 
     public void onCreate(Bundle savedInstanceState) {
+        mapView.setTileSource(TileSourceFactory.MAPNIK);
+        mapView.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.SHOW_AND_FADEOUT);
+        mapView.setMultiTouchControls(true);
+
+        Configuration.getInstance().setUserAgentValue(OSMDROID_USER_AGENT);
+
+        IMapController iMapController = mapView.getController();
+        iMapController.setZoom(15.);
+
+        new LoadRoute().execute(new LoadParam(context, mDB, mID, mapView, iMapController));
+    }
+
+    private class LoadParam {
+        LoadParam(Context context, SQLiteDatabase mDB, long mID, MapView mapView, IMapController iMapController) {
+            this.context = context;
+            this.mDB = mDB;
+            this.mID = mID;
+            this.mapView = mapView;
+            this.iMapController = iMapController;
+        }
+
+        final Context context;
+        final SQLiteDatabase mDB;
+        final long mID;
+        final MapView mapView;
+        final IMapController iMapController;
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    private class LoadRoute extends AsyncTask<LoadParam, Void, Polyline> {
+        @Override
+        protected Polyline doInBackground(LoadParam... params) {
+            MapView mapView = params[0].mapView;
+            SQLiteDatabase mDB = params[0].mDB;
+            long mID = params[0].mID;
+            IMapController iMapController = params[0].iMapController;
+            Polyline route = new Polyline(mapView, true);
+            route.getOutlinePaint().setStrokeWidth(10.f);
+            LocationEntity.LocationList<LocationEntity> ll = new LocationEntity.LocationList<>(mDB, mID);
+            List<GeoPoint> points = new LinkedList<>();
+            for (LocationEntity loc : ll) {
+                GeoPoint point = new GeoPoint(loc.getLatitude(), loc.getLongitude());
+                points.add(point);
+            }
+            ll.close();
+            route.setPoints(points);
+            Marker markerStart = new Marker(mapView);
+            Marker markerEnd = new Marker(mapView);
+            if (points.size() > 0) {
+                iMapController.setCenter(points.get(0));
+
+                markerStart.setPosition(points.get(0));
+                markerEnd.setPosition(points.get(points.size() - 1));
+
+                markerStart.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+                markerEnd.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+
+                mapView.getOverlays().add(markerStart);
+                mapView.getOverlays().add(markerEnd);
+            }
+
+            mapView.getOverlays().add(route);
+            return route;
+        }
+    }
+
+    public void onResume() {
+        mapView.onResume();
     }
 
     public void onStart() {
@@ -42,10 +136,8 @@ public class MapWrapper implements Constants {
     public void onStop() {
     }
 
-    public void onResume() {
-    }
-
     public void onPause() {
+        mapView.onPause();
     }
 
     public void onSaveInstanceState(Bundle outState) {

--- a/app/src/free/org/runnerup/util/MapWrapper.java
+++ b/app/src/free/org/runnerup/util/MapWrapper.java
@@ -40,8 +40,6 @@ import java.util.List;
 
 public class MapWrapper implements Constants {
 
-    public static final boolean USING_OSMDROID = true;
-
     private final Context context;
     private final SQLiteDatabase mDB;
     private final long mID;
@@ -127,9 +125,10 @@ public class MapWrapper implements Constants {
 
                 mapView.getOverlays().add(markerStart);
                 mapView.getOverlays().add(markerEnd);
+
+                mapView.getOverlays().add(route);
             }
 
-            mapView.getOverlays().add(route);
             return route;
         }
     }

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -81,6 +81,7 @@ import java.util.Map;
 
 import static org.runnerup.content.ActivityProvider.GPX_MIME;
 import static org.runnerup.content.ActivityProvider.TCX_MIME;
+import static org.runnerup.util.MapWrapper.USING_OSMDROID;
 
 
 public class DetailActivity extends AppCompatActivity implements Constants {
@@ -127,10 +128,13 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        MapWrapper.start(this);
-        setContentView(R.layout.detail);
-
+        if (USING_OSMDROID || BuildConfig.MAPBOX_ENABLED > 0) {
+            MapWrapper.start(this);
+            setContentView(R.layout.detail);
+        } else {
+            // No MapBox key nor Osmdroid, load without mapview, do not set mapWrapper
+            setContentView(R.layout.detail_nomap);
+        }
         Toolbar toolbar = findViewById(R.id.actionbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -166,9 +170,11 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         sport = findViewById(R.id.summary_sport);
         notes = findViewById(R.id.notes_text);
 
-        Object mapView = findViewById(R.id.mapview);
-        mapWrapper = new MapWrapper(this, mDB, mID, formatter, mapView);
-        mapWrapper.onCreate(savedInstanceState);
+        if (USING_OSMDROID || BuildConfig.MAPBOX_ENABLED > 0) {
+            Object mapView = findViewById(R.id.mapview);
+            mapWrapper = new MapWrapper(this, mDB, mID, formatter, mapView);
+            mapWrapper.onCreate(savedInstanceState);
+        }
 
         saveButton.setOnClickListener(saveButtonClick);
         uploadButton.setOnClickListener(uploadButtonClick);
@@ -198,10 +204,12 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         tabSpec.setContent(R.id.tab_lap);
         th.addTab(tabSpec);
 
-        tabSpec = th.newTabSpec("map");
-        tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Map)));
-        tabSpec.setContent(R.id.tab_map);
-        th.addTab(tabSpec);
+        if (USING_OSMDROID || BuildConfig.MAPBOX_ENABLED > 0) {
+            tabSpec = th.newTabSpec("map");
+            tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Map)));
+            tabSpec.setContent(R.id.tab_map);
+            th.addTab(tabSpec);
+        }
 
         tabSpec = th.newTabSpec("graph");
         tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Graph)));

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -79,9 +79,9 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.runnerup.BuildConfig.USING_OSMDROID;
 import static org.runnerup.content.ActivityProvider.GPX_MIME;
 import static org.runnerup.content.ActivityProvider.TCX_MIME;
-import static org.runnerup.util.MapWrapper.USING_OSMDROID;
 
 
 public class DetailActivity extends AppCompatActivity implements Constants {

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -127,13 +127,10 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
-            MapWrapper.start(this);
-            setContentView(R.layout.detail);
-        } else {
-            // No MapBox key, load without mapview, do not set mapWrapper
-            setContentView(R.layout.detail_nomap);
-        }
+
+        MapWrapper.start(this);
+        setContentView(R.layout.detail);
+
         Toolbar toolbar = findViewById(R.id.actionbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -169,11 +166,9 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         sport = findViewById(R.id.summary_sport);
         notes = findViewById(R.id.notes_text);
 
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
-            Object mapView = findViewById(R.id.mapview);
-            mapWrapper = new MapWrapper(this, mDB, mID, formatter, mapView);
-            mapWrapper.onCreate(savedInstanceState);
-        }
+        Object mapView = findViewById(R.id.mapview);
+        mapWrapper = new MapWrapper(this, mDB, mID, formatter, mapView);
+        mapWrapper.onCreate(savedInstanceState);
 
         saveButton.setOnClickListener(saveButtonClick);
         uploadButton.setOnClickListener(uploadButtonClick);
@@ -203,12 +198,10 @@ public class DetailActivity extends AppCompatActivity implements Constants {
         tabSpec.setContent(R.id.tab_lap);
         th.addTab(tabSpec);
 
-        if (BuildConfig.MAPBOX_ENABLED > 0) {
-            tabSpec = th.newTabSpec("map");
-            tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Map)));
-            tabSpec.setContent(R.id.tab_map);
-            th.addTab(tabSpec);
-        }
+        tabSpec = th.newTabSpec("map");
+        tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Map)));
+        tabSpec.setContent(R.id.tab_map);
+        th.addTab(tabSpec);
 
         tabSpec = th.newTabSpec("graph");
         tabSpec.setIndicator(WidgetUtil.createHoloTabIndicator(this, getString(R.string.Graph)));

--- a/app/src/play/org/runnerup/util/MapViewWrapper.java
+++ b/app/src/play/org/runnerup/util/MapViewWrapper.java
@@ -1,0 +1,17 @@
+package org.runnerup.util;
+
+import android.content.Context;
+import android.os.Handler;
+import android.util.AttributeSet;
+
+
+public class MapViewWrapper extends com.mapbox.mapboxsdk.maps.MapView {
+
+    public MapViewWrapper(Context context) {
+        super(context);
+    }
+    public MapViewWrapper(Context context, AttributeSet attributeSet) {
+        super(context, attributeSet);
+    }
+
+}

--- a/app/src/play/org/runnerup/util/MapWrapper.java
+++ b/app/src/play/org/runnerup/util/MapWrapper.java
@@ -64,6 +64,8 @@ import static org.runnerup.util.Formatter.Format.TXT_SHORT;
 
 public class MapWrapper implements Constants {
 
+    public static final boolean USING_OSMDROID = false;
+
     private final MapView mapView;
     private LineManager lineManager;
     private SymbolManager symbolManager;

--- a/app/src/play/org/runnerup/util/MapWrapper.java
+++ b/app/src/play/org/runnerup/util/MapWrapper.java
@@ -64,8 +64,6 @@ import static org.runnerup.util.Formatter.Format.TXT_SHORT;
 
 public class MapWrapper implements Constants {
 
-    public static final boolean USING_OSMDROID = false;
-
     private final MapView mapView;
     private LineManager lineManager;
     private SymbolManager symbolManager;


### PR DESCRIPTION
The `MapView` widget will now be visible in the free version of RunnerUp. It will link to an Osmdroid widget which is compatible with F-Droid.

This edit allows to view the track on a map with the free version on F-Droid.

The play version will remain identical to the current one.