### PR TITLE
Fix some output streams writing too many bytes

### DIFF
--- a/app/src/main/org/runnerup/util/FileUtil.java
+++ b/app/src/main/org/runnerup/util/FileUtil.java
@@ -29,9 +29,10 @@ public class FileUtil {
     private static int copy(InputStream src, OutputStream dst) throws IOException {
         int cnt = 0;
         byte[] buf = new byte[1024];
-        while (src.read(buf) > 0) {
-            cnt += buf.length;
-            dst.write(buf);
+        int bytesRead;
+        while ((bytesRead = src.read(buf)) > 0) {
+            cnt += bytesRead;
+            dst.write(buf, 0, bytesRead);
         }
         return cnt;
     }

--- a/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
@@ -249,8 +249,9 @@ public class ManageWorkoutsActivity extends AppCompatActivity implements Constan
         BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(f));
         BufferedInputStream in = new BufferedInputStream(is);
         byte[] buf = new byte[1024];
-        while (in.read(buf) > 0) {
-            out.write(buf);
+        int bytesRead;
+        while ((bytesRead = in.read(buf)) > 0) {
+            out.write(buf, 0, bytesRead);
         }
         in.close();
         out.close();


### PR DESCRIPTION
There is a bug in the `FileUtil.copy` method where the output stream writes too much data, causing the copied file not to be the same as the original file. This fix ensures that the output stream writes only the number of bytes read from the input stream.