### PR TITLE
fix: allow Rest with no time info

### DIFF
--- a/app/src/main/org/runnerup/workout/PauseStep.java
+++ b/app/src/main/org/runnerup/workout/PauseStep.java
@@ -28,12 +28,6 @@ public class PauseStep extends Step {
   @Override
   public void onInit(Workout s) {
     super.onInit(s);
-    if (BuildConfig.DEBUG
-        && (getIntensity() != Intensity.RESTING || getDurationType() != Dimension.TIME)) {
-      throw new AssertionError(
-          String.format(
-              "PauseStep with intensity %s and duration %s", getIntensity(), getDurationType()));
-    }
     saveDurationValue = super.durationValue;
   }
 


### PR DESCRIPTION
Assertion in Debug avoided, it is valid to Rest until button for instance.

Some other assertions could probably be removed too.