### PR TITLE
fix: do not reuse attrs in the spinner

### DIFF
--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -37,7 +37,7 @@
         <item name="android:textSize">20sp</item>
     </style>
 
-    <style name="RunHeader" parent="AppTheme">
+    <style name="RunHeader" parent="android:Widget.TextView">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_weight">1</item>
@@ -46,7 +46,7 @@
         <item name="android:textStyle">italic</item>
     </style>
 
-    <style name="RunInfo" parent="AppTheme">
+    <style name="RunInfo" parent="android:Widget.TextView">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_weight">1</item>

--- a/app/src/main/org/runnerup/widget/DistancePicker.java
+++ b/app/src/main/org/runnerup/widget/DistancePicker.java
@@ -33,7 +33,7 @@ public class DistancePicker extends LinearLayout {
   private final NumberPicker meters;
 
   public DistancePicker(Context context, AttributeSet attrs) {
-    super(context, attrs);
+    super(context);
 
     unitMeters = new NumberPicker(context, attrs);
     LinearLayout unitStringLayout = new LinearLayout(context);

--- a/app/src/main/org/runnerup/widget/DurationPicker.java
+++ b/app/src/main/org/runnerup/widget/DurationPicker.java
@@ -28,7 +28,7 @@ public class DurationPicker extends LinearLayout {
   private final NumberPicker seconds;
 
   public DurationPicker(Context context, AttributeSet attrs) {
-    super(context, attrs);
+    super(context);
 
     hours = new NumberPicker(context, attrs);
     hours.setMinimumHeight(48);

--- a/app/src/main/org/runnerup/widget/NumberPicker.java
+++ b/app/src/main/org/runnerup/widget/NumberPicker.java
@@ -65,7 +65,7 @@ public class NumberPicker extends LinearLayout {
   private String fmtString = "%0" + digits + "d";
 
   public NumberPicker(Context context, AttributeSet attrs) {
-    super(context, attrs);
+    super(context);
 
     createValueText(context);
     createButton(context, '+');


### PR DESCRIPTION
Reusing the attrs in the parent causes a nullexception
Seen in Play Console too