### PR TITLE
feat: edge-to-edge inserts

### DIFF
--- a/app/res/layout/account.xml
+++ b/app/res/layout/account.xml
@@ -16,9 +16,10 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/account_rootview"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:gravity="center_horizontal"
     android:orientation="vertical">
 

--- a/app/res/layout/account_list.xml
+++ b/app/res/layout/account_list.xml
@@ -16,6 +16,7 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/account_list_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical" >

--- a/app/res/layout/create_advanced_workout.xml
+++ b/app/res/layout/create_advanced_workout.xml
@@ -1,6 +1,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:runnerup="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
+                android:id="@+id/create_advanced_workout_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 tools:context="org.runnerup.view.CreateAdvancedWorkout">

--- a/app/res/layout/detail.xml
+++ b/app/res/layout/detail.xml
@@ -16,6 +16,7 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/detail_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">

--- a/app/res/layout/detail_nomap.xml
+++ b/app/res/layout/detail_nomap.xml
@@ -16,6 +16,7 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/detail_nomap_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">

--- a/app/res/layout/heartratezonerow.xml
+++ b/app/res/layout/heartratezonerow.xml
@@ -17,6 +17,7 @@
 -->
 <TableRow xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/heartratezonerow_view"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content">
 

--- a/app/res/layout/heartratezones.xml
+++ b/app/res/layout/heartratezones.xml
@@ -16,10 +16,12 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/heartratezone_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical" xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_margin="@dimen/activity_margin">
+    android:layout_margin="@dimen/activity_margin"
+    android:orientation="vertical">
 
     <org.runnerup.widget.TitleSpinner
         android:id="@+id/hrz_age"

--- a/app/res/layout/hr_settings.xml
+++ b/app/res/layout/hr_settings.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/hr_settings_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".view.HRSettingsActivity">

--- a/app/res/layout/manage_workouts.xml
+++ b/app/res/layout/manage_workouts.xml
@@ -16,6 +16,7 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/manage_workouts_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/app/res/layout/run.xml
+++ b/app/res/layout/run.xml
@@ -16,6 +16,7 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/start_view"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical" >

--- a/app/res/layout/upload.xml
+++ b/app/res/layout/upload.xml
@@ -16,9 +16,10 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/upload_rootview"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
   <LinearLayout

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -20,7 +20,6 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="AppTheme">

--- a/app/res/xml/audio_cue_settings.xml
+++ b/app/res/xml/audio_cue_settings.xml
@@ -17,6 +17,7 @@
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
+	android:id="@+id/activity_cue_settings_view"
 	android:layout_width="fill_parent"
 	android:layout_height="fill_parent">
 
@@ -272,5 +273,8 @@
 		<Preference android:title="@string/Android_text_to_speech_settings"
 			android:key="tts_settings"
 			app:iconSpaceReserved="false" />
+		<!-- add padding for navigating -->
+		<Preference
+			app:minHeight="12px" />
 	</PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/org/runnerup/util/ViewUtil.java
+++ b/app/src/main/org/runnerup/util/ViewUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 jonas.oreland@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.runnerup.util;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+public class ViewUtil {
+  public static void Insets(View rootView, boolean marginLayout){
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+
+              // Pad the root layout for navigation bar
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            int top = marginLayout ? 0 : insets.top;
+            v.setPadding(insets.left, top, insets.right, insets.bottom);
+
+            if (marginLayout){
+                // Adjust margins to avoid gesture conflicts
+              ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+              mlp.topMargin = insets.top;
+            }
+
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
+  }
+}

--- a/app/src/main/org/runnerup/view/AccountActivity.java
+++ b/app/src/main/org/runnerup/view/AccountActivity.java
@@ -42,9 +42,14 @@ import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import org.runnerup.R;
@@ -112,6 +117,19 @@ public class AccountActivity extends AppCompatActivity implements Constants {
       Button btn = findViewById(R.id.disconnect_account_button);
       btn.setOnClickListener(disconnectButtonClick);
     }
