### PR TITLE
Fix Farsi language label

### DIFF
--- a/app/res/values/array.xml
+++ b/app/res/values/array.xml
@@ -45,7 +45,7 @@
     <item>Čeština</item>
     <item>Deutsch</item>
     <item>Español</item>
-    <item>زبان فارسی</item>
+    <item>فارسی</item>
     <item>Français</item>
     <item>עברית</item>
     <item>Italiano</item>


### PR DESCRIPTION
There is no need for the word "zaban" which means language itself. Just
"Farsi" is the correct use.