### PR TITLE
fix check mslAltitude conditions

### DIFF
--- a/app/src/main/org/runnerup/tracker/component/TrackerElevation.java
+++ b/app/src/main/org/runnerup/tracker/component/TrackerElevation.java
@@ -239,7 +239,7 @@ public class TrackerElevation extends DefaultTrackerComponent implements SensorE
 
     /** Initiates a calculation of the last known offset without blocking if needed. */
     synchronized void calcOffset(Location location) {
-      if (location == null) {
+      if (location == null || !location.hasAltitude() || !LocationCompat.hasVerticalAccuracy(location)) {
         return;
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ project.ext {
     mockitoVersion = '5.21.0'
 
     //The Git tag for the release must be identical for F-Droid
-    versionName = '2.10.0.2'
+    versionName = '2.10.0.3'
     // wear uses +1, only set even codes
     versionCode = 370
     latestBaseVersionCode = minSdk * 1000000

--- a/fastlane/metadata/android/en-US/changelogs/23000370.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23000370.txt
@@ -1,0 +1,4 @@
+#1298 Target Android 16 and 16KB stack
+#1241 Activities without GPS
+#1298 Target Android 16
+#1276 #1284 Treadmill, Gym and Stationary bike activities


### PR DESCRIPTION
Some devices do not add all info required
to calculate mean sea level elevation.

This was seen on a Xiaomi P8 with Android 8, that should have MSL adjustment built in already, so non conformant.