### PR TITLE
fix: graph distance adaptive formatter

### DIFF
--- a/app/res/layout/detail.xml
+++ b/app/res/layout/detail.xml
@@ -189,13 +189,21 @@
 		      android:layout_height="match_parent" />
 		  </LinearLayout>
 
-                  <LinearLayout
+                <ScrollView
                     android:id="@+id/tab_graph"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:weightSum="1"
-                    android:layout_margin="@dimen/activity_margin"/>
+                    android:layout_height="match_parent"
+                    android:scrollbars="none"
+                    android:clipToPadding="false">
+
+                    <LinearLayout
+                        android:id="@+id/graphview"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="@dimen/activity_margin"
+                        android:orientation="vertical"
+                        android:weightSum="1" />
+                </ScrollView>
 
                 <LinearLayout
                     android:id="@+id/tab_upload"

--- a/app/src/main/org/runnerup/util/Formatter.java
+++ b/app/src/main/org/runnerup/util/Formatter.java
@@ -556,6 +556,16 @@ public class Formatter implements OnSharedPreferenceChangeListener {
   }
 
   /**
+   * @return elevation unit string
+   */
+  String getElevationUnit() {
+    return resources.getString(
+        metric
+            ? org.runnerup.common.R.string.metrics_distance_m
+            : org.runnerup.common.R.string.metrics_distance_ft);
+  }
+
+  /**
    * @param meters_per_second
    * @return string suitable for printing according to settings
    */
@@ -720,10 +730,12 @@ public class Formatter implements OnSharedPreferenceChangeListener {
   public String formatElevation(Format target, double meters) {
     // TODO add (plural) strings and handle Format, cues
     DecimalFormat df = new DecimalFormat("#.0");
-    if (metric) {
-      return df.format(meters) + " m";
+    String value = metric ? df.format(meters) : df.format(meters / meters_per_foot);
+
+    if (target == Format.TXT || target == Format.TXT_SHORT) {
+      return value;
     } else {
-      return df.format(meters / meters_per_foot) + " ft";
+      return value + " " + getElevationUnit();
     }
   }
 

--- a/app/src/main/org/runnerup/util/Formatter.java
+++ b/app/src/main/org/runnerup/util/Formatter.java
@@ -28,6 +28,7 @@ import android.text.format.DateUtils;
 import android.util.Log;
 import androidx.preference.PreferenceManager;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -38,37 +39,23 @@ import org.runnerup.workout.SpeedUnit;
 
 public class Formatter implements OnSharedPreferenceChangeListener {
 
-  private final Context context;
+  public static final double km_meters = 1000.0;
+  public static final double mi_meters = 1609.34;
+  private static final double meters_per_foot = 0.3048;
   private final Resources resources;
   private final LocaleResources cueResources;
   private final SharedPreferences sharedPreferences;
   private final java.text.DateFormat dateFormat;
+  // private HRZones hrZones = null;
   private final java.text.DateFormat timeFormat;
   private final java.text.DateFormat monthFormat;
   private final java.text.DateFormat dayOfMonthFormat;
-  // private HRZones hrZones = null;
-
+  private final boolean unitCue;
   private boolean metric = true;
   private String base_unit = "km";
   private double base_meters = km_meters;
-  private final boolean unitCue;
-
-  public static final double km_meters = 1000.0;
-  public static final double mi_meters = 1609.34;
-  private static final double meters_per_foot = 0.3048;
-
-  public enum Format {
-    CUE, // for text to speech
-    CUE_SHORT, // brief for tts
-    CUE_LONG, // long for tts
-    TXT, // same as TXT_SHORT but without unit
-    TXT_SHORT, // brief for printing
-    TXT_LONG, // long for printing
-    TXT_TIMESTAMP, // For current time e.g 13:41:24
-  }
 
   public Formatter(Context ctx) {
-    context = ctx;
     resources = ctx.getResources();
     cueResources = getCueLangResources(ctx);
     sharedPreferences = PreferenceManager.getDefaultSharedPreferences(ctx);
@@ -79,57 +66,8 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     monthFormat = new SimpleDateFormat("LLL yyyy", cueResources.defaultLocale);
     dayOfMonthFormat = new SimpleDateFormat("E d", cueResources.defaultLocale);
     unitCue = sharedPreferences.getBoolean(cueResources.getString(R.string.cueinfo_units), true);
-    // hrZones = new HRZones(context);
 
     setUnit();
-  }
-
-  private class LocaleResources {
-    final Resources resources;
-    final Configuration configuration;
-    final Locale defaultLocale;
-    final Locale audioLocale;
-
-    LocaleResources(Context ctx, Locale configAudioLocale) {
-      resources = ctx.getResources();
-      configuration = resources.getConfiguration();
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-          && !ctx.getResources().getConfiguration().getLocales().isEmpty()) {
-        defaultLocale = configuration.getLocales().get(0);
-      } else {
-        defaultLocale = configuration.locale;
-      }
-
-      if (configAudioLocale == null) {
-        audioLocale = defaultLocale;
-      } else {
-        audioLocale = configAudioLocale;
-      }
-    }
-
-    void setLang(Locale locale) {
-      // enableSplit = false set in build.gradle
-      configuration.setLocale(locale);
-      resources.updateConfiguration(configuration, resources.getDisplayMetrics());
-    }
-
-    public String getString(int id) throws Resources.NotFoundException {
-      setLang(audioLocale);
-      String result = resources.getString(id);
-
-      setLang(defaultLocale);
-      return result;
-    }
-
-    // General getQuantityString accepts "Object ...", limit to exactly one argument (current use)
-    // to avoid runtime crashes
-    public String getQuantityString(int id, int quantity, Object formatArgs)
-        throws Resources.NotFoundException {
-      setLang(audioLocale);
-      String result = resources.getQuantityString(id, quantity, formatArgs);
-      setLang(defaultLocale);
-      return result;
-    }
   }
 
   public static Locale getAudioLocale(Context ctx) {
@@ -137,50 +75,6 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
     if (prefs.contains(res.getString(R.string.pref_audio_lang))) {
       return new Locale(prefs.getString(res.getString(R.string.pref_audio_lang), "en"));
-    }
-    return null;
-  }
-
-  private LocaleResources getCueLangResources(Context ctx) {
-    Locale loc = getAudioLocale(ctx);
-    return new LocaleResources(ctx, loc);
-  }
-
-  public String getCueString(int msgId) {
-    return cueResources.getString(msgId);
-  }
-
-  @Override
-  public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-    if (key != null && context.getString(R.string.pref_unit).contentEquals(key)) setUnit();
-  }
-
-  private void setUnit() {
-    metric = getUseMetric(context.getResources(), sharedPreferences, null);
-
-    if (metric) {
-      base_unit = "km";
-      base_meters = km_meters;
-    } else {
-      base_unit = "mi";
-      base_meters = mi_meters;
-    }
-  }
-
-  public String getDistanceUnit(Format target) {
-    switch (target) {
-      case CUE:
-      case CUE_LONG:
-      case CUE_SHORT:
-      case TXT_LONG:
-      // No string for long - not used
-      // return resources.getString(km ? R.plurals.cue_kilometer : R.plurals.cue_mile);
-      case TXT:
-      case TXT_SHORT:
-        return resources.getString(
-            metric
-                ? org.runnerup.common.R.string.metrics_distance_km
-                : org.runnerup.common.R.string.metrics_distance_mi);
     }
     return null;
   }
@@ -210,18 +104,64 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     return true;
   }
 
