### PR TITLE
Inconsistent return value for `HRProvider.getBatteryLevel()` when battery information is unavailable

### DIFF
--- a/app/src/main/org/runnerup/tracker/Tracker.java
+++ b/app/src/main/org/runnerup/tracker/Tracker.java
@@ -843,7 +843,7 @@ public class Tracker extends android.app.Service implements LocationListener, Co
 
   public Integer getCurrentBatteryLevel() {
     HRProvider hrProvider = trackerHRM.getHrProvider();
-    if (hrProvider == null) return null;
+    if (hrProvider == null) return HRProvider.BATTERY_LEVEL_UNAVAILABLE;
     return hrProvider.getBatteryLevel();
   }
 

--- a/app/src/main/org/runnerup/view/StartFragment.java
+++ b/app/src/main/org/runnerup/view/StartFragment.java
@@ -70,6 +70,7 @@ import org.runnerup.common.tracker.TrackerState;
 import org.runnerup.common.util.Constants;
 import org.runnerup.common.util.Constants.DB;
 import org.runnerup.db.DBHelper;
+import org.runnerup.hr.HRProvider;
 import org.runnerup.hr.MockHRProvider;
 import org.runnerup.notification.GpsBoundState;
 import org.runnerup.notification.GpsSearchingState;
@@ -1146,7 +1147,10 @@ public class StartFragment extends Fragment implements TickListener, GpsInformat
       if (hrVal != null) {
         str.append(" ").append(hrVal);
         Integer batteryLevel = mTracker.getCurrentBatteryLevel();
-        str.append(" ").append(batteryLevel).append("%");
+
+        if (batteryLevel != HRProvider.BATTERY_LEVEL_UNAVAILABLE) {
+          str.append(" ").append(batteryLevel).append("%");
+        }
       }
     }
     return str.toString();

--- a/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/AndroidBLEHRProvider.java
@@ -64,7 +64,7 @@ public class AndroidBLEHRProvider extends BtHRBase implements HRProvider {
   private int hrValue = 0;
   private long hrTimestamp = 0;
   private long hrElapsedRealtime = 0;
-  private int batteryLevel = -1;
+  private int batteryLevel = HRProvider.BATTERY_LEVEL_UNAVAILABLE;
   private boolean hasBatteryService = false;
 
   private long mPrevHrTimestampNotZero = 0;

--- a/hrdevice/src/org/runnerup/hr/AntPlus.java
+++ b/hrdevice/src/org/runnerup/hr/AntPlus.java
@@ -410,7 +410,7 @@ public class AntPlus extends BtHRBase {
 
   @Override
   public int getBatteryLevel() {
-    return -1;
+    return HRProvider.BATTERY_LEVEL_UNAVAILABLE;
   }
 
   // ANT+ requires Bluetooth too, as well as that system libs are loaded

--- a/hrdevice/src/org/runnerup/hr/Bt20Base.java
+++ b/hrdevice/src/org/runnerup/hr/Bt20Base.java
@@ -175,7 +175,7 @@ public abstract class Bt20Base extends BtHRBase {
 
   @Override
   public int getBatteryLevel() {
-    return -1;
+    return HRProvider.BATTERY_LEVEL_UNAVAILABLE;
   }
 
   /** Cancels all the threads. */

--- a/hrdevice/src/org/runnerup/hr/HRProvider.java
+++ b/hrdevice/src/org/runnerup/hr/HRProvider.java
@@ -30,6 +30,9 @@ import androidx.appcompat.app.AppCompatActivity;
  */
 public interface HRProvider {
 
+  /** Indicates that the battery level is not available or not supplied by the device. */
+  int BATTERY_LEVEL_UNAVAILABLE = -1;
+
   /**
    * An interface through which the client of the {@link HRProvider} is notified of changes to the
    * state of the {@link HRProvider}
@@ -158,8 +161,9 @@ public interface HRProvider {
   HRData getHRData();
 
   /**
-   * @return The battery level, in percents, of the heart rate monitor device or 0 if no device has
-   *     been connected or the device doesn't supply battery information
+   * @return The battery level, in percents (0-100), of the heart rate monitor device, or {@link
+   *     #BATTERY_LEVEL_UNAVAILABLE} if no device has been connected or the device doesn't supply
+   *     battery information.
    */
   int getBatteryLevel();
 }


### PR DESCRIPTION
The Javadoc for the HRProvider.getBatteryLevel() interface method specifies that it should return 0 if no device has been connected or if the connected device does not supply battery information.

```java
/**
 * @return The battery level, in percents, of the heart rate monitor device or 0 if no device has
 *     been connected or the device doesn't supply battery information
 */
int getBatteryLevel();
```

However, some implementations of this interface, such as AntPlus.java, currently return -1 in these scenarios:

```java
@Override
public int getBatteryLevel() {
  return -1;
}
```

This PR:

- Introduces a constant BATTERY_LEVEL_UNAVAILABLE (-1) in HRPRovider.java to represent "unavailable" battery level.
- Updates HRProvider Javadoc for getBatteryLevel().
- Modifies all implementations of HRProvider and other client code to use BATTERY_LEVEL_UNAVAILABLE instead of -1.
- Adjusts StartFragment to display battery percentage only if battery level is available.