### PR TITLE
Add accessor for the getOnItemSelectedListener to Spinner

### DIFF
--- a/app/src/main/org/runnerup/widget/ClassicSpinner.java
+++ b/app/src/main/org/runnerup/widget/ClassicSpinner.java
@@ -87,4 +87,9 @@ public class ClassicSpinner extends AppCompatSpinner implements SpinnerInterface
   public void setViewOnItemSelectedListener(AdapterView.OnItemSelectedListener listener) {
     setOnItemSelectedListener(listener);
   }
+
+  @Override
+  public AdapterView.OnItemSelectedListener getViewOnItemSelectedListener() {
+    return getOnItemSelectedListener();
+  }
 }

--- a/app/src/main/org/runnerup/widget/SpinnerInterface.java
+++ b/app/src/main/org/runnerup/widget/SpinnerInterface.java
@@ -28,6 +28,7 @@ public interface SpinnerInterface {
 
   void viewOnClose(OnCloseDialogListener listener, boolean b);
 
+  AdapterView.OnItemSelectedListener getViewOnItemSelectedListener();
   void setViewOnItemSelectedListener(AdapterView.OnItemSelectedListener listener);
 
   void setOnClickSpinnerOpen();

--- a/app/src/main/org/runnerup/widget/TitleSpinner.java
+++ b/app/src/main/org/runnerup/widget/TitleSpinner.java
@@ -119,6 +119,11 @@ public class TitleSpinner extends LinearLayout implements SpinnerInterface {
     mSpinner.setOnItemSelectedListener(listener);
   }
 
+  @Override
+  public AdapterView.OnItemSelectedListener getViewOnItemSelectedListener() {
+    return mSpinner.getOnItemSelectedListener();
+  }
+
   public void setAdapter(SpinnerAdapter adapter) {
     mSpinner.setAdapter(adapter);
     mPresenter.loadValue(null);


### PR DESCRIPTION
This so that one can easily chain listeners.
A (maybe) better option would be to instead
change from setlistener to addlistener, but that
is a much bigger change...not needed here.

This feature is to be used for sport w/o gps,
e.g. treadmill.