### PR TITLE
Fix TCX export for non-GPS activities (#1337)

### DIFF
--- a/app/src/main/org/runnerup/export/format/TCX.java
+++ b/app/src/main/org/runnerup/export/format/TCX.java
@@ -300,7 +300,7 @@ public class TCX {
     double totalDistance = 0;
     while (lok) {
       if (exportOptions.shouldExportLap(
-          sport.getDbValue(), /* distance= */ cLap.getFloat(1), /* time= */ cLap.getLong(2))) {
+          sport.getDbValue(), /* distance= */ cLap.getFloat(2), /* time= */ cLap.getLong(1))) {
         long lap = cLap.getLong(0);
         while (pok && cLocation.getLong(0) != lap) {
           pok = cLocation.moveToNext();


### PR DESCRIPTION
Fixes #1337

Non-GPS activities, such as Gym workouts, could be exported without lap data, resulting in incomplete TCX files that Strava rejected for missing activity time information.

In `TCX.exportLaps()`, the call to `ExportOptions.shouldExportLap()` passed lap time and distance values in the wrong order. As a result, laps from activities with a duration but no distance were incorrectly filtered out during export.

After swapping the time and distance arguments in the `shouldExportLap()` call, Gym and other non-GPS activities can now be successfully uploaded to Strava.

**Note**! There is still a separate issue related to how Strava interprets non-GPS activities when GPS-related fields are present in the exported TCX file, but this is outside the scope of this PR.