### PR TITLE
Fix misplaced endTag for TCX exports without trackpoints

### DIFF
--- a/app/src/main/org/runnerup/export/format/TCX.java
+++ b/app/src/main/org/runnerup/export/format/TCX.java
@@ -347,8 +347,8 @@ public class TCX {
                     mXML.text(formatTime(startTime));
                     mXML.endTag("", "Time");
                     mXML.endTag("", "Trackpoint");
+                    mXML.endTag("", "Track");
                 }
-                mXML.endTag("", "Track");
 
                 if (cntHR > 0) {
                     mXML.startTag("", "AverageHeartRateBpm");

--- a/app/src/main/org/runnerup/export/format/TCX.java
+++ b/app/src/main/org/runnerup/export/format/TCX.java
@@ -349,7 +349,9 @@ public class TCX {
                     mXML.endTag("", "Trackpoint");
                     mXML.endTag("", "Track");
                 }
-
+                else if (hasTrackpoints) {
+                    mXML.endTag("", "Track");
+                }
                 if (cntHR > 0) {
                     mXML.startTag("", "AverageHeartRateBpm");
                     mXML.startTag("", "Value");


### PR DESCRIPTION
misplaced endTag causes exceptions for all exports without tracking data.

related issue: #1105