+  public static double getUnitMeters(Resources res, SharedPreferences prefs) {
+    if (getUseMetric(res, prefs, null)) return km_meters;
+    else return mi_meters;
+  }
+
+  private static double round(double base, double decimals) {
+    double exp = Math.pow(10, decimals);
+    return Math.round(base * exp) / exp;
+  }
+
+  public static double getUnitMeters(Context mContext) {
+    return getUnitMeters(
+        mContext.getResources(), PreferenceManager.getDefaultSharedPreferences(mContext));
+  }
+
+  private LocaleResources getCueLangResources(Context ctx) {
+    Locale loc = getAudioLocale(ctx);
+    return new LocaleResources(resources, loc);
+  }
+
+  public String getCueString(int msgId) {
+    return cueResources.getString(msgId);
+  }
+
+  @Override
+  public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+    if (key != null && resources.getString(R.string.pref_unit).contentEquals(key)) setUnit();
+  }
+
+  private void setUnit() {
+    metric = getUseMetric(resources, sharedPreferences, null);
+
+    if (metric) {
+      base_unit = "km";
+      base_meters = km_meters;
+    } else {
+      base_unit = "mi";
+      base_meters = mi_meters;
+    }
+  }
+
+  public String getDistanceUnit() {
+    return resources.getString(
+        metric
+            ? org.runnerup.common.R.string.metrics_distance_km
+            : org.runnerup.common.R.string.metrics_distance_mi);
+  }
+
   /**
    * Gets the user's preferred Speedunit
    *
-   * @param context Context element to access configuration
    * @return Configured Speed Unit (falls back to pace, if the configured value is invalid)
    */
