### PR TITLE
Deprecate sportEntries (string-array) in favor of static map in Sport

### DIFF
--- a/app/src/main/org/runnerup/view/StartFragment.java
+++ b/app/src/main/org/runnerup/view/StartFragment.java
@@ -89,6 +89,7 @@ import org.runnerup.widget.SpinnerInterface.OnSetValueListener;
 import org.runnerup.widget.TitleSpinner;
 import org.runnerup.widget.WidgetUtil;
 import org.runnerup.workout.Dimension;
+import org.runnerup.workout.Sport;
 import org.runnerup.workout.Workout;
 import org.runnerup.workout.Workout.StepListEntry;
 import org.runnerup.workout.WorkoutBuilder;
@@ -193,8 +194,8 @@ public class StartFragment extends Fragment implements TickListener, GpsInformat
 
     ClassicSpinner sportSpinner = view.findViewById(R.id.sport_spinner);
     ArrayAdapter<CharSequence> adapter =
-        ArrayAdapter.createFromResource(
-            context, org.runnerup.common.R.array.sportEntries, R.layout.actionbar_spinner);
+        new ArrayAdapter<CharSequence>(
+            context, R.layout.actionbar_spinner, Sport.getStringArray(getResources()));
     adapter.setDropDownViewResource(R.layout.actionbar_dropdown_spinner);
     sportSpinner.setAdapter(adapter);
     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/org/runnerup/workout/Sport.java
+++ b/app/src/main/org/runnerup/workout/Sport.java
@@ -18,6 +18,9 @@
 package org.runnerup.workout;
 
 import android.content.res.Resources;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.runnerup.R;
 import org.runnerup.common.util.Constants.DB;
 
@@ -38,6 +41,46 @@ public enum Sport {
     return dbValue;
   }
 
+  private static Map<Integer, Integer> createSportToStringMap() {
+    Map<Integer, Integer> result = new HashMap<>();
+    result.put(DB.ACTIVITY.SPORT_RUNNING, org.runnerup.common.R.string.SPORT_RUNNING);
+    result.put(DB.ACTIVITY.SPORT_BIKING, org.runnerup.common.R.string.SPORT_BIKING);
+    result.put(DB.ACTIVITY.SPORT_OTHER, org.runnerup.common.R.string.SPORT_OTHER);
+    result.put(DB.ACTIVITY.SPORT_ORIENTEERING, org.runnerup.common.R.string.SPORT_ORIENTEERING);
+    result.put(DB.ACTIVITY.SPORT_WALKING, org.runnerup.common.R.string.SPORT_WALKING);
+    return Collections.unmodifiableMap(result);
+  }
+  private static final Map<Integer,Integer> gSportToStringMap = createSportToStringMap();
+
+  public static String[] getStringArray(Resources res) {
+    String[] ret = new String[DB.ACTIVITY.SPORT_MAX + 1];
+
+    {  // Backward compability. TODO: Remove once new sport strings are translated.
+      int resId = org.runnerup.common.R.array.sportEntries;
+      String[] org = res.getStringArray(resId);
+      for (int i = 0; i < org.length && i < ret.length; i++) {
+        if (ret[i] == null) {
+          ret[i] = org[i];
+        }
+      }
+    }
+
+    for (int i = 0; i < ret.length; i++) {
+      if (ret[i] == null && gSportToStringMap.containsKey(i)) {
+        int id = gSportToStringMap.get(i);
+        ret[i] = res.getString(id);
+      }
+    }
+
+    for (int i = 0; i < ret.length; i++) {
+      if (ret[i] == null) {
+        ret[i] = res.getString(org.runnerup.common.R.string.Unknown);
+      }
+    }
+
+    return ret;
+  }
+
   public static String textOf(int dbValue) {
     return textOf(null, dbValue);
   }
@@ -45,7 +88,7 @@ public enum Sport {
   public static String textOf(Resources res, int dbValue) {
     String sportName = null;
     if (res != null) {
-      String[] sports = res.getStringArray(org.runnerup.common.R.array.sportEntries);
+      String[] sports = getStringArray(res);
       if (0 <= dbValue && dbValue < sports.length) {
         sportName = sports[dbValue];
       }

--- a/common/src/main/java/org/runnerup/common/util/Constants.java
+++ b/common/src/main/java/org/runnerup/common/util/Constants.java
@@ -57,6 +57,8 @@ public interface Constants {
       int SPORT_OTHER = 2; // unknown
       int SPORT_ORIENTEERING = 3;
       int SPORT_WALKING = 4;
+      int SPORT_MAX = 4;
+
       String WITH_BAROMETER = "<WithBarometer/>";
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -362,4 +362,11 @@
   <string name="Activity_ongoing">Activity ongoing</string>
   <string name="Activity_paused">Activity paused</string>
   <string name="Activity_stopped">Activity stopped</string>
+
+  <!--Name of sports, these deprecate array.sportEntries -->
+  <string name="SPORT_RUNNING">Running</string>
+  <string name="SPORT_BIKING">Biking</string>
+  <string name="SPORT_OTHER">Other</string>
+  <string name="SPORT_ORIENTEERING">Orienteering</string>
+  <string name="SPORT_WALKING">Walking</string>
 </resources>


### PR DESCRIPTION
This patchs adds a map between DB.ACTIVITY.SPORT_xxx and R.strings.SPORT_xxx that is intended to be used instead of array.sport_entries, which apparently is hard to handle wrt to translations.

The patch currently use the existing sport_entries as bases so that languages that has not yet added R.strings.SPORT_xxx will be unaffected.