### PR TITLE
Graph-x-axis

### DIFF
--- a/app/src/main/org/runnerup/util/Formatter.java
+++ b/app/src/main/org/runnerup/util/Formatter.java
@@ -185,11 +185,6 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     return null;
   }
 
-  public String getElapsedUnit(Format target) {
-    return resources.getString(
-        org.runnerup.common.R.string.metrics_elapsed_unit);
-  }
-
   public static boolean getUseMetric(Resources res, SharedPreferences prefs, Editor editor) {
     boolean _km;
     String unit = prefs.getString(res.getString(R.string.pref_unit), null);

--- a/app/src/main/org/runnerup/util/GraphWrapper.java
+++ b/app/src/main/org/runnerup/util/GraphWrapper.java
@@ -58,10 +58,10 @@ public class GraphWrapper implements Constants {
     double getX(double distance, double time_ms);
   };
 
+  private final XAxis distanceXAxis;
+  private final XAxis timeXAxis;
   boolean useDistanceAsX = true;
-  XAxis distanceXAxis;
-  XAxis timeXAxis;
-  XAxis xAxis;
+  private XAxis xAxis;
 
   /** Called when the activity is first created. */
   @SuppressLint("ObsoleteSdkInt")

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -23,7 +23,6 @@
   <string name="metrics_elapsed_m">m</string>
   <string name="metrics_elapsed_min">min</string>
   <string name="metrics_elapsed_s">s</string>
-  <string name="metrics_elapsed_unit">hh:mm</string>
   <string name="metrics_heartrate">HR</string>
   <string name="Maximum_heart_rate_MHR">Maximum heart rate (MHR)</string>
   <string name="Target_pace_HHMMSS">Target pace</string>


### PR DESCRIPTION
This patch makes it possible to use time (instead of distance) as X-axis in graphs...and makes it modifyable.
It also removes pace graph if there is no pace data.

Both of these features are planned for sport without gps, i.e Treadmill. But in theory, one can imagine useing time instead of distance as x-axis also for e.g. running. Maybe it should be a switch ? (in a future version!)