### PR TITLE
fix: edge-to-edge insets

### DIFF
--- a/app/src/main/org/runnerup/export/oauth2client/OAuth2Activity.java
+++ b/app/src/main/org/runnerup/export/oauth2client/OAuth2Activity.java
@@ -42,6 +42,7 @@ import org.runnerup.common.util.Constants.DB;
 import org.runnerup.export.Synchronizer;
 import org.runnerup.export.util.FormValues;
 import org.runnerup.export.util.SyncHelper;
+import org.runnerup.util.ViewUtil;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class OAuth2Activity extends AppCompatActivity {
@@ -266,6 +267,7 @@ public class OAuth2Activity extends AppCompatActivity {
         });
 
     setContentView(wv);
+    ViewUtil.Insets(wv, true);
   }
 
   @Override

--- a/app/src/main/org/runnerup/view/AudioCueSettingsActivity.java
+++ b/app/src/main/org/runnerup/view/AudioCueSettingsActivity.java
@@ -19,7 +19,13 @@ package org.runnerup.view;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import org.runnerup.R;
 import org.runnerup.widget.WidgetUtil;
 
@@ -48,5 +54,18 @@ public class AudioCueSettingsActivity extends AppCompatActivity {
           .replace(R.id.settings_fragment_container, AudioCueSettingsFragment.class, bundle)
           .commit();
     }
+
+    ViewCompat.setOnApplyWindowInsetsListener(
+        findViewById(R.id.settings_fragment_container),
+        new OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
+            Insets systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0);
+            return WindowInsetsCompat.CONSUMED;
+          }
+        });
   }
 }

--- a/app/src/main/org/runnerup/view/AudioCueSettingsFragment.java
+++ b/app/src/main/org/runnerup/view/AudioCueSettingsFragment.java
@@ -21,10 +21,6 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceClickListener;
 import androidx.preference.PreferenceFragmentCompat;
@@ -154,19 +150,6 @@ public class AudioCueSettingsFragment extends PreferenceFragmentCompat {
       }
       spinner.setOnSetValueListener(onSetValueListener);
     }
-
-    ViewCompat.setOnApplyWindowInsetsListener(
-        view,
-        new OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public WindowInsetsCompat onApplyWindowInsets(
-              @NonNull View v, @NonNull WindowInsetsCompat windowInsets) {
-            Insets systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0);
-            return WindowInsetsCompat.CONSUMED;
-          }
-        });
   }
 
   private void removePrefs(int[] remove) {

--- a/app/src/main/org/runnerup/view/ManualActivity.java
+++ b/app/src/main/org/runnerup/view/ManualActivity.java
@@ -37,6 +37,7 @@ import org.runnerup.common.util.Constants.DB;
 import org.runnerup.db.DBHelper;
 import org.runnerup.util.Formatter;
 import org.runnerup.util.SafeParse;
+import org.runnerup.util.ViewUtil;
 import org.runnerup.widget.SpinnerInterface.OnSetValueListener;
 import org.runnerup.widget.TitleSpinner;
 
@@ -74,6 +75,8 @@ public class ManualActivity extends AppCompatActivity {
     manualPace = findViewById(R.id.manual_pace);
     manualPace.setVisibility(View.GONE);
     manualNotes = findViewById(R.id.manual_notes);
+
+    ViewUtil.Insets(findViewById(R.id.tab_manual), true);
   }
 
   @Override


### PR DESCRIPTION
This pull request addresses an oversight from #1226 where insets were not applied to the following activities, causing UI elements to overlap with system bars.

- OAuth2Activity
- ManualActivity

This PR also fixes an issue when switching/selecting between different audio cues in AudioCueSettingsFragment. The new fragment's UI got obscured by the AppBar (due to lost insets?).

Tested in Android Studio on AVDs running Android 11 and Android 15.