### PR TITLE
Use system file picker (SAF) for DB export/import

### DIFF
--- a/app/res/xml/settings_maintenance.xml
+++ b/app/res/xml/settings_maintenance.xml
@@ -25,6 +25,8 @@
         android:title="@string/Database_category"
         app:iconSpaceReserved="false">
 
+        <!--  TODO: Update @string/Maintenance_explanation_summary text to describe SAF-based
+                    import/export (user-chosen locations, system picker).  -->
         <Preference
             android:key="@string/Maintenance_explanation_summary"
             android:summary="@string/Maintenance_explanation_summary"

--- a/app/src/main/org/runnerup/db/DBHelper.java
+++ b/app/src/main/org/runnerup/db/DBHelper.java
@@ -693,17 +693,20 @@ public class DBHelper extends SQLiteOpenHelper implements Constants {
     mDBHelper.close();
 
     DialogInterface.OnClickListener listener = (dialog, which) -> dialog.dismiss();
+    AlertDialog.Builder builder = new AlertDialog.Builder(ctx).setTitle("Import " + DBNAME);
 
     if (!isValidRunnerUpDatabase(ctx, from)) {
       Log.e(TAG, "Selected Uri is not a valid RunnerUp database: " + from);
-      // TODO: Show error dialog
+      builder
+          .setMessage(org.runnerup.common.R.string.import_error_invalid_database)
+          .setPositiveButton(org.runnerup.common.R.string.OK, listener)
+          .show();
       return;
     }
 
     // TODO 2: Prompt user that this will overwrite current database
     // TODO 3: Backup the current DB before importing
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(ctx).setTitle("Import " + DBNAME);
     try {
       Uri to = getDbUri(ctx);
       int cnt = FileUtil.copyFile(ctx, to, from);

--- a/app/src/main/org/runnerup/view/MainLayout.java
+++ b/app/src/main/org/runnerup/view/MainLayout.java
@@ -28,7 +28,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
-import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.os.Bundle;
@@ -167,7 +166,10 @@ public class MainLayout extends AppCompatActivity {
     handleBundled(getApplicationContext().getAssets(), "bundled", getFilesDir().getPath() + "/..");
 
     // if we were called from an intent-filter because user opened "runnerup.db.export", load it
-    final String filePath;
+    // TODO: Add/Update intent-filter in Manifest to handle ACTION_VIEW for 'content' (and
+    //  optionally 'file') schemes with appropriate MIME and path, but only after implementing
+    //  "overwrite protection" when importing (prompt user to confirm overwrite).
+    /*final String filePath;
     final Uri data = getIntent().getData();
     if (data != null) {
       if ("content".equals(data.getScheme())) {
@@ -193,7 +195,7 @@ public class MainLayout extends AppCompatActivity {
       // No check for permissions or that this is within scooped storage (>=SDK29)
       Log.i(getClass().getSimpleName(), "Importing database from " + filePath);
       DBHelper.importDatabase(MainLayout.this, filePath);
-    }
+    }*/
 
     // Apply system bars insets to avoid UI overlap
     ViewUtil.Insets(findViewById(R.id.main_root), true);

--- a/app/src/main/org/runnerup/view/SettingsMaintenanceFragment.java
+++ b/app/src/main/org/runnerup/view/SettingsMaintenanceFragment.java
@@ -1,8 +1,18 @@
 package org.runnerup.view;
 
+import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import java.util.Locale;
@@ -10,6 +20,8 @@ import org.runnerup.R;
 import org.runnerup.db.DBHelper;
 
 public class SettingsMaintenanceFragment extends PreferenceFragmentCompat {
+
+  private static final String TAG = "SettingsMaintenance";
 
   @Override
   public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -37,18 +49,80 @@ public class SettingsMaintenanceFragment extends PreferenceFragmentCompat {
                 path));
   }
 
+  /**
+   * ActivityResultLauncher for handling the result of the {@link Intent#ACTION_CREATE_DOCUMENT}
+   * intent used for exporting the database.
+   *
+   * <p>When the user selects a destination file, this launcher receives the {@link Uri} and
+   * initiates the database export process via {@link DBHelper#exportDatabase(Context, Uri)}. If the
+   * export is cancelled or no Uri is returned, a toast message is shown and a warning is logged.
+   */
+  private final ActivityResultLauncher<Intent> exportDbLauncher =
+      registerForActivityResult(
+          new ActivityResultContracts.StartActivityForResult(),
+          result -> {
+            Uri toUri = getUriFromResult(result);
+            if (toUri != null) {
+              DBHelper.exportDatabase(requireContext(), toUri);
+            } else {
+              Toast.makeText(
+                      requireContext(),
+                      org.runnerup.common.R.string.export_cancelled,
+                      Toast.LENGTH_SHORT)
+                  .show();
+              Log.w(TAG, "Export cancelled or URI not found.");
+            }
+          });
+
+  /**
+   * ActivityResultLauncher for handling the result of the {@link Intent#ACTION_OPEN_DOCUMENT}
+   * intent used for importing the database.
+   *
+   * <p>When the user selects a database file, this launcher receives its {@link Uri} and initiates
+   * the database import process via {@link DBHelper#importDatabase(Context, Uri)}. If the import is
+   * cancelled or no Uri is returned, a toast message is shown and a warning is logged.
+   */
+  private final ActivityResultLauncher<Intent> importDbLauncher =
+      registerForActivityResult(
+          new ActivityResultContracts.StartActivityForResult(),
+          result -> {
+            Uri fromUri = getUriFromResult(result);
+            if (fromUri != null) {
+              DBHelper.importDatabase(requireContext(), fromUri);
+            } else {
+              Toast.makeText(
+                      requireContext(),
+                      org.runnerup.common.R.string.import_cancelled,
+                      Toast.LENGTH_SHORT)
+                  .show();
+              Log.w(TAG, "Import cancelled or URI not found.");
+            }
+          });
+
   private final Preference.OnPreferenceClickListener onExportClick =
       preference -> {
-        // TODO Use picker with ACTION_CREATE_DOCUMENT
-        DBHelper.exportDatabase(requireContext(), null);
-        return false;
+        Intent intent =
+            new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                // Use "application/octet-stream" to be consistent with the mime type used in
+                // the http intent-filter for MainLayout (in AndroidManifest).
+                .setType("application/octet-stream")
+                .putExtra(
+                    Intent.EXTRA_TITLE,
+                    "runnerup.db.export"); // Suggest a name (note: user may change it)
+        exportDbLauncher.launch(intent);
+        return true;
       };
 
   private final Preference.OnPreferenceClickListener onImportClick =
       preference -> {
-        // TODO Use picker with ACTION_OPEN_DOCUMENT
-        DBHelper.importDatabase(requireContext(), null);
-        return false;
+        Intent intent =
+            new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("application/octet-stream")
+                .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false);
+        importDbLauncher.launch(intent);
+        return true;
       };
 
   private final Preference.OnPreferenceClickListener onPruneClick =
@@ -59,4 +133,21 @@ public class SettingsMaintenanceFragment extends PreferenceFragmentCompat {
         DBHelper.purgeDeletedActivities(requireContext(), dialog, dialog::dismiss);
         return false;
       };
+
+  /**
+   * Helper method to check the result of an ActivityResult and extract the Uri.
+   *
+   * @param result The ActivityResult from the launcher.
+   * @return The Uri if the result was OK and data is present, otherwise null.
+   */
+  @Nullable
+  private Uri getUriFromResult(ActivityResult result) {
+    if (result.getResultCode() == Activity.RESULT_OK) {
+      Intent data = result.getData();
+      if (data != null && data.getData() != null) {
+        return data.getData();
+      }
+    }
+    return null;
+  }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -372,4 +372,7 @@
   <string name="SPORT_ORIENTEERING">Orienteering</string>
   <string name="SPORT_WALKING">Walking</string>
   <string name="SPORT_TREADMILL">Treadmill</string>
+
+  <string name="import_cancelled">Import cancelled</string>
+  <string name="export_cancelled">Export cancelled</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -375,4 +375,5 @@
 
   <string name="import_cancelled">Import cancelled</string>
   <string name="export_cancelled">Export cancelled</string>
+  <string name="import_error_invalid_database">Selected file is not a valid RunnerUp database!</string>
 </resources>


### PR DESCRIPTION
Previously, database exports were saved to app-private storage, making it difficult (if not impossible) for users to access the database file outside of RunnerUp. This PR refactors the database import and export functionality from using app-private storage to using the Storage Access Framework (SAF). This framework allows users to interact with a system picker to select files from shared storage, not requiring any system permissions. For RunnerUp, users may now choose where their database backups are saved and accessed from.

Fixes #1083 and #1153.

TODOs (separate PRs):
1. Add confirmation prompt before overwriting existing DB when importing (#1089).
2. Backup the current DB before overwriting.
3. Enable direct DB file opening from file managers via AndroidManifest intent filter.