### PR TITLE
Preserve lap information in PathSimplifier

### DIFF
--- a/app/src/main/org/runnerup/db/PathSimplifier.java
+++ b/app/src/main/org/runnerup/db/PathSimplifier.java
@@ -163,7 +163,8 @@ public class PathSimplifier {
         "_id",
         Constants.DB.LOCATION.LATITUDE,
         Constants.DB.LOCATION.LONGITUDE,
-        Constants.DB.LOCATION.TYPE
+        Constants.DB.LOCATION.TYPE,
+        Constants.DB.LOCATION.LAP
       };
 
       // get table from database
@@ -183,13 +184,16 @@ public class PathSimplifier {
       idsStr = new ArrayList<>();
       // Location IDs to remove from the activity
       ArrayList<String> simplifiedIDs = new ArrayList<>();
+      int lap = 0;
+      int lap_prev = -1;
 
       if (c.moveToFirst()) {
         do {
           int lstate = c.getInt(3);
+          lap = c.getInt(4);
 
           // Only TYPE_GPS locations are considered for simplification
-          if (lstate == Constants.DB.LOCATION.TYPE_GPS) {
+          if (lstate == Constants.DB.LOCATION.TYPE_GPS && lap == lap_prev) {
             // save ID of the location entry
             Location l = new Location(String.format(Locale.US, "%d", c.getInt(0)));
             // get location's coordinates
@@ -198,8 +202,10 @@ public class PathSimplifier {
             idsStr.add(l.getProvider());
             locations.add(l);
 
-          } else if ((lstate == Constants.DB.LOCATION.TYPE_PAUSE)
-              || (lstate == Constants.DB.LOCATION.TYPE_END)) {
+          } else if (((lstate == Constants.DB.LOCATION.TYPE_PAUSE)
+                  || (lstate == Constants.DB.LOCATION.TYPE_END))
+              // also keep first and last location of a lap to preserve lap information
+              || (lstate == Constants.DB.LOCATION.TYPE_GPS)) {
             // this is the end of a segment
 
             // simplify current segment
@@ -208,6 +214,8 @@ public class PathSimplifier {
             for (Location sl : simplifiedLocations) {
               simplifiedIDs.add(sl.getProvider());
             }
+
+            lap_prev = lap;
 
             // start new segment
             locations = new ArrayList<>();


### PR DESCRIPTION
I noticed lap times and distances changed quite a bit when simplifying the path, this PR tries to change that.

It looks like the code already simplifies by segment, I tried to make it so that every lap is a segment. I quickly tested it and it seems to work, but it's possible I overlooked some things.