### PR TITLE
Fixed Endurain authentication

### DIFF
--- a/app/src/main/org/runnerup/export/EndurainSynchronizer.java
+++ b/app/src/main/org/runnerup/export/EndurainSynchronizer.java
@@ -171,7 +171,6 @@ public class EndurainSynchronizer extends DefaultSynchronizer {
       OkHttpClient client = getAuthClient();
       RequestBody formBody =
           new FormBody.Builder()
-              // .add("grant_type", "password")
               .add("username", username)
               .add("password", password)
               .build();


### PR DESCRIPTION
Fixes #1300 since endurain changed authentication: token endpoint changed from /api/v1/token to /api/v1/auth/login. See https://docs.endurain.com/developer-guide/authentication/#core-authentication-endpoints for references...