### PR TITLE
Fix problem occuring with really short intervals (e.g 15s)

### DIFF
--- a/app/src/main/org/runnerup/workout/feedback/AudioCountdownFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/AudioCountdownFeedback.java
@@ -18,7 +18,6 @@
 package org.runnerup.workout.feedback;
 
 import android.content.Context;
-import android.speech.tts.TextToSpeech;
 import java.util.HashMap;
 import org.runnerup.util.Formatter;
 import org.runnerup.workout.Dimension;
@@ -60,7 +59,7 @@ public class AudioCountdownFeedback extends Feedback {
 
     if (remaining > 0) {
       String msg = formatter.formatRemaining(Formatter.Format.CUE_SHORT, dimension, remaining);
-      textToSpeech.speak(msg, TextToSpeech.QUEUE_ADD, null);
+      textToSpeech.speak(msg, AudioFeedback.PRIO_COUNTDOWN, /* flush= */true, null);
     }
   }
 }

--- a/app/src/main/org/runnerup/workout/feedback/AudioCountdownFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/AudioCountdownFeedback.java
@@ -59,7 +59,7 @@ public class AudioCountdownFeedback extends Feedback {
 
     if (remaining > 0) {
       String msg = formatter.formatRemaining(Formatter.Format.CUE_SHORT, dimension, remaining);
-      textToSpeech.speak(msg, AudioFeedback.PRIO_COUNTDOWN, /* flush= */true, null);
+      textToSpeech.speak(msg, UtterancePrio.PRIO_COUNTDOWN, /* flush= */ true, null);
     }
   }
 }

--- a/app/src/main/org/runnerup/workout/feedback/AudioFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/AudioFeedback.java
@@ -18,7 +18,6 @@
 package org.runnerup.workout.feedback;
 
 import android.content.Context;
-import android.speech.tts.TextToSpeech;
 import android.widget.Toast;
 import java.util.HashMap;
 import org.runnerup.BuildConfig;
@@ -40,6 +39,11 @@ public class AudioFeedback extends Feedback {
   private Intensity intensity;
   RUTextToSpeech textToSpeech;
   Formatter formatter;
+
+  // Higher prio will interrupt (flush) lower prio.
+  public static final int PRIO_CUE = 0;
+  public static final int PRIO_COACH = 1;
+  public static final int PRIO_COUNTDOWN = 2;
 
   public AudioFeedback(int msgId) {
     super();
@@ -121,7 +125,7 @@ public class AudioFeedback extends Feedback {
       if (BuildConfig.DEBUG) {
         Toast.makeText(ctx, msg, Toast.LENGTH_SHORT).show();
       }
-      textToSpeech.speak(msg, TextToSpeech.QUEUE_ADD, null);
+      textToSpeech.speak(msg, PRIO_CUE, /* flush= */false, null);
     }
   }
 }

--- a/app/src/main/org/runnerup/workout/feedback/AudioFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/AudioFeedback.java
@@ -40,11 +40,6 @@ public class AudioFeedback extends Feedback {
   RUTextToSpeech textToSpeech;
   Formatter formatter;
 
-  // Higher prio will interrupt (flush) lower prio.
-  public static final int PRIO_CUE = 0;
-  public static final int PRIO_COACH = 1;
-  public static final int PRIO_COUNTDOWN = 2;
-
   public AudioFeedback(int msgId) {
     super();
     this.msgId = msgId;
@@ -125,7 +120,7 @@ public class AudioFeedback extends Feedback {
       if (BuildConfig.DEBUG) {
         Toast.makeText(ctx, msg, Toast.LENGTH_SHORT).show();
       }
-      textToSpeech.speak(msg, PRIO_CUE, /* flush= */false, null);
+      textToSpeech.speak(msg, UtterancePrio.PRIO_CUE, /* flush= */false, null);
     }
   }
 }

--- a/app/src/main/org/runnerup/workout/feedback/CoachFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/CoachFeedback.java
@@ -18,7 +18,6 @@
 package org.runnerup.workout.feedback;
 
 import android.content.Context;
-import android.speech.tts.TextToSpeech;
 import org.runnerup.R;
 import org.runnerup.util.Formatter;
 import org.runnerup.workout.Dimension;
@@ -74,7 +73,8 @@ public class CoachFeedback extends AudioFeedback {
               + " "
               + formatter.format(Formatter.Format.CUE_LONG, dimension, val)
               + msg,
-          TextToSpeech.QUEUE_ADD,
+          AudioFeedback.PRIO_COACH,
+          /* flush= */true,
           null);
     }
   }

--- a/app/src/main/org/runnerup/workout/feedback/CoachFeedback.java
+++ b/app/src/main/org/runnerup/workout/feedback/CoachFeedback.java
@@ -73,8 +73,8 @@ public class CoachFeedback extends AudioFeedback {
               + " "
               + formatter.format(Formatter.Format.CUE_LONG, dimension, val)
               + msg,
-          AudioFeedback.PRIO_COACH,
-          /* flush= */true,
+          UtterancePrio.PRIO_COACH,
+          /* flush= */ true,
           null);
     }
   }

