### PR TITLE
Add 2 new properties for a Sport

### DIFF
--- a/app/src/main/org/runnerup/workout/Sport.java
+++ b/app/src/main/org/runnerup/workout/Sport.java
@@ -189,4 +189,12 @@ public enum Sport {
       return "Other";
     }
   }
+
+  public static boolean isWithoutGps(int dbValue) {
+    return false;
+  }
+
+  public static boolean hasManualDistance(int dbValue) {
+    return false;
+  }
 }


### PR DESCRIPTION
- Manual distance A user is prompted to enter distance at end of workout

- WithoutGps The GPS location is not saved. No distance/speed/pace is computed