### PR TITLE
Use explicit PendingIntents for notification actions

### DIFF
--- a/app/src/main/org/runnerup/notification/GpsBoundState.java
+++ b/app/src/main/org/runnerup/notification/GpsBoundState.java
@@ -28,6 +28,7 @@ public class GpsBoundState implements NotificationState {
         PendingIntent pi = PendingIntent.getActivity(context, 0, i, intentFlags);
 
         Intent startIntent = new Intent()
+                .setPackage(context.getPackageName())
                 .setAction(Constants.Intents.START_ACTIVITY);
         PendingIntent pendingStart = PendingIntent.getBroadcast(
                 context, 0, startIntent, PendingIntent.FLAG_UPDATE_CURRENT | intentFlags);

--- a/app/src/main/org/runnerup/notification/OngoingState.java
+++ b/app/src/main/org/runnerup/notification/OngoingState.java
@@ -39,11 +39,13 @@ public class OngoingState implements NotificationState {
         PendingIntent pi = PendingIntent.getActivity(context, 0, i, intentFlags);
 
         Intent lapIntent = new Intent()
+                .setPackage(context.getPackageName())
                 .setAction(Constants.Intents.NEW_LAP);
         PendingIntent pendingLap = PendingIntent.getBroadcast(
                 context, 0, lapIntent, PendingIntent.FLAG_UPDATE_CURRENT | intentFlags);
 
         Intent pauseIntent = new Intent()
+                .setPackage(context.getPackageName())
                 .setAction(Constants.Intents.PAUSE_RESUME);
         PendingIntent pendingPause = PendingIntent.getBroadcast(
                 context, 0, pauseIntent, PendingIntent.FLAG_UPDATE_CURRENT | intentFlags);


### PR DESCRIPTION
Fixes #1189

Starting with Android 14, implicit intents are restricted for internal app components. This commit explicitly sets the package name for PendingIntents used as notification actions to ensure compatibility with the behavior changes outlined in: https://developer.android.com/about/versions/14/behavior-changes-14#security