### PR TITLE
remove package from AndroidManifest.xml

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -15,7 +15,7 @@
   ~  along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<manifest package="org.runnerup"
+<manifest
           xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 


### PR DESCRIPTION
When I build I get a warning that it should be removed. I don't remember how this work...why it was there, and why it should no longer be there.

But since we build both org.runnerup and org.runnerup.debug from same manifest it "feel right"