+    View yourRootView = findViewById(R.id.account_rootview);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        yourRootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/AccountActivity.java
+++ b/app/src/main/org/runnerup/view/AccountActivity.java
@@ -42,14 +42,9 @@ import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import org.runnerup.R;
@@ -60,6 +55,7 @@ import org.runnerup.export.RunnerUpLiveSynchronizer;
 import org.runnerup.export.SyncManager;
 import org.runnerup.export.Synchronizer;
 import org.runnerup.util.Bitfield;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.widget.WidgetUtil;
 import org.runnerup.workout.FileFormats;
 
@@ -117,19 +113,8 @@ public class AccountActivity extends AppCompatActivity implements Constants {
       Button btn = findViewById(R.id.disconnect_account_button);
       btn.setOnClickListener(disconnectButtonClick);
     }
-    View yourRootView = findViewById(R.id.account_rootview);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        yourRootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, insets.top, insets.right, insets.bottom);
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+
+    ViewUtil.Insets(findViewById(R.id.account_rootview), false);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/AccountListActivity.java
+++ b/app/src/main/org/runnerup/view/AccountListActivity.java
@@ -44,6 +44,10 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.cursoradapter.widget.CursorAdapter;
 import androidx.loader.app.LoaderManager.LoaderCallbacks;
 import androidx.loader.content.Loader;
@@ -103,6 +107,21 @@ public class AccountListActivity extends AppCompatActivity
     listView.setOnItemClickListener(configureItemClick);
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    View rootView = findViewById(R.id.account_list_view);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/AccountListActivity.java
+++ b/app/src/main/org/runnerup/view/AccountListActivity.java
@@ -44,10 +44,6 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.cursoradapter.widget.CursorAdapter;
 import androidx.loader.app.LoaderManager.LoaderCallbacks;
 import androidx.loader.content.Loader;
@@ -59,6 +55,7 @@ import org.runnerup.export.Synchronizer;
 import org.runnerup.export.Synchronizer.Status;
 import org.runnerup.util.Bitfield;
 import org.runnerup.util.SimpleCursorLoader;
+import org.runnerup.util.ViewUtil;
 
 public class AccountListActivity extends AppCompatActivity
     implements Constants, LoaderCallbacks<Cursor> {
@@ -107,21 +104,7 @@ public class AccountListActivity extends AppCompatActivity
     listView.setOnItemClickListener(configureItemClick);
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-    View rootView = findViewById(R.id.account_list_view);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.account_list_view), true);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/AudioCueSettingsFragment.java
+++ b/app/src/main/org/runnerup/view/AudioCueSettingsFragment.java
@@ -21,6 +21,10 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceClickListener;
 import androidx.preference.PreferenceFragmentCompat;
@@ -150,6 +154,19 @@ public class AudioCueSettingsFragment extends PreferenceFragmentCompat {
       }
       spinner.setOnSetValueListener(onSetValueListener);
     }
+
+    ViewCompat.setOnApplyWindowInsetsListener(
+        view,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0);
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   private void removePrefs(int[] remove) {

--- a/app/src/main/org/runnerup/view/CreateAdvancedWorkout.java
+++ b/app/src/main/org/runnerup/view/CreateAdvancedWorkout.java
@@ -10,20 +10,16 @@ import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TableRow;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONException;
 import org.runnerup.R;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.widget.TitleSpinner;
 import org.runnerup.workout.RepeatStep;
 import org.runnerup.workout.Step;
@@ -82,20 +78,8 @@ public class CreateAdvancedWorkout extends AppCompatActivity {
     } catch (Exception e) {
       handleWorkoutFileException(e);
     }
-    View rootView = findViewById(R.id.create_advanced_workout_view);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+
+    ViewUtil.Insets(findViewById(R.id.create_advanced_workout_view), true);
   }
 
   private void createAdvancedWorkout(String name, boolean workoutExists)

