### PR TITLE
Setting default values for all XML preference files

### DIFF
--- a/app/src/main/org/runnerup/view/MainLayout.java
+++ b/app/src/main/org/runnerup/view/MainLayout.java
@@ -127,6 +127,13 @@ public class MainLayout extends TabActivity {
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false);
         PreferenceManager.setDefaultValues(this, R.xml.audio_cue_settings, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_controls, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_graph, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_maintenance, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_map, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_sensors, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_units, true);
+        PreferenceManager.setDefaultValues(this, R.xml.settings_workout, true);
 
         TabHost tabHost = getTabHost(); // The activity TabHost
 


### PR DESCRIPTION
When migrating to the AndroidX Preference library (#1174), the new XML preference files did not get their default values set.