### PR TITLE
fix: restore "Are you sure?" string value

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="Loading">Loading</string>
     <string name="Saving">Saving</string>
     <string name="Cancellingplease_wait">Cancelling, please wait…</string>
-    <string name="Are_you_sure">Are_you_sure</string>
+    <string name="Are_you_sure">Are you sure?</string>
     <string name="Delete_audio_cue">Delete audio cue?</string>
     <string name="Configure_audio_cues">Configure audio cues</string>
     <string name="Downloadeditremove_workouts">Edit workouts</string>


### PR DESCRIPTION
Fixes an issue introduced in 6489c52 where the key name was used instead of the intended value:

<img width="340" height="216" alt="image" src="https://github.com/user-attachments/assets/6a369e62-7e27-4cf2-81a2-1bfde73c3f77" />