--- a/app/src/main/org/runnerup/view/CreateAdvancedWorkout.java
+++ b/app/src/main/org/runnerup/view/CreateAdvancedWorkout.java
@@ -10,9 +10,14 @@ import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TableRow;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,6 +82,20 @@ public class CreateAdvancedWorkout extends AppCompatActivity {
     } catch (Exception e) {
       handleWorkoutFileException(e);
     }
+    View rootView = findViewById(R.id.create_advanced_workout_view);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(View v, WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   private void createAdvancedWorkout(String name, boolean workoutExists)

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -56,6 +56,10 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,6 +114,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
 
   private TitleSpinner sport = null;
   private EditText notes = null;
+  private View rootView;
 
   private MapWrapper mapWrapper = null;
 
@@ -127,9 +132,11 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     if (USING_OSMDROID || BuildConfig.MAPBOX_ENABLED > 0) {
       MapWrapper.start(this);
       setContentView(R.layout.detail);
+      rootView = findViewById(R.id.detail_view);
     } else {
       // No MapBox key nor Osmdroid, load without mapview, do not set mapWrapper
       setContentView(R.layout.detail_nomap);
+      rootView = findViewById(R.id.detail_nomap_view);
     }
     Toolbar toolbar = findViewById(R.id.actionbar);
     setSupportActionBar(toolbar);
@@ -257,6 +264,27 @@ public class DetailActivity extends AppCompatActivity implements Constants {
                 }
               }
             });
+
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            int bottomPadding =
+                saveButton.getVisibility() == View.VISIBLE
+                        || uploadButton.getVisibility() == View.VISIBLE
+                    ? insets.bottom
+                    : 0;
+            v.setPadding(insets.left, 0, insets.right, bottomPadding);
+
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   private void setEdit(boolean value) {
@@ -265,6 +293,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     else saveButton.setVisibility(View.GONE);
     WidgetUtil.setEditable(notes, value);
     sport.setEnabled(value);
+    ViewCompat.requestApplyInsets(rootView);
   }
 
   private void setUploadVisibility() {
@@ -274,6 +303,7 @@ public class DetailActivity extends AppCompatActivity implements Constants {
     } else {
       uploadButton.setVisibility(View.GONE);
     }
+    ViewCompat.requestApplyInsets(rootView);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/HRSettingsActivity.java
+++ b/app/src/main/org/runnerup/view/HRSettingsActivity.java
@@ -43,15 +43,10 @@ import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import com.jjoe64.graphview.DefaultLabelFormatter;
 import com.jjoe64.graphview.GraphView;
@@ -69,6 +64,7 @@ import org.runnerup.hr.HRManager;
 import org.runnerup.hr.HRProvider;
 import org.runnerup.hr.HRProvider.HRClient;
 import org.runnerup.util.Formatter;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.widget.WidgetUtil;
 
 public class HRSettingsActivity extends AppCompatActivity implements HRClient {
@@ -139,22 +135,7 @@ public class HRSettingsActivity extends AppCompatActivity implements HRClient {
     scanButton.setOnClickListener(scanButtonClick);
     connectButton = findViewById(R.id.connect_button);
     connectButton.setOnClickListener(arg0 -> connect());
-    View rootView = findViewById(R.id.hr_settings_view);
-
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.hr_settings_view), true);
 
     formatter = new Formatter(this);
     {

--- a/app/src/main/org/runnerup/view/HRSettingsActivity.java
+++ b/app/src/main/org/runnerup/view/HRSettingsActivity.java
@@ -43,10 +43,15 @@ import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import com.jjoe64.graphview.DefaultLabelFormatter;
 import com.jjoe64.graphview.GraphView;
@@ -134,6 +139,22 @@ public class HRSettingsActivity extends AppCompatActivity implements HRClient {
     scanButton.setOnClickListener(scanButtonClick);
     connectButton = findViewById(R.id.connect_button);
     connectButton.setOnClickListener(arg0 -> connect());
+    View rootView = findViewById(R.id.hr_settings_view);
+
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
 
     formatter = new Formatter(this);
     {

--- a/app/src/main/org/runnerup/view/HRZonesActivity.java
+++ b/app/src/main/org/runnerup/view/HRZonesActivity.java
@@ -34,13 +34,8 @@ import android.widget.EditText;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import java.util.Locale;
 import java.util.Vector;
 import org.runnerup.R;
@@ -48,6 +43,7 @@ import org.runnerup.common.util.Constants;
 import org.runnerup.util.HRZoneCalculator;
 import org.runnerup.util.HRZones;
 import org.runnerup.util.SafeParse;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.widget.TitleSpinner;
 import org.runnerup.widget.WidgetUtil;
 
@@ -209,21 +205,7 @@ public class HRZonesActivity extends AppCompatActivity implements Constants {
           }
         });
 
-    View rootView = findViewById(R.id.heartratezone_view);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.heartratezone_view), true);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/HRZonesActivity.java
+++ b/app/src/main/org/runnerup/view/HRZonesActivity.java
@@ -34,8 +34,13 @@ import android.widget.EditText;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.util.Locale;
 import java.util.Vector;
 import org.runnerup.R;
