### PR TITLE
Update endurain api endpoints

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,7 +170,7 @@ dependencies {
         latestImplementation "com.google.android.gms:play-services-wearable:${rootProject.ext.googlePlayServicesWearableVersion}"
     }
 
-    implementation "com.squareup.okhttp3:okhttp:3.12.3"
+    implementation "com.squareup.okhttp3:okhttp:5.1.0"
     latestImplementation 'com.getpebble:pebblekit:4.0.1'
     if (rootProject.ext.allowNonFree) {
         // MapBox uses telemetry, without Play there may be exceptions from mapbox (OK to ignore)

--- a/app/src/main/org/runnerup/export/EndurainSynchronizer.java
+++ b/app/src/main/org/runnerup/export/EndurainSynchronizer.java
@@ -45,8 +45,8 @@ public class EndurainSynchronizer extends DefaultSynchronizer {
 
   public static final String NAME = "Endurain";
 
-  private static final String TOKEN_URL_PATH = "/token";
-  private static final String UPLOAD_URL_PATH = "/activities/create/upload";
+  private static final String TOKEN_URL_PATH = "/api/v1/token";
+  private static final String UPLOAD_URL_PATH = "/api/v1/activities/create/upload";
 
   private long id = 0;
 


### PR DESCRIPTION
This PR fixes the endurain api endpoints to upload activities to the current endurain selfhosted backend.

This fixes #1205 

Please have a look on the increased okhttp version.
I had some errors logged while using this okhttp version on Android 16 Pixel 9a Emulator so probably it should be updated to get rid of reflection errors referencing internal apis (caused by okhttp)

It is also working with the old okhttp version so if there is anything against updating it could stay as the old version.

@jonasoreland can you please have a look?

Here is the coresponding log regarding okhttp:
```
025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/ConscryptEngineSocket;->setUseSessionTickets(Z)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setUseSessionTickets(Z)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setUseSessionTickets(Z)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/ConscryptEngineSocket;->setHostname(Ljava/lang/String;)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setHostname(Ljava/lang/String;)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setHostname(Ljava/lang/String;)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setAlpnProtocols([B)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.236  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setAlpnProtocols([B)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.272  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->getAlpnSelectedProtocol()[B (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:17.272  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->getAlpnSelectedProtocol()[B (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.256  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/ConscryptEngineSocket;->setUseSessionTickets(Z)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.256  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setUseSessionTickets(Z)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.256  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setUseSessionTickets(Z)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.257  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/ConscryptEngineSocket;->setHostname(Ljava/lang/String;)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.257  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setHostname(Ljava/lang/String;)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.257  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setHostname(Ljava/lang/String;)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.257  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setAlpnProtocols([B)V (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.257  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->setAlpnProtocols([B)V (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.275  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/OpenSSLSocketImpl;->getAlpnSelectedProtocol()[B (runtime_flags=CorePlatformApi, domain=core-platform, api=max-target-q,core-platform-api) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-07-28 21:08:22.275  9816-9883  .runnerup.debug         org.runnerup.debug                   E  hiddenapi: Accessing hidden method Lcom/android/org/conscrypt/AbstractConscryptSocket;->getAlpnSelectedProtocol()[B (runtime_flags=0, domain=core-platform, api=max-target-q) from Lokhttp3/internal/platform/OptionalMethod; (domain=app) using reflection: denied
2025-
```