-  public static SpeedUnit getPreferredSpeedUnit(Context context) {
-    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+  public SpeedUnit getPreferredSpeedUnit() {
     // use either pace or speed according to the user's preference
     String speedUnit =
-        prefs.getString(
-            context.getResources().getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
+        sharedPreferences.getString(
+            resources.getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
     assert speedUnit != null; // may not happen
     switch (speedUnit) {
       case Constants.SPEED_UNIT.SPEED:
@@ -234,11 +174,6 @@ public class Formatter implements OnSharedPreferenceChangeListener {
 
   public double getUnitMeters() {
     return this.base_meters;
-  }
-
-  public static double getUnitMeters(Resources res, SharedPreferences prefs) {
-    if (getUseMetric(res, prefs, null)) return km_meters;
-    else return mi_meters;
   }
 
   public String getUnitString() {
@@ -485,7 +420,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
   public String formatVelocityByPreferredUnit(Format target, double meters_per_second) {
     String paceTextUnit =
         this.sharedPreferences.getString(
-            context.getResources().getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
+            resources.getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
     assert paceTextUnit != null;
     if (paceTextUnit.contentEquals(SpeedUnit.PACE.getValue())) {
       return this.formatPaceSpeed(target, meters_per_second);
@@ -502,12 +437,12 @@ public class Formatter implements OnSharedPreferenceChangeListener {
   public String formatVelocityLabel() {
     String paceTextUnit =
         this.sharedPreferences.getString(
-            context.getResources().getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
+            resources.getString(R.string.pref_speedunit), SpeedUnit.PACE.getValue());
     assert paceTextUnit != null;
     if (paceTextUnit.contentEquals(SpeedUnit.PACE.getValue())) {
-      return this.context.getString(org.runnerup.common.R.string.Pace);
+      return this.resources.getString(org.runnerup.common.R.string.Pace);
     } else {
-      return this.context.getString(org.runnerup.common.R.string.Speed);
+      return this.resources.getString(org.runnerup.common.R.string.Speed);
     }
   }
 
@@ -534,25 +469,34 @@ public class Formatter implements OnSharedPreferenceChangeListener {
   }
 
   /**
-   * @return pace unit string
+   * @return pace/speed unit string
    */
-  String getVelocityUnit(
-      Context context) { // Resources resources, SharedPreferences sharedPreferences) {
+  String getVelocityUnit() { // Resources resources, SharedPreferences sharedPreferences) {
+    switch (getPreferredSpeedUnit()) {
+      case SPEED:
+        return getSpeedUnit();
+      case PACE:
+      default:
+        return getPaceUnit();
+    }
+  }
+
+  private String getPaceUnit() {
     int du =
         metric
             ? org.runnerup.common.R.string.metrics_distance_km
             : org.runnerup.common.R.string.metrics_distance_mi;
-    switch (getPreferredSpeedUnit(context)) {
-      case SPEED:
-        return resources.getString(du)
-            + "/"
-            + resources.getString(org.runnerup.common.R.string.metrics_elapsed_h);
-      case PACE:
-      default:
-        return resources.getString(org.runnerup.common.R.string.metrics_elapsed_min)
-            + "/"
-            + resources.getString(du);
-    }
+    return "/" + resources.getString(du);
+  }
+
+  private String getSpeedUnit() {
+    int du =
+        metric
+            ? org.runnerup.common.R.string.metrics_distance_km
+            : org.runnerup.common.R.string.metrics_distance_mi;
+    return resources.getString(du)
+        + "/"
+        + resources.getString(org.runnerup.common.R.string.metrics_elapsed_h);
   }
 
   /**
@@ -579,13 +523,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
       str = DateUtils.formatElapsedTime(val);
     }
     if (includeUnit) {
-      str =
-          str
-              + " /"
-              + resources.getString(
-                  (metric
-                      ? org.runnerup.common.R.string.metrics_distance_km
-                      : org.runnerup.common.R.string.metrics_distance_mi));
+      str = str + " " + getPaceUnit();
     }
     return str;
   }
@@ -633,7 +571,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
    * @param meters_per_second
    * @return
    */
-  private String formatSpeed(Format target, double meters_per_second) {
+  public String formatSpeed(Format target, double meters_per_second) {
     switch (target) {
       case CUE:
       case CUE_SHORT:
@@ -662,15 +600,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     String str = String.format(cueResources.defaultLocale, "%.1f", distance_per_hour);
     if (!includeUnit) return str;
     else {
-      int res =
-          metric
-              ? org.runnerup.common.R.string.metrics_distance_km
-              : org.runnerup.common.R.string.metrics_distance_mi;
-      return str
-          + " "
-          + resources.getString(res)
-          + "/"
-          + resources.getString(org.runnerup.common.R.string.metrics_elapsed_h);
+      return str + " " + getSpeedUnit();
     }
   }
 
@@ -729,7 +659,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
    */
   public String formatElevation(Format target, double meters) {
     // TODO add (plural) strings and handle Format, cues
-    DecimalFormat df = new DecimalFormat("#.0");
+    DecimalFormat df = new DecimalFormat("#");
     String value = metric ? df.format(meters) : df.format(meters / meters_per_foot);
 
     if (target == Format.TXT || target == Format.TXT_SHORT) {
@@ -760,6 +690,20 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     return null;
   }
 
+  /**
+   * Distance in consistent km/miles for e.g. graph, as formatDistance formats shorter distances in
+   * meters.
+   *
+   * @param meters
+   * @return
+   */
+  public String getDistanceDisplay(double meters) {
+    DecimalFormat distanceFormat =
+        new DecimalFormat("0.#", DecimalFormatSymbols.getInstance(cueResources.defaultLocale));
+    distanceFormat.setGroupingUsed(false);
+    return distanceFormat.format(getRoundedDistanceInKmOrMiles((long) meters));
+  }
+
   private double getRoundedDistanceInKmOrMiles(long meters) {
     double decimals = 2;
     return round(meters / base_meters, decimals);
@@ -774,15 +718,7 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     if (meters >= base_meters * 0.99) {
       double val = getRoundedDistanceInKmOrMiles(meters);
       if (txt) {
-        res =
-            String.format(
-                cueResources.defaultLocale,
-                "%.2f %s",
-                val,
-                resources.getString(
-                    metric
-                        ? org.runnerup.common.R.string.metrics_distance_km
-                        : org.runnerup.common.R.string.metrics_distance_mi));
+        res = String.format(cueResources.defaultLocale, "%.2f %s", val, getDistanceUnit());
       } else {
         // Get a localized presentation string, used with the localized plurals string
         String val2;
@@ -856,13 +792,61 @@ public class Formatter implements OnSharedPreferenceChangeListener {
     return timeFormat.format(seconds_since_epoch * 1000);
   }
 
-  public static double round(double base, double decimals) {
-    double exp = Math.pow(10, decimals);
-    return Math.round(base * exp) / exp;
+  public enum Format {
+    CUE, // for text to speech
+    CUE_SHORT, // brief for tts
+    CUE_LONG, // long for tts
+    TXT, // same as TXT_SHORT but without unit
+    TXT_SHORT, // value only, except for distance that has unit too different from TXT_LONG
+    TXT_LONG, // long for printing
+    TXT_TIMESTAMP, // For current time e.g 13:41:24
   }
 
-  public static double getUnitMeters(Context mContext) {
-    return getUnitMeters(
-        mContext.getResources(), PreferenceManager.getDefaultSharedPreferences(mContext));
+  private static class LocaleResources {
+    final Resources resources;
+    final Configuration configuration;
+    final Locale defaultLocale;
+    final Locale audioLocale;
+
+    LocaleResources(Resources resources, Locale configAudioLocale) {
+      this.resources = resources;
+      configuration = resources.getConfiguration();
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+          && !resources.getConfiguration().getLocales().isEmpty()) {
+        defaultLocale = configuration.getLocales().get(0);
+      } else {
+        defaultLocale = configuration.locale;
+      }
+
+      if (configAudioLocale == null) {
+        audioLocale = defaultLocale;
+      } else {
+        audioLocale = configAudioLocale;
+      }
+    }
+
+    void setLang(Locale locale) {
+      // enableSplit = false set in build.gradle
+      configuration.setLocale(locale);
+      resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+    }
+
+    public String getString(int id) throws Resources.NotFoundException {
+      setLang(audioLocale);
+      String result = resources.getString(id);
+
+      setLang(defaultLocale);
+      return result;
+    }
+
+    // General getQuantityString accepts "Object ...", limit to exactly one argument (current use)
+    // to avoid runtime crashes
+    public String getQuantityString(int id, int quantity, Object formatArgs)
+        throws Resources.NotFoundException {
+      setLang(audioLocale);
+      String result = resources.getQuantityString(id, quantity, formatArgs);
+      setLang(defaultLocale);
+      return result;
+    }
   }
 }

--- a/app/src/main/org/runnerup/util/GraphWrapper.java
+++ b/app/src/main/org/runnerup/util/GraphWrapper.java
@@ -83,14 +83,28 @@ public class GraphWrapper implements Constants {
             return context.getString(org.runnerup.common.R.string.Distance);
           }
 
+          public String labelLong() {
+            return label() + " " + formatter.getDistanceUnit();
+          }
+
+          @Override
+          public String formatLongValue(double value) {
+            return formatter.getDistanceDisplay(value) + " " + formatter.getDistanceUnit();
+          }
+
           @Override
           public String formatValue(double value) {
-            return formatter.formatDistance(Formatter.Format.TXT_SHORT, (long) value);
+            return formatter.getDistanceDisplay(value);
           }
 
           @Override
           public double getX(double distance, double time_ms) {
             return distance;
+          }
+
+          @Override
+          public String unit() {
+            return formatter.getDistanceUnit();
           }
         };
 
@@ -101,6 +115,15 @@ public class GraphWrapper implements Constants {
             return context.getString(org.runnerup.common.R.string.Time);
           }
 
+          public String labelLong() {
+            return label();
+          }
+
+          @Override
+          public String formatLongValue(double value) {
+            return formatValue(value);
+          }
+
           @Override
           public String formatValue(double value) {
             return formatter.formatElapsedTime(Formatter.Format.TXT_SHORT, (long) value);
@@ -109,6 +132,11 @@ public class GraphWrapper implements Constants {
           @Override
           public double getX(double distance, double time_ms) {
             return time_ms / 1000;
+          }
+
+          @Override
+          public String unit() {
+            return "";
           }
         };
 
@@ -136,10 +164,8 @@ public class GraphWrapper implements Constants {
                 }
               }
             });
-    velocityGraphView
-        .getGridLabelRenderer()
-        .setVerticalAxisTitle(formatter.getVelocityUnit(context));
-    velocityGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    velocityGraphView.getGridLabelRenderer().setVerticalAxisTitle(formatter.getVelocityUnit());
+    velocityGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.labelLong());
     // enable zoom
     velocityGraphView.getViewport().setScalable(true);
     velocityGraphView.getViewport().setScrollable(true);
@@ -147,7 +173,7 @@ public class GraphWrapper implements Constants {
     hrGraphView = new GraphView(context);
     hrGraphView.setTitle(context.getString(org.runnerup.common.R.string.Heart_rate));
     hrGraphView.getGridLabelRenderer().setVerticalAxisTitle("bpm");
-    hrGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    hrGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.labelLong());
     hrGraphView
         .getGridLabelRenderer()
         .setLabelFormatter(
@@ -166,10 +192,8 @@ public class GraphWrapper implements Constants {
 
     elevationGraphView = new GraphView(context);
     elevationGraphView.setTitle(context.getString(org.runnerup.common.R.string.Elevation));
-    elevationGraphView
-        .getGridLabelRenderer()
-        .setVerticalAxisTitle(formatter.getElevationUnit());
-    elevationGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    elevationGraphView.getGridLabelRenderer().setVerticalAxisTitle(formatter.getElevationUnit());
+    elevationGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.labelLong());
     elevationGraphView
         .getGridLabelRenderer()
         .setLabelFormatter(
@@ -179,7 +203,7 @@ public class GraphWrapper implements Constants {
                 if (isValueX) {
                   return xAxis.formatValue(value);
                 } else {
-                  return formatter.formatElevation(Formatter.Format.TXT_LONG, value);
+                  return formatter.formatElevation(Formatter.Format.TXT_SHORT, value);
                 }
               }
             });
@@ -301,12 +325,18 @@ public class GraphWrapper implements Constants {
   interface XAxis {
     String label();
 
+    String labelLong();
 
+    String formatLongValue(double val);
 
     String formatValue(double val);
 
     double getX(double distance, double time_ms);
+
+    String unit();
   }
+
+  record LoadParam(Context context, SQLiteDatabase mDB, long mID) {}
 
   class GraphProducer {
     final int interval;
@@ -366,7 +396,7 @@ public class GraphWrapper implements Constants {
         Arrays.fill(this.hrzHist, 0);
         showHRZhist = true;
       }
-      this.preferred_speedunit = Formatter.getPreferredSpeedUnit(context);
+      this.preferred_speedunit = formatter.getPreferredSpeedUnit();
 
       clearSmooth(0);
     }
@@ -546,13 +576,12 @@ public class GraphWrapper implements Constants {
           (series, dataPoint) -> {
             String msg =
                 String.format(
-                    "%s: %s\n%s: %s %s",
-                    graphView.getContext().getString(org.runnerup.common.R.string.Distance),
-                    xAxis.formatValue(dataPoint.getX()),
+                    "%s: %s\n%s: %s",
+                    xAxis.label(),
+                    xAxis.formatLongValue(dataPoint.getX()),
                     formatter.formatVelocityLabel(),
                     formatter.formatVelocityByPreferredUnit(
-                        Formatter.Format.TXT_SHORT, dataPoint.getY()),
-                    formatter.getVelocityUnit(graphView.getContext()));
+                        Formatter.Format.TXT_LONG, dataPoint.getY()));
             Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
           });
       if (showHR) {
@@ -566,10 +595,10 @@ public class GraphWrapper implements Constants {
               String msg =
                   String.format(
                       "%s: %s\n%s: %s",
-                      graphView.getContext().getString(org.runnerup.common.R.string.Distance),
-                      xAxis.formatValue(dataPoint.getX()),
+                      xAxis.label(),
+                      xAxis.formatLongValue(dataPoint.getX()),
                       graphView.getContext().getString(org.runnerup.common.R.string.Heart_rate),
-                      formatter.formatHeartRate(Formatter.Format.TXT_SHORT, dataPoint.getY()));
+                      formatter.formatHeartRate(Formatter.Format.TXT_LONG, dataPoint.getY()));
               Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
             });
 
@@ -600,10 +629,10 @@ public class GraphWrapper implements Constants {
               String msg =
                   String.format(
                       "%s: %s\n%s: %s",
-                      graphView.getContext().getString(org.runnerup.common.R.string.Distance),
-                      xAxis.formatValue(dataPoint.getX()),
+                      xAxis.label(),
+                      xAxis.formatLongValue(dataPoint.getX()),
                       graphView.getContext().getString(org.runnerup.common.R.string.Elevation),
-                      formatter.formatElevation(Formatter.Format.TXT_SHORT, dataPoint.getY()));
+                      formatter.formatElevation(Formatter.Format.TXT_LONG, dataPoint.getY()));
               Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
             });
       }
@@ -757,6 +786,4 @@ public class GraphWrapper implements Constants {
       }
     }
   }
-
-  record LoadParam(Context context, SQLiteDatabase mDB, long mID) {}
 }

--- a/app/src/main/org/runnerup/util/GraphWrapper.java
+++ b/app/src/main/org/runnerup/util/GraphWrapper.java
@@ -45,8 +45,9 @@ import org.runnerup.view.HRZonesBar;
 import org.runnerup.workout.SpeedUnit;
 
 public class GraphWrapper implements Constants {
-  private final GraphView graphView;
-  private final GraphView graphView2;
+  private final GraphView velocityGraphView;
+  private final GraphView hrGraphView;
+  private final GraphView elevationGraphView;
 
   private final LinearLayout graphTab;
   private final HRZonesBar hrzonesBar;
@@ -120,9 +121,9 @@ public class GraphWrapper implements Constants {
 
     loadParam = new LoadParam(context, mDB, mID);
 
-    graphView = new GraphView(context);
-    graphView.setTitle(formatter.formatVelocityLabel());
-    graphView
+    velocityGraphView = new GraphView(context);
+    velocityGraphView.setTitle(formatter.formatVelocityLabel());
+    velocityGraphView
         .getGridLabelRenderer()
         .setLabelFormatter(
             new DefaultLabelFormatter() {
@@ -135,17 +136,19 @@ public class GraphWrapper implements Constants {
                 }
               }
             });
-    graphView.getGridLabelRenderer().setVerticalAxisTitle(formatter.getVelocityUnit(context));
-    graphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    velocityGraphView
+        .getGridLabelRenderer()
+        .setVerticalAxisTitle(formatter.getVelocityUnit(context));
+    velocityGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
     // enable zoom
-    graphView.getViewport().setScalable(true);
-    graphView.getViewport().setScrollable(true);
+    velocityGraphView.getViewport().setScalable(true);
+    velocityGraphView.getViewport().setScrollable(true);
 
-    graphView2 = new GraphView(context);
-    graphView2.setTitle(context.getString(org.runnerup.common.R.string.Heart_rate));
-    graphView2.getGridLabelRenderer().setVerticalAxisTitle("bpm");
-    graphView2.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
-    graphView2
+    hrGraphView = new GraphView(context);
+    hrGraphView.setTitle(context.getString(org.runnerup.common.R.string.Heart_rate));
+    hrGraphView.getGridLabelRenderer().setVerticalAxisTitle("bpm");
+    hrGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    hrGraphView
         .getGridLabelRenderer()
         .setLabelFormatter(
             new DefaultLabelFormatter() {
@@ -158,8 +161,30 @@ public class GraphWrapper implements Constants {
                 }
               }
             });
-    graphView2.getViewport().setScalable(true);
-    graphView2.getViewport().setScrollable(true);
+    hrGraphView.getViewport().setScalable(true);
+    hrGraphView.getViewport().setScrollable(true);
+
+    elevationGraphView = new GraphView(context);
+    elevationGraphView.setTitle(context.getString(org.runnerup.common.R.string.Elevation));
+    elevationGraphView
+        .getGridLabelRenderer()
+        .setVerticalAxisTitle(formatter.getElevationUnit());
+    elevationGraphView.getGridLabelRenderer().setHorizontalAxisTitle(xAxis.label());
+    elevationGraphView
+        .getGridLabelRenderer()
+        .setLabelFormatter(
+            new DefaultLabelFormatter() {
+              @Override
+              public String formatLabel(double value, boolean isValueX) {
+                if (isValueX) {
+                  return xAxis.formatValue(value);
+                } else {
+                  return formatter.formatElevation(Formatter.Format.TXT_LONG, value);
+                }
+              }
+            });
+    elevationGraphView.getViewport().setScalable(true);
+    elevationGraphView.getViewport().setScrollable(true);
 
     hrzonesBar = new HRZonesBar(context);
     loadGraph();
@@ -175,8 +200,9 @@ public class GraphWrapper implements Constants {
     } else {
       xAxis = timeXAxis;
     }
-    graphView.removeAllSeries();
-    graphView2.removeAllSeries();
+    velocityGraphView.removeAllSeries();
+    hrGraphView.removeAllSeries();
+    elevationGraphView.removeAllSeries();
     loadGraph();
   }
 
@@ -226,18 +252,19 @@ public class GraphWrapper implements Constants {
   private void onPostExecute(GraphProducer graphData) {
     if (graphData == null) return;
 
-    graphData.complete(graphView);
-    graphTab.removeView(graphView);
-    graphTab.removeView(graphView2);
-    if (graphData.HasPaceInfo() && !graphData.HasHRInfo()) {
-      graphTab.addView(graphView);
-    } else if (!graphData.HasPaceInfo() && graphData.HasHRInfo()) {
-      graphTab.addView(graphView2);
-    } else if (graphData.HasPaceInfo() && graphData.HasHRInfo()) {
-      graphTab.addView(graphView, new LayoutParams(LayoutParams.MATCH_PARENT, 0, 0.5f));
+    graphData.complete(velocityGraphView);
+    graphTab.removeView(velocityGraphView);
+    graphTab.removeView(hrGraphView);
+    graphTab.removeView(elevationGraphView);
 
-      graphTab.addView(graphView2, new LayoutParams(LayoutParams.MATCH_PARENT, 0, 0.5f));
-    }
+    LayoutParams layout =
+        new LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            (int) (250 * graphTab.getResources().getDisplayMetrics().density));
+
+    if (graphData.HasPaceInfo()) graphTab.addView(velocityGraphView, layout);
+    if (graphData.HasHRInfo()) graphTab.addView(hrGraphView, layout);
+    if (graphData.HasElevationInfo()) graphTab.addView(elevationGraphView, layout);
 
     hrzonesBarLayout.removeView(hrzonesBar);
     if (graphData.HasHRZHist()) {
@@ -274,6 +301,8 @@ public class GraphWrapper implements Constants {
   interface XAxis {
     String label();
 
+
+
     String formatValue(double val);
 
     double getX(double distance, double time_ms);
@@ -283,9 +312,11 @@ public class GraphWrapper implements Constants {
     final int interval;
     final double[] time;
     final double[] distance;
+    final double[] elevation;
     final int[] hr;
     final List<DataPoint> velocityList;
     final List<DataPoint> hrList;
+    final List<DataPoint> elevationList;
     final HRZones hrCalc;
     final SpeedUnit preferred_speedunit;
     boolean first = true;
@@ -299,6 +330,7 @@ public class GraphWrapper implements Constants {
     double min_velocity = Double.MAX_VALUE;
     double max_velocity = Double.MIN_VALUE;
     boolean showPace = false;
+    boolean showElevation = false;
     boolean showHR = false;
     boolean showHRZhist = false;
 
@@ -321,6 +353,9 @@ public class GraphWrapper implements Constants {
 
       this.hrList = new ArrayList<>();
       this.hr = new int[graphAverageSeconds];
+
+      this.elevationList = new ArrayList<>();
+      this.elevation = new double[graphAverageSeconds];
 
       Resources res = context.getResources();
       Context ctx = context.getApplicationContext();
@@ -347,6 +382,7 @@ public class GraphWrapper implements Constants {
         time[i] = 0;
         distance[i] = 0;
         hr[i] = 0;
+        elevation[i] = 0;
       }
       pos = 0;
       sum_time = 0;
@@ -380,8 +416,13 @@ public class GraphWrapper implements Constants {
         this.hr[p] = 0;
       }
 
+      Double altitude = loc.getAltitude();
+      this.elevation[p] = altitude != null ? altitude : 0.0;
+
       if (delta_distance > 0 && delta_time > 0) {
         showPace = true;
+        if (altitude != null) showElevation = true;
+        ;
       }
 
       pos += 1;
@@ -405,9 +446,13 @@ public class GraphWrapper implements Constants {
         // Avoid presenting very slow pace (easier than to handle manual y axis scaling)
         velocity = Math.max(velocity, paceLimit);
       }
+
+      double elevation = this.elevation[pos % this.time.length];
+
       if (first) {
         if (tot_X > 0) {
           velocityList.add(new DataPoint(0, velocity));
+          elevationList.add(new DataPoint(0, elevation));
           if (avg_hr > 0) {
             hrList.add(new DataPoint(0, Math.round(avg_hr)));
           }
@@ -415,6 +460,7 @@ public class GraphWrapper implements Constants {
         first = false;
       }
       velocityList.add(new DataPoint(tot_X, velocity));
+      elevationList.add(new DataPoint(tot_X, elevation));
       if (avg_hr > 0) {
         hrList.add(new DataPoint(tot_X, Math.round(avg_hr)));
       }
@@ -491,12 +537,12 @@ public class GraphWrapper implements Constants {
         Log.d(getClass().getName(), s.toString());
         f.complete();
       }
-      LineGraphSeries<DataPoint> graphViewData =
+      LineGraphSeries<DataPoint> velocityGraphViewData =
           new LineGraphSeries<>(velocityList.toArray(new DataPoint[0]));
-      graphView.addSeries(graphViewData); // data
+      graphView.addSeries(velocityGraphViewData); // data
       graphView.getViewport().setMinX(graphView.getViewport().getMinX(true));
       graphView.getViewport().setMaxX(graphView.getViewport().getMaxX(true));
-      graphViewData.setOnDataPointTapListener(
+      velocityGraphViewData.setOnDataPointTapListener(
           (series, dataPoint) -> {
             String msg =
                 String.format(
@@ -510,21 +556,20 @@ public class GraphWrapper implements Constants {
             Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
           });
       if (showHR) {
-        LineGraphSeries<DataPoint> graphViewData2 =
+        LineGraphSeries<DataPoint> hrGraphViewData =
             new LineGraphSeries<>(hrList.toArray(new DataPoint[0]));
-        graphView2.addSeries(graphViewData2); // data
-        graphView2.getViewport().setMinX(graphView2.getViewport().getMinX(true));
-        graphView2.getViewport().setMaxX(graphView2.getViewport().getMaxX(true));
-        graphViewData2.setOnDataPointTapListener(
+        hrGraphView.addSeries(hrGraphViewData); // data
+        hrGraphView.getViewport().setMinX(hrGraphView.getViewport().getMinX(true));
+        hrGraphView.getViewport().setMaxX(hrGraphView.getViewport().getMaxX(true));
+        hrGraphViewData.setOnDataPointTapListener(
             (series, dataPoint) -> {
               String msg =
-                  graphView.getContext().getString(org.runnerup.common.R.string.Distance)
-                      + ": "
-                      + xAxis.formatValue(dataPoint.getX())
-                      + "\n"
-                      + graphView.getContext().getString(org.runnerup.common.R.string.Heart_rate)
-                      + ": "
-                      + formatter.formatHeartRate(Formatter.Format.TXT_SHORT, dataPoint.getY());
+                  String.format(
+                      "%s: %s\n%s: %s",
+                      graphView.getContext().getString(org.runnerup.common.R.string.Distance),
+                      xAxis.formatValue(dataPoint.getX()),
+                      graphView.getContext().getString(org.runnerup.common.R.string.Heart_rate),
+                      formatter.formatHeartRate(Formatter.Format.TXT_SHORT, dataPoint.getY()));
               Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
             });
 
@@ -543,6 +588,24 @@ public class GraphWrapper implements Constants {
           Log.d(getClass().getName(), s.toString());
           hrzonesBar.pushHrzData(hrzHist);
         }
+      }
+      if (showElevation) {
+        LineGraphSeries<DataPoint> elevationGraphViewData =
+            new LineGraphSeries<>(elevationList.toArray(new DataPoint[0]));
+        elevationGraphView.addSeries(elevationGraphViewData); // data
+        elevationGraphView.getViewport().setMinX(elevationGraphView.getViewport().getMinX(true));
+        elevationGraphView.getViewport().setMaxX(elevationGraphView.getViewport().getMaxX(true));
+        elevationGraphViewData.setOnDataPointTapListener(
+            (series, dataPoint) -> {
+              String msg =
+                  String.format(
+                      "%s: %s\n%s: %s",
+                      graphView.getContext().getString(org.runnerup.common.R.string.Distance),
+                      xAxis.formatValue(dataPoint.getX()),
+                      graphView.getContext().getString(org.runnerup.common.R.string.Elevation),
+                      formatter.formatElevation(Formatter.Format.TXT_SHORT, dataPoint.getY()));
+              Toast.makeText(graphView.getContext(), msg, Toast.LENGTH_SHORT).show();
+            });
       }
     }
 
@@ -564,6 +627,10 @@ public class GraphWrapper implements Constants {
 
     public boolean HasPaceInfo() {
       return showPace;
+    }
+
+    public boolean HasElevationInfo() {
+      return showElevation;
     }
 
     public boolean HasHRInfo() {

--- a/app/src/main/org/runnerup/view/DetailActivity.java
+++ b/app/src/main/org/runnerup/view/DetailActivity.java
@@ -316,11 +316,20 @@ public class DetailActivity extends AppCompatActivity implements Constants {
 
             ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
             mlp.topMargin = insets.top;
+
+            View graphScroll = findViewById(R.id.tab_graph);
+            if (graphScroll != null) {
+              graphScroll.setPadding(
+                  graphScroll.getPaddingLeft(),
+                  graphScroll.getPaddingTop(),
+                  graphScroll.getPaddingRight(),
+                  Math.max(0, insets.bottom - bottomPadding));
+            }
             return WindowInsetsCompat.CONSUMED;
           }
         });
 
-    LinearLayout graphTabLayout = findViewById(R.id.tab_graph);
+    LinearLayout graphTabLayout = findViewById(R.id.graphview);
     LinearLayout hrzonesBarLayout = findViewById(R.id.hrzonesBarLayout);
     boolean use_distance_as_x = !Sport.isWithoutGps(sport.getValueInt());
     // variable not needed

--- a/app/src/main/org/runnerup/view/StartFragment.java
+++ b/app/src/main/org/runnerup/view/StartFragment.java
@@ -1178,11 +1178,11 @@ public class StartFragment extends Fragment implements TickListener, GpsInformat
           res +=
               String.format(
                   Locale.getDefault(),
-                  " [%1$s, %2$s/%3$s/s, %4$.1f/%5$.1f deg]",
+                  " [%1$s, %2$s/%3$s, %4$.1f/%5$.1f deg]",
                   formatter.formatElevation(
                       Formatter.Format.TXT_LONG, l.getVerticalAccuracyMeters()),
-                  formatter.formatElevation(Formatter.Format.TXT_SHORT, l.getSpeed()),
-                  formatter.formatElevation(
+                  formatter.formatSpeed(Formatter.Format.TXT_SHORT, l.getSpeed()),
+                  formatter.formatSpeed(
                       Formatter.Format.TXT_LONG, l.getSpeedAccuracyMetersPerSecond()),
                   l.getBearing(),
                   l.getBearingAccuracyDegrees());

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
   <string name="metrics_distance_km">km</string>
   <string name="metrics_distance_mi">mi</string>
   <string name="metrics_distance_m">m</string>
+  <string name="metrics_distance_ft">ft</string>
   <string name="metrics_elapsed_h">h</string>
   <string name="metrics_elapsed_m">m</string>
   <string name="metrics_elapsed_min">min</string>
@@ -51,6 +52,7 @@
   <string name="Start_hour">Start hour</string>
   <string name="Heart_rate">Heart rate</string>
   <string name="Pace">Pace</string>
+  <string name="Elevation">Elevation</string>
   <string name="Scan">Scan</string>
   <string name="Connect">Connect</string>
   <string name="Connecting">Connecting</string>


### PR DESCRIPTION
First four is #1357 and some cleanups to that
Will merge these together regardless

Declutter the graph axis, consistently use km/miles in units.
Remove elevation decimals.
Cleanup some context use in Formatter
Include units in graph popups