@@ -201,6 +206,22 @@ public class HRZonesActivity extends AppCompatActivity implements Constants {
         (spinner, ok) -> {
           if (ok) {
             recomputeZones();
+          }
+        });
+
+    View rootView = findViewById(R.id.heartratezone_view);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
           }
         });
   }

--- a/app/src/main/org/runnerup/view/MainLayout.java
+++ b/app/src/main/org/runnerup/view/MainLayout.java
@@ -38,11 +38,19 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup;
 import android.webkit.WebView;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TabHost;
+import android.widget.TabWidget;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.io.File;
 import java.io.IOException;
@@ -203,6 +211,35 @@ public class MainLayout extends TabActivity {
       Log.i(getClass().getSimpleName(), "Importing database from " + filePath);
       DBHelper.importDatabase(MainLayout.this, filePath);
     }
+
+    View rootLayout = findViewById(android.R.id.tabhost).getRootView();
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootLayout,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets systemBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBarsInsets.left, systemBarsInsets.top, systemBarsInsets.right, 0);
+            TabWidget tabWidget = getTabWidget();
+            if (tabWidget != null) {
+              ViewGroup.MarginLayoutParams tabWidgetLp =
+                  (ViewGroup.MarginLayoutParams) tabWidget.getLayoutParams();
+              tabWidgetLp.leftMargin = systemBarsInsets.left;
+              tabWidgetLp.rightMargin = systemBarsInsets.right;
+              tabWidgetLp.bottomMargin = systemBarsInsets.bottom;
+              tabWidget.setLayoutParams(tabWidgetLp);
+            }
+
+            FrameLayout tabContent =
+                getTabHost().getTabContentView(); // This is android.R.id.tabcontent
+            if (tabContent != null) {
+              tabContent.setPadding(systemBarsInsets.left, 0, systemBarsInsets.right, 0);
+            }
+            return WindowInsetsCompat.CONSUMED; // If fully handled
+          }
+        });
   }
 
   private void handleBundled(AssetManager mgr, String srcBase, String dstBase) {

--- a/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
@@ -42,8 +42,13 @@ import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -147,6 +152,24 @@ public class ManageWorkoutsActivity extends AppCompatActivity implements Constan
             .show();
       }
     }
+
+    View rootView = findViewById(R.id.manage_workouts_view);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
+
     // launch home Activity (with FLAG_ACTIVITY_CLEAR_TOP)
   }
 

--- a/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
+++ b/app/src/main/org/runnerup/view/ManageWorkoutsActivity.java
@@ -42,13 +42,8 @@ import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -71,6 +66,7 @@ import org.runnerup.export.SyncManager.Callback;
 import org.runnerup.export.SyncManager.WorkoutRef;
 import org.runnerup.export.Synchronizer;
 import org.runnerup.export.Synchronizer.Status;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.workout.Workout;
 import org.runnerup.workout.WorkoutSerializer;
 
