### PR TITLE
fix: special lint config if no mapbox key

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,6 +60,7 @@ jobs:
           
       - name: Prepare builddir
         run: |
+          # secrets are only available for collabrators, other will build with OsmDroid (but a few more options than F-Droid still)
           echo "${{ secrets.MAPBOX }}" > $GITHUB_WORKSPACE/mapbox.properties
           echo "${{ secrets.DROPBOX }}" > $GITHUB_WORKSPACE/dropbox.properties
           echo "${{ secrets.RUNALYZE }}" > $GITHUB_WORKSPACE/runalyze.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,11 @@ android {
     lint {
         baseline = file('lint-baseline.xml')
         checkReleaseBuilds = true
-        lintConfig = file('lint.xml')
+        if (mapboxEnabled) {
+            lintConfig = file('lint.xml')
+        } else {
+            lintConfig = file('lint-osmdroid.xml')
+        }
         showAll = true
         //textOutput = 'stdout'
         textReport = true

--- a/app/lint-osmdroid.xml
+++ b/app/lint-osmdroid.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="all" >
+        <ignore path="ANT-Android-SDKs/**" />
+    </issue>
+    <!-- promote to error, must be handled -->
+    <issue id="InlinedApi" severity="fatal" />
+    <issue id="InconsistentArrays" severity="fatal" />
+
+    <issue id="UsingOnClickInXml" severity="ignore">
+        <ignore path="**/reportlist_row.xml" />
+    </issue>
+
+    <!-- All translations will not be complete -->
+    <issue id="MissingTranslation" severity="ignore" />
+
+    <!-- icon with all densities are not included - don't bother -->
+    <issue id="IconMissingDensityFolder" severity="ignore" />
+    <issue id="MissingQuantity">
+        <!-- Transifex refuses quantity="one" for tr,pl (gradle) lint requires it, Inspect allows both-->
+        <ignore path="res/values-tr/cues.xml" />
+        <ignore path="res/values-pl/cues.xml" />
+        <ignore path="res/values-zh/cues.xml" />
+    </issue>
+    <issue id="UnusedQuantity">
+        <ignore path="res/values-lt/cues.xml" />
+        <ignore path="res/values-zh/cues.xml" />
+    </issue>
+
+    <issue id="IconDensities">
+        <ignore path="res/**" />
+        <ignore path="**/common/src/main/res/**" />
+    </issue>
+    <issue id="IconColors">
+        <ignore path="**/ic_stat_notify.png" />
+    </issue>
+    <issue id="ObsoleteSdkInt" severity="ignore">
+        <ignore regexp=".*drawable-r21$" />
+    </issue>
+    <!-- TODO -->
+    <issue id="ClickableViewAccessibility" severity="ignore">
+        <ignore path="**/NumberPicker.java" />
+    </issue>
+    <!-- Specific for CI - MapBox cannot be downloaded -->
+    <issue id="UnusedResources" severity="ignore">
+        <ignore path="**/res/drawable-*/ic_map_marker*.png" />
+    </issue>
+</lint>

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -69,4 +69,5 @@
     <issue id="ClickableViewAccessibility" severity="ignore">
         <ignore path="**/NumberPicker.java" />
     </issue>
+    <!-- lint-osmdroid.xml has specific suppressions, maintained separately -->
 </lint>

--- a/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
+++ b/app/src/main/org/runnerup/tracker/component/TrackerGPS.java
@@ -28,6 +28,8 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.os.Handler;
 import android.text.TextUtils;
+
+import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 import org.runnerup.R;
@@ -116,11 +118,16 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
     return Integer.parseInt(s);
   }
 
-  static Location getLastKnownLocation(LocationManager lm) {
+  static Location getLastKnownLocation(LocationManager lm, Context context) {
     String[] list = {GPS_PROVIDER, NETWORK_PROVIDER, PASSIVE_PROVIDER};
     Location lastLocation = null;
     for (String s : list) {
-      Location tmp = lm.getLastKnownLocation(s);
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            // User has deactivated location permission during the workout.
+            continue;
+        }
+        Location tmp = lm.getLastKnownLocation(s);
       if (tmp == null) {
         continue;
       }
@@ -154,7 +161,7 @@ public class TrackerGPS extends DefaultTrackerComponent implements TickListener 
       var lm = locationManager;
       SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
       frequency_ms = parseAndFixInteger(preferences, R.string.pref_pollInterval, "1000", context);
-      mLastLocation = getLastKnownLocation(lm);
+      mLastLocation = getLastKnownLocation(lm, context);
       if (!mWithoutGps) {
         Integer frequency_meters =
             parseAndFixInteger(preferences, R.string.pref_pollDistance, "0", context);


### PR DESCRIPTION
Lint (and thereby GitHub Action) failed if MapBox was not enabled.
This adopts the lint configuration, if no mapbox token for the lib download, a lint config adapted for osmdroid is used. 