--- a/app/src/main/org/runnerup/workout/feedback/RUTextToSpeech.java
+++ b/app/src/main/org/runnerup/workout/feedback/RUTextToSpeech.java
@@ -46,10 +46,10 @@ public class RUTextToSpeech {
     final HashMap<String, String> params;
     final String id;
 
-    public Entry(String text, int prio, boolean flush, HashMap<String, String> params, String id) {
+    public Entry(String text, UtterancePrio prio, boolean flush, HashMap<String, String> params, String id) {
       this.text = text;
       this.flush = flush;
-      this.prio = prio;
+      this.prio = prio.value;
       this.params = params;
       this.id = id;
     }
@@ -100,12 +100,12 @@ public class RUTextToSpeech {
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  int speak(String text, int prio, boolean flush, HashMap<String, String> params) {
+  int speak(String text, UtterancePrio prio, boolean flush, HashMap<String, String> params) {
     if (!isAvailable()) {
       return 0;
     }
 
-    boolean trace = true;
+    final boolean trace = true;
     if (!cueSet.contains(text)) {
       //noinspection ConstantConditions
       if (trace) {

--- a/app/src/main/org/runnerup/workout/feedback/RUTextToSpeech.java
+++ b/app/src/main/org/runnerup/workout/feedback/RUTextToSpeech.java
@@ -23,9 +23,11 @@ import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
 import android.util.Log;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.runnerup.util.Formatter;
 
 public class RUTextToSpeech {
@@ -34,15 +36,22 @@ public class RUTextToSpeech {
   private final boolean mute;
   private final TextToSpeech textToSpeech;
   private final AudioManager audioManager;
+  private final AtomicBoolean hasAudioFocus = new AtomicBoolean(false);
   private long id = (long) (System.nanoTime() + (1000 * Math.random()));
 
   class Entry {
+    final int prio;
+    final boolean flush;
     final String text;
     final HashMap<String, String> params;
+    final String id;
 
-    public Entry(String text, HashMap<String, String> params) {
+    public Entry(String text, int prio, boolean flush, HashMap<String, String> params, String id) {
       this.text = text;
+      this.flush = flush;
+      this.prio = prio;
       this.params = params;
+      this.id = id;
     }
   }
 
@@ -91,92 +100,58 @@ public class RUTextToSpeech {
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  int speak(String text, int queueMode, HashMap<String, String> params) {
+  int speak(String text, int prio, boolean flush, HashMap<String, String> params) {
     if (!isAvailable()) {
       return 0;
     }
 
-    final boolean trace = true;
-    if (queueMode == TextToSpeech.QUEUE_FLUSH) {
-      // Unused in RU
+    boolean trace = true;
+    if (!cueSet.contains(text)) {
       //noinspection ConstantConditions
       if (trace) {
-        Log.e(getClass().getName(), "speak (mute: " + mute + "): " + text);
+        Log.e(getClass().getName(), "buffer speak: " + text);
       }
-      // speak directly
-      if (mute) {
-        return speakWithMute(text, queueMode, params);
-      } else {
-        return textToSpeech.speak(text, queueMode, params);
-      }
+      cueSet.add(text);
+      cueList.add(new Entry(text, prio, flush, params, getId(text)));
     } else {
-      if (!cueSet.contains(text)) {
-        //noinspection ConstantConditions
-        if (trace) {
-          Log.e(getClass().getName(), "buffer speak: " + text);
-        }
-        cueSet.add(text);
-        cueList.add(new Entry(text, params));
-      } else {
-        //noinspection ConstantConditions
-        if (trace) {
-          Log.e(getClass().getName(), "skip buffer (duplicate) speak: " + text);
-        }
+      //noinspection ConstantConditions
+      if (trace) {
+        Log.e(getClass().getName(), "skip buffer (duplicate) speak: " + text);
       }
-      return 0;
     }
+    return 0;
   }
 
-  /**
-   * Requests audio focus before speaking, if no focus is given nothing is said.
-   *
-   * @param text
-   * @param queueMode
-   * @param params
-   * @return
-   */
-  private int speakWithMute(String text, int queueMode, HashMap<String, String> params) {
-    if (!isAvailable()) {
-      return TextToSpeech.ERROR;
-    }
-
-    if (requestFocus()) {
-      final String utId = getId(text);
-      outstanding.add(utId);
-
-      if (params == null) {
-        params = new HashMap<>();
-      }
-      params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utId);
-      int res = textToSpeech.speak(text, queueMode, params);
-      if (res == TextToSpeech.ERROR) {
-        outstanding.remove(utId);
-      }
-      if (outstanding.isEmpty()) {
-        audioManager.abandonAudioFocus(null);
-      }
-      return res;
-    }
-    Log.e(getClass().getName(), "Could not get audio focus.");
-    return TextToSpeech.ERROR;
-  }
-
-  private final HashSet<String> outstanding = new HashSet<>();
+  private final HashMap<String, Entry> outstanding = new HashMap<>();
 
   void utteranceCompleted(String id) {
     outstanding.remove(id);
-    if (outstanding.isEmpty()) {
-      audioManager.abandonAudioFocus(null);
-    }
+    maybeAbandonAudioFocus();
   }
 
   private boolean requestFocus() {
+    if (hasAudioFocus.get()) {
+      return true;
+    }
     int result =
         audioManager.requestAudioFocus(
             null, // afChangeListener,
             AudioManager.STREAM_MUSIC,
             AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
-    return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    var granted = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    hasAudioFocus.set(granted);
+    return granted;
+  }
+
+  private void maybeAbandonAudioFocus() {
+    if (!hasAudioFocus.get()) {
+      return;
+    }
+    if (!outstanding.isEmpty()) {
+      return;
+    }
+    hasAudioFocus.set(false);
+    audioManager.abandonAudioFocus(null);
   }
 
   public void emit() {
@@ -186,39 +161,62 @@ public class RUTextToSpeech {
     if (cueSet.isEmpty()) {
       return;
     }
-    if (mute && requestFocus()) {
-      for (Entry e : cueList) {
-        final String utId = getId(e.text);
-        outstanding.add(utId);
+    if (mute && !requestFocus()) {
+      // Log error ?
+      return;
+    }
 
-        HashMap<String, String> params = e.params;
-        if (params == null) {
-          params = new HashMap<>();
-        }
-        params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utId);
-        int res = textToSpeech.speak(e.text, TextToSpeech.QUEUE_ADD, params);
-        if (res == TextToSpeech.ERROR) {
-          Log.e(
-              getClass().getName(),
-              "res == ERROR emit() text: "
-                  + e.text
-                  + ", utId: "
-                  + utId
-                  + ") outstanding.size(): "
-                  + outstanding.size());
-          outstanding.remove(utId);
-        }
-      }
-      if (outstanding.isEmpty()) {
-        audioManager.abandonAudioFocus(null);
-      }
-    } else {
-      for (Entry e : cueList) {
-        textToSpeech.speak(e.text, TextToSpeech.QUEUE_ADD, e.params);
+    // Sort pending utterances accoring to prio.
+    Collections.sort(cueList, (x,y) -> -Integer.compare(x.prio, y.prio));
+
+    int mode = TextToSpeech.QUEUE_ADD;
+    int maxPrio = cueList.get(0).prio;
+
+    // Check outstanding.
+    if (!outstanding.isEmpty()) {
+      int outstandingPrio = getMaxOutstandingPrio();
+      if (maxPrio >= outstandingPrio) {
+        mode = TextToSpeech.QUEUE_FLUSH;
+        outstanding.clear();
       }
     }
+
+    for (Entry e : cueList) {
+      HashMap<String, String> params = e.params;
+      if (params == null) {
+        params = new HashMap<>();
+      }
+
+      params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, e.id);
+
+      int res = textToSpeech.speak(e.text, mode, params);
+      if (res == TextToSpeech.ERROR) {
+        Log.e(
+            getClass().getName(),
+              "res == ERROR emit() text: "
+              + e.text
+              + ", utId: "
+              + e.id
+              + ") outstanding.size(): "
+              + outstanding.size());
+      } else {
+        outstanding.put(e.id, e);
+        // Subsequent utterances will be added.
+        mode = TextToSpeech.QUEUE_ADD;
+      }
+    }
+
     cueSet.clear();
     cueList.clear();
+    maybeAbandonAudioFocus();
+  }
+
+  int getMaxOutstandingPrio() {
+    int prio = -1;
+    for (Entry e : outstanding.values()) {
+      prio = Math.max(prio, e.prio);
+    }
+    return prio;
   }
 }
 

--- a/app/src/main/org/runnerup/workout/feedback/UtterancePrio.java
+++ b/app/src/main/org/runnerup/workout/feedback/UtterancePrio.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 jonas.oreland@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.runnerup.workout.feedback;
+
+// Higher prio will interrupt (flush) lower prio.
+enum UtterancePrio {
+  PRIO_CUE(0),
+  PRIO_COACH(1),
+  PRIO_COUNTDOWN(2);
+
+  private UtterancePrio(int val) { value = val; }
+  final int value;
+};


### PR DESCRIPTION
In that case the audio cues would "add up" so that one missed the start/stop and count downs.

This patch introduces a PRIO so that higher prio interrupt lower prio.

This fixes immediate problem...maybe we should avoid adding several "speak" commands in total and do our own scheduling, using some sort of key per cue...todo...

Tested/iterated a couple of times with short intervals, and tested with soft runs (no change)