@@ -153,22 +149,7 @@ public class ManageWorkoutsActivity extends AppCompatActivity implements Constan
       }
     }
 
-    View rootView = findViewById(R.id.manage_workouts_view);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.manage_workouts_view), true);
 
     // launch home Activity (with FLAG_ACTIVITY_CLEAR_TOP)
   }

--- a/app/src/main/org/runnerup/view/RunActivity.java
+++ b/app/src/main/org/runnerup/view/RunActivity.java
@@ -46,10 +46,7 @@ import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,6 +63,7 @@ import org.runnerup.tracker.Tracker;
 import org.runnerup.tracker.component.TrackerHRM;
 import org.runnerup.util.Formatter;
 import org.runnerup.util.TickListener;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.workout.Intensity;
 import org.runnerup.workout.Scope;
 import org.runnerup.workout.Step;
@@ -188,21 +186,7 @@ public class RunActivity extends AppCompatActivity implements TickListener {
                 // ignore back while in an activity
               }
             });
-    View rootView = findViewById(R.id.start_view);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.start_view), true);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/RunActivity.java
+++ b/app/src/main/org/runnerup/view/RunActivity.java
@@ -46,7 +46,10 @@ import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -185,6 +188,21 @@ public class RunActivity extends AppCompatActivity implements TickListener {
                 // ignore back while in an activity
               }
             });
+    View rootView = findViewById(R.id.start_view);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/UploadActivity.java
+++ b/app/src/main/org/runnerup/view/UploadActivity.java
@@ -36,13 +36,8 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -56,6 +51,7 @@ import org.runnerup.export.Synchronizer;
 import org.runnerup.export.Synchronizer.Status;
 import org.runnerup.util.Formatter;
 import org.runnerup.util.SyncActivityItem;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.workout.Sport;
 
 public class UploadActivity extends AppCompatActivity implements Constants {
@@ -120,21 +116,7 @@ public class UploadActivity extends AppCompatActivity implements Constants {
       }
     }
 
-    View rootView = findViewById(R.id.upload_rootview);
-    ViewCompat.setOnApplyWindowInsetsListener(
-        rootView,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(insets.left, 0, insets.right, insets.bottom);
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
+    ViewUtil.Insets(findViewById(R.id.upload_rootview), true);
 
     fillData();
     {

--- a/app/src/main/org/runnerup/view/UploadActivity.java
+++ b/app/src/main/org/runnerup/view/UploadActivity.java
@@ -36,8 +36,13 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -114,6 +119,22 @@ public class UploadActivity extends AppCompatActivity implements Constants {
         dwbtn.setVisibility(View.GONE);
       }
     }
+
+    View rootView = findViewById(R.id.upload_rootview);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        rootView,
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(insets.left, 0, insets.right, insets.bottom);
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
 
     fillData();
     {

--- a/app/src/main/org/runnerup/widget/SpinnerPresenter.java
+++ b/app/src/main/org/runnerup/widget/SpinnerPresenter.java
@@ -210,7 +210,7 @@ public class SpinnerPresenter {
                 .getViewAdapter()
                 .getItem(item)
                 .toString()); // I assume that it's called with a string because of the spinner_txt
-                              // type, but don't know for sure
+        // type, but don't know for sure
       }
     } else {
       setValue(getRealValue(item));
@@ -565,7 +565,7 @@ public class SpinnerPresenter {
         int intVal = find(mSpin.getViewAdapter(), value);
         mCurrValue =
             intVal; // here because onclicklistener doesn't react to changing to the same value
-                    // twice
+        // twice
         mSpin.setViewSelection(intVal);
       }
     }


### PR DESCRIPTION
Adopt Android 15 edge-to-edge inserts. apply where required. Buttons, tabbar and menubar must not be extended to the top system bar and navigation area.

This is required to target Android 16.
There is a very minor benefit on Android 15 devices, the map is extended.
Note though that the statusbar is no longer colored (it is quite difficult to achieve this.

The TabActivity layout has been deprecated since Android 4 or so, it need to be replaced... I was stuck some time on getting that to apply here.