### PR TITLE
chore: agp 8.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,6 @@ android {
             } else {
                 java.srcDirs += ['src/nonmapbox']
             }
-            resources.srcDirs = java.srcDirs
-            aidl.srcDirs = java.srcDirs
             // renderscript.srcDirs = java.srcDirs
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.10.0'
     }
 }
 
@@ -69,16 +69,4 @@ allprojects {
             flatDir { dirs rootProject.ext.antPlusLibPath }
         }
     }
-}
-
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-}
-
-dependencies {
-    implementation 'com.github.google:google-java-format:1.13.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Android Studio 2024.3.2

I did not see errors before update - or did not look enough

There is a warning I do not get away now:

2025-05-25 21:59:10,666 [  25793]   WARN - #c.i.o.e.s.p.m.ContentRootDataService - Duplicating content roots detected.
2025-05-25 21:59:10,667 [  25794]   WARN - #c.i.o.e.s.p.m.ContentRootDataService - Path [C:/dev/gc/runnerup/app] of module [runnerup.app] was removed from modules [runnerup.app.main]
2025-05-25 21:59:10,667 [  25794]   WARN - #c.i.o.e.s.p.m.ContentRootDataService - Path [C:/dev/gc/runnerup/hrdevice] of module [runnerup.hrdevice] was removed from modules [runnerup.hrdevice.main]

Gemini suggests changing the structure. Not this PR, also if it it resolves

Removed the dependency to google-java-format in gradle
It probably had no effect and failed after updating too
Maybe a another gradle plugin is needed
If installed in AS, reformat code uses this style
But the question is if there should be automatic checks or enforcements at build or commit?
separate