### PR TITLE
Fix bundled workout copy failure on fresh installations

### DIFF
--- a/app/src/main/org/runnerup/view/MainLayout.java
+++ b/app/src/main/org/runnerup/view/MainLayout.java
@@ -315,7 +315,7 @@ public class MainLayout extends AppCompatActivity {
 
         if (!isFile) {
           // The request is hierarchical, source is still on a directory level
-          File dstDir = new File(dstBase);
+          File dstDir = new File(dst);
           //noinspection ResultOfMethodCallIgnored
           dstDir.mkdir();
           if (!dstDir.isDirectory()) {


### PR DESCRIPTION
This PR fixes an issue that prevented bundled workout files from being copied during a fresh installation.

The initial suspicion came after reading several recently opened issues from @ByteBreeze233. Screenshots from the *Manage Workouts* activity showed that the four bundled workouts were missing (left picture), even though they should have been copied automatically during app installation (right picture).

<img width="1555" height="775" alt="image" src="https://github.com/user-attachments/assets/ab27b296-16ee-4930-a609-769029554017" />

In `MainLayout.handleBundled()`, the destination directory (`dstDir`) was incorrectly initialized using `dstBase`, which points to the parent directory, instead of `dst`, which represents the intended target subdirectory.

As a result, required subdirectories such as `app_workouts` were never created before attempting to copy the bundled workout files. When the application tried to copy the workout files into the non-existent directory, it threw a `FileNotFoundException`.

I've tested the fix on my Google Pixel 6 running Android 16 and on an Android 10 emulator